### PR TITLE
fix: devcontainerのkubectl-helm-minikube設定を更新

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -19,7 +19,7 @@
     "ghcr.io/devcontainers-extra/features/zsh-plugins:0": {},
     "ghcr.io/devcontainers/features/kubectl-helm-minikube:1": {
       "version": "1.28",
-      "helm": "3.12",
+      "helm": "latest",
       "minikube": "none"
     },
     "ghcr.io/dhoeric/features/act:1": {}


### PR DESCRIPTION
- helmのバージョンを「3.12」から「latest」に変更し、最新の機能を利用可能に。
