### PR TITLE
Add Docker image build workflow

### DIFF
--- a/.devcontainer/README.md
+++ b/.devcontainer/README.md
@@ -1,0 +1,16 @@
+# 共通 devcontainer コンポーネント
+
+このディレクトリには他のリポジトリから利用できる共通の devcontainer 設定が含まれています。
+
+## 使い方
+
+1. `.devcontainer` ディレクトリをプロジェクトにコピーするか、`devcontainer.json` からこのディレクトリを参照します。
+2. devcontainer を起動すると、`features/common` が実行され、リポジトリ内の `script/import.sh` を用いて各種設定が自動で適用されます。
+
+```jsonc
+"features": {
+    "../features/common": {}
+}
+```
+
+これにより、シェル設定や VS Code 拡張などがインストールされます。

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,7 @@
+{
+    "name": "Config Base Container",
+    "image": "mcr.microsoft.com/devcontainers/base:ubuntu",
+    "features": {
+        "../features/common": {}
+    }
+}

--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -1,0 +1,34 @@
+name: Build and Release Docker Image
+
+on:
+  push:
+    branches: [ main ]
+    paths:
+      - 'docker/**'
+      - '.github/workflows/docker-image.yml'
+  workflow_dispatch:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - uses: actions/checkout@v3
+      - uses: docker/setup-qemu-action@v2
+      - uses: docker/setup-buildx-action@v2
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@v2
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      - name: Build and push
+        uses: docker/build-push-action@v5
+        with:
+          context: ./docker
+          file: ./docker/Dockerfile
+          push: true
+          tags: ghcr.io/${{ github.repository }}/config-base:latest
+

--- a/README.md
+++ b/README.md
@@ -10,6 +10,8 @@ It includes settings for various tools, such as the shell (Zsh), Git, npm, and V
 - `kubernetes`: Contains files for setting up a Kubernetes cluster using Vagrant, including a Vagrantfile, scripts for the master and worker nodes, and a script for fetching GKE credentials.
 - `script`: Contains scripts for exporting configuration settings from a system to this repository (`export.sh`), importing configuration settings from this repository to a system (`import.sh`), and checking for changes and making a commit (`commit_changes.sh`).
 - `.zsh`, `git`, `macOS`, `.vscode`, `linux`, `vscode`, `npm`, `brew`, `dot`: These directories contain various configuration files and settings for different tools and systems.
+- `.devcontainer`: Provides a reusable devcontainer configuration and feature for applying these settings automatically.
+- GitHub Actions builds the `docker/Dockerfile` and publishes the image to GitHub Container Registry.
 
 ## Usage
 
@@ -35,6 +37,10 @@ Ensure `REPO_PATH` points to the repository and run the `export.sh` script to ca
 ### Checking for Changes
 
 Run the `commit_changes.sh` script with `REPO_PATH` set to this repository to check for local modifications. If there are changes, it stages all of them and makes a commit.
+
+### Devcontainer
+
+The `.devcontainer` directory provides a base configuration for VS Code Dev Containers. Include it in a project or reference the feature directly to automatically apply the settings in this repository when the container is built.
 
 ## Glossary
 

--- a/features/common/devcontainer-feature.json
+++ b/features/common/devcontainer-feature.json
@@ -1,0 +1,6 @@
+{
+    "id": "config-base",
+    "version": "0.1.0",
+    "name": "Config Base",
+    "description": "Applies common configuration from this repository inside a dev container."
+}

--- a/features/common/install.sh
+++ b/features/common/install.sh
@@ -1,0 +1,6 @@
+#!/bin/sh
+set -e
+REPO_ROOT="$(cd "$(dirname "$0")/../.." && pwd)"
+if [ -f "$REPO_ROOT/script/import.sh" ]; then
+  /bin/zsh "$REPO_ROOT/script/import.sh"
+fi


### PR DESCRIPTION
## Summary
- build Dockerfile and publish to GHCR via GitHub Actions
- mention the automatic Docker image build in README

## Testing
- `bash -n features/common/install.sh`
- `jq . .devcontainer/devcontainer.json`
- `jq . features/common/devcontainer-feature.json`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Introduced a reusable devcontainer configuration for streamlined development environment setup.
  - Added a configurable devcontainer feature for applying common settings automatically.
  - Enabled automated building and publishing of Docker images to the GitHub Container Registry via GitHub Actions.

- **Documentation**
  - Added and updated README files with instructions for using the devcontainer setup and details about the new automation workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->