### PR TITLE
docs: update documentation to reflect current repository structure

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,19 +6,14 @@ It includes settings for various tools, such as the shell (Zsh), Git, npm, and V
 
 ## Directory Structure
 
-- `.devcontainer/`: Provides a reusable devcontainer configuration and feature for applying these settings automatically in VS Code Dev Containers.
-- `brew/`: Contains Brewfiles for different operating systems (Linux, macOS) and dependency configurations, including lock files for reproducible package installations.
-- `docker/`: Contains a Dockerfile and docker-compose file for setting up a Docker-based development environment.
-- `dot/`: Contains dotfiles and configuration files that are typically placed in the home directory.
+- `brew/`: Contains Brewfiles for different operating systems (Linux, macOS) and dependency configurations, including lock files for reproducible package installations. Supports categorized package management and dependency analysis.
+- `credentials/`: Contains templates and scripts for secure credential management using 1Password CLI integration.
+- `dot/`: Directory for dotfiles and configuration files that are typically placed in the home directory.
 - `git/`: Contains Git configuration files including gitconfig, gitignore, and modular configuration files in the `gitconfig.d/` subdirectory.
-- `kubernetes/`: Contains files for setting up a Kubernetes cluster using Vagrant, including a Vagrantfile, scripts for the master and worker nodes, and a script for fetching GKE credentials.
-- `linux/`: Contains Linux-specific setup scripts for 1Password, Brew, Kubernetes, NordVPN, and Ubuntu-specific configurations.
-- `macOS/`: Contains macOS-specific configuration files including Brewfile and system preferences scripts.
 - `npm/`: Contains npm global package configuration.
-- `script/`: Contains utility scripts for exporting configuration settings (`export.sh`), importing configuration settings (`import.sh`), checking for changes and making commits (`commit_changes.sh`), and version management (`version.sh`).
+- `script/`: Contains utility scripts for exporting configuration settings (`export.sh`), importing configuration settings (`import.sh`), checking for changes and making commits (`commit_changes.sh`), credential management (`credentials.sh`), Homebrew dependency management (`brew-deps.sh`), and version management (`version.sh`).
 - `supabase/`: Contains Supabase-related configuration and documentation.
-- `vscode/`: Contains Visual Studio Code configuration including extensions list, color themes, and documentation.
-- GitHub Actions builds the `docker/Dockerfile` and publishes the image to GitHub Container Registry.
+- `vscode/`: Contains Visual Studio Code configuration including extensions list and installation documentation.
 
 ## Security
 
@@ -40,9 +35,11 @@ git config --global user.signingkey "$(cat ~/.ssh/id_ed25519.pub)"
 ```
 
 ### Setup Instructions
-1. Copy the environment template: `cp .env.example .env`
-2. Configure Git settings using the commands above
-3. Use the credentials script for 1Password integration: `./script/credentials.sh fetch`
+1. Configure Git settings using the commands above
+2. Install 1Password CLI: `brew install --cask 1password-cli`
+3. Sign in to 1Password: `op signin`
+4. Use the credentials script for 1Password integration: `make credentials`
+5. Install packages using Homebrew: `brew bundle --file=brew/StandaloneBrewfile`
 
 For detailed security guidelines, see [SECURITY.md](SECURITY.md).
 
@@ -71,14 +68,11 @@ Ensure `REPO_PATH` points to the repository and run the `export.sh` script to ca
 
 Run the `commit_changes.sh` script with `REPO_PATH` set to this repository to check for local modifications. If there are changes, it stages all of them and makes a commit.
 
-### Devcontainer
+### Available Commands
 
-The `.devcontainer` directory provides a base configuration for VS Code Dev Containers. Include it in a project or reference the feature directly to automatically apply the settings in this repository when the container is built.
+The repository includes a Makefile with various utility commands:
 
-#### Versioning
-
-The devcontainer images are released with semantic versioning. Use the following commands to create version tags:
-
+#### Version Management
 ```bash
 # Create a patch version (1.0.0 -> 1.0.1)
 make version-patch
@@ -93,23 +87,67 @@ make version-major
 make version-dry-run
 ```
 
-After creating a tag, push it to trigger the Docker image build:
+#### Credential Management
 ```bash
-git push origin v1.0.1
+# Fetch credentials from 1Password
+make credentials
+
+# Clean up credential files
+make clean-credentials
+
+# List available credential templates
+make list-credentials
 ```
 
-For detailed information about the versioning system, see [.devcontainer/VERSIONING.md](.devcontainer/VERSIONING.md).
+#### Homebrew Package Management
+```bash
+# List packages without dependencies (standalone packages)
+make brew-leaves
+
+# List packages organized by category
+make brew-categorized
+
+# Generate Brewfiles for standalone packages
+make brew-generate
+
+# Show dependencies of a specific package
+make brew-deps pkg=<package>
+
+# Show packages that depend on a specific package
+make brew-uses pkg=<package>
+```
+
+#### GitHub Actions Local Testing
+```bash
+# List available workflows
+make act-list
+
+# Run a specific workflow locally
+make act-run workflow=<workflow-name>
+```
+
+### Automated Releases
+
+This repository uses semantic-release for automated version management and releases based on commit messages. Follow conventional commit format:
+
+- `feat:` - New features (minor version bump)
+- `fix:` - Bug fixes (patch version bump)
+- `BREAKING CHANGE:` - Breaking changes (major version bump)
+- `docs:`, `style:`, `refactor:`, `test:`, `chore:` - No version bump
+
+Releases are automatically created when changes are pushed to the main branch.
 
 ## Glossary
 
-- Docker: An open-source platform used for automating the deployment, scaling, and management of applications.
-- Kubernetes: An open-source platform designed to automate deploying, scaling, and operating application containers.
-- Vagrant: A tool for building and managing virtual machine environments in a single workflow.
-- Zsh: A shell designed for interactive use, although it is also a powerful scripting language.
-- Git: A distributed version control system for tracking changes in source code during software development.
-- npm: The default package manager for the JavaScript runtime environment Node.js.
-- Visual Studio Code: A free source-code editor made by Microsoft for Windows, Linux, and macOS.
-- 1Password: A password manager, which provides a place for users to store various passwords, software licenses, and other sensitive information in a virtual vault locked with a PBKDF2-guarded master password.
+- **Homebrew (Brew)**: A package manager for macOS and Linux that allows easy installation and management of software packages.
+- **Brewfile**: A file format used by Homebrew to declare and install packages in a reproducible way.
+- **1Password**: A password manager that securely stores credentials, with CLI integration for automated credential management.
+- **Git**: A distributed version control system for tracking changes in source code during software development.
+- **npm**: The default package manager for the JavaScript runtime environment Node.js.
+- **Visual Studio Code**: A free source-code editor made by Microsoft for Windows, Linux, and macOS.
+- **Supabase**: An open-source Firebase alternative providing backend-as-a-service features.
+- **Semantic Release**: Automated version management and release process based on commit messages.
+- **GitHub Actions**: CI/CD platform integrated with GitHub for automating workflows.
 
 ## Disclaimer
 


### PR DESCRIPTION
Updates main README.md to fix outdated information and match current repository structure.

## Changes
- Remove references to non-existent directories (.devcontainer/, docker/, kubernetes/, linux/, macOS/)
- Update directory structure documentation to match actual layout
- Add comprehensive Makefile commands documentation
- Update setup instructions with correct workflow
- Add automated releases section for semantic-release
- Update glossary with current tools
- Fix broken references throughout documentation

Fixes #48

Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the README to reflect new repository structure, enhanced usage instructions, and revised tooling workflows.
  * Expanded directory descriptions and added information about credential management and package management integration.
  * Revised setup steps to include 1Password CLI and streamlined Homebrew usage.
  * Introduced a comprehensive list of available Makefile commands.
  * Added a section on automated releases using semantic-release.
  * Updated the glossary with new tool descriptions and removed outdated entries.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->