### PR TITLE
Fix npm global package installation in devcontainer

### DIFF
--- a/.devcontainer/features/common/install.sh
+++ b/.devcontainer/features/common/install.sh
@@ -57,7 +57,7 @@ fi
 packages=$(jq -r '.dependencies | keys[]' "$GLOBAL_JSON_FILE" 2>/dev/null || true)
 if [ -n "$packages" ]; then
   echo "Installing npm packages: $packages"
-  npm install -g $packages --prefer-offline --no-audit --no-fund --location=user
+  npm install -g $packages --prefer-offline --no-audit --no-fund
 else
   echo "No packages found in global.json dependencies"
 fi


### PR DESCRIPTION
## Summary
- Remove `--location=user` flag from npm global install command to fix package availability in devcontainer

## Fixes
Fixes #13

## What changed
The `--location=user` flag was causing npm packages to be installed in user-specific directories instead of globally accessible locations. This prevented the packages from being available in the devcontainer environment.

By removing this flag, packages are now installed in the standard global location and are properly accessible.

## Test plan
- [ ] Rebuild devcontainer
- [ ] Verify npm global packages are accessible
- [ ] Confirm @anthropic-ai/claude-code and npm are available globally

🤖 Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated the installation process for global npm packages to improve compatibility and reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->