### PR TITLE
feat: Claude GitHub ActionsワークフローにBashツールの許可を追加

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -34,3 +34,4 @@ jobs:
         with:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
           github_token: ${{ secrets.GITHUB_TOKEN }}
+          allowed_tools: "Bash"


### PR DESCRIPTION
## Summary
- Claude GitHub ActionsインテグレーションでBashツールの使用を明示的に許可
- `allowed_tools: "Bash"`パラメータを追加

## Test plan
- [ ] GitHub ActionsでClaude integrationが正常に動作することを確認
- [ ] Bashツールが適切に使用できることを確認

🤖 Generated with [Claude Code](https://claude.ai/code)