### PR TITLE
fix: add copyright holder info to LICENSE file

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2024
+Copyright (c) 2025 keito4
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal


### PR DESCRIPTION
Update LICENSE copyright line to include holder name 'keito4' and update year to 2025.

Fixes #6

Generated with [Claude Code](https://claude.ai/code)