### PR TITLE
fix: devcontainerのkubectl-helm-minikubeエラーを修正

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -17,7 +17,11 @@
     "ghcr.io/devcontainers-extra/features/supabase-cli:1": {},
     "ghcr.io/nils-geistmann/devcontainers-features/zsh:0": {},
     "ghcr.io/devcontainers-extra/features/zsh-plugins:0": {},
-    "ghcr.io/devcontainers/features/kubectl-helm-minikube:1": {},
+    "ghcr.io/devcontainers/features/kubectl-helm-minikube:1": {
+      "version": "1.28",
+      "helm": "3.12",
+      "minikube": "none"
+    },
     "ghcr.io/dhoeric/features/act:1": {}
   },
   "remoteEnv": {


### PR DESCRIPTION
- minikubeのインストールを無効化（マルチプラットフォームビルドとの互換性問題のため）
- kubectl/helmの具体的なバージョンを指定（1.28/3.12）
- これによりGitHub ActionsでのDevContainerビルドエラーが解消される

🤖 Generated with [Claude Code](https://claude.ai/code)