### PR TITLE
fix: DevContainerビルドエラーを修正 - 存在しないcommitlint.config.jsへの参照を削除

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -48,5 +48,4 @@ RUN echo 'source ~/.bashrc' >> /home/vscode/.bash_profile \
 # Husky用の設定
 COPY package.json package-lock.json /tmp/
 COPY .husky /tmp/.husky/
-COPY commitlint.config.js /tmp/
 RUN cd /tmp && npm ci && npm run prepare || true


### PR DESCRIPTION
## Summary
- DevContainerビルドエラーを修正するため、Dockerfileから存在しないcommitlint.config.jsファイルへの参照を削除

## Test plan
- [x] DevContainerのビルドが成功することを確認
- [x] Huskyの設定が正常に動作することを確認

🤖 Generated with [Claude Code](https://claude.ai/code)