### PR TITLE
Add reusable devcontainer setup

### DIFF
--- a/.devcontainer/README.md
+++ b/.devcontainer/README.md
@@ -1,0 +1,16 @@
+# 共通 devcontainer コンポーネント
+
+このディレクトリには他のリポジトリから利用できる共通の devcontainer 設定が含まれています。
+
+## 使い方
+
+1. `.devcontainer` ディレクトリをプロジェクトにコピーするか、`devcontainer.json` からこのディレクトリを参照します。
+2. devcontainer を起動すると `features/common` が実行され、シェルの関数や Git 設定がホームディレクトリにコピーされます。
+
+```jsonc
+"features": {
+    "../features/common": {}
+}
+```
+
+Homebrew などの重いパッケージはインストールされず、最小限の設定のみが適用されます。

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,7 @@
+{
+    "name": "Config Base Container",
+    "image": "mcr.microsoft.com/devcontainers/base:ubuntu",
+    "features": {
+        "../features/common": {}
+    }
+}

--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@ It includes settings for various tools, such as the shell (Zsh), Git, npm, and V
 - `kubernetes`: Contains files for setting up a Kubernetes cluster using Vagrant, including a Vagrantfile, scripts for the master and worker nodes, and a script for fetching GKE credentials.
 - `script`: Contains scripts for exporting configuration settings from a system to this repository (`export.sh`), importing configuration settings from this repository to a system (`import.sh`), and checking for changes and making a commit (`commit_changes.sh`).
 - `.zsh`, `git`, `macOS`, `.vscode`, `linux`, `vscode`, `npm`, `brew`, `dot`: These directories contain various configuration files and settings for different tools and systems.
+- `.devcontainer`: Provides a reusable devcontainer configuration and feature for applying these settings automatically.
 
 ## Usage
 
@@ -35,6 +36,10 @@ Ensure `REPO_PATH` points to the repository and run the `export.sh` script to ca
 ### Checking for Changes
 
 Run the `commit_changes.sh` script with `REPO_PATH` set to this repository to check for local modifications. If there are changes, it stages all of them and makes a commit.
+
+### Devcontainer
+
+The `.devcontainer` directory offers a reusable setup for VS Code Dev Containers. Refer to the included feature to copy shell functions and Git settings into the container without installing heavy packages like Homebrew.
 
 ## Glossary
 

--- a/features/common/devcontainer-feature.json
+++ b/features/common/devcontainer-feature.json
@@ -1,0 +1,6 @@
+{
+    "id": "config-base",
+    "version": "0.2.0",
+    "name": "Config Base",
+    "description": "Copies shell functions and Git config from this repository without installing heavy dependencies."
+}

--- a/features/common/install.sh
+++ b/features/common/install.sh
@@ -1,0 +1,25 @@
+#!/bin/sh
+set -e
+
+REPO_ROOT="$(cd "$(dirname "$0")/../.." && pwd)"
+
+# Determine the home directory for the target user. When the feature runs
+# as root, the USERNAME environment variable points to the non-root user.
+TARGET_HOME="$HOME"
+if [ "$(id -u)" = 0 ] && [ -n "$USERNAME" ] && [ -d "/home/$USERNAME" ]; then
+  TARGET_HOME="/home/$USERNAME"
+fi
+
+# Copy minimal shell configuration and functions without installing brew or
+# other heavy dependencies.
+mkdir -p "$TARGET_HOME/.zsh"
+cp -r "$REPO_ROOT/.zsh/functions" "$TARGET_HOME/.zsh/"
+cp "$REPO_ROOT/dot/.zprofile" "$TARGET_HOME/"
+cp "$REPO_ROOT/dot/.zshrc" "$TARGET_HOME/"
+cp -r "$REPO_ROOT/git" "$TARGET_HOME/"
+
+# Ensure files are owned by the target user when running as root.
+if [ "$(id -u)" = 0 ] && [ -n "$USERNAME" ]; then
+  chown -R "$USERNAME":"$USERNAME" "$TARGET_HOME/.zsh" "$TARGET_HOME/.zprofile" \
+    "$TARGET_HOME/.zshrc" "$TARGET_HOME/git"
+fi


### PR DESCRIPTION
## Summary
- create reusable devcontainer config using Dev Container Features
- document how to use it in README
- copy minimal shell configs and Git settings instead of running full import script

## Testing
- `bash -n features/common/install.sh`
- `jq . .devcontainer/devcontainer.json`
- `jq . features/common/devcontainer-feature.json`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Introduced a reusable development container setup for consistent development environments.
  - Added a feature that automatically copies shell functions and Git configuration into the container, ensuring minimal setup without installing heavy dependencies.

- **Documentation**
  - Added and updated documentation to explain the new devcontainer setup, usage instructions, and included features.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->