### PR TITLE
fix: devcontainerのkubectl-helm-minikube設定を更新し、helmのバージョンを「latest」から「none」に変更

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -19,7 +19,7 @@
     "ghcr.io/devcontainers-extra/features/zsh-plugins:0": {},
     "ghcr.io/devcontainers/features/kubectl-helm-minikube:1": {
       "version": "1.28",
-      "helm": "latest",
+      "helm": "none",
       "minikube": "none"
     },
     "ghcr.io/dhoeric/features/act:1": {}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated development container configuration for improved tool management. No impact on user-facing features.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->