### PR TITLE
fix: Dockerビルド時のキャッシュを無効化してclaude-codeの最新版を取得

### DIFF
--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -72,6 +72,7 @@ jobs:
           platforms: linux/amd64,linux/arm64
           cache-from: type=registry,ref=ghcr.io/${{ github.repository_owner }}/config-base:cache
           cache-to: type=registry,ref=ghcr.io/${{ github.repository_owner }}/config-base:cache,mode=max
+          no-cache: true
 
       - name: Export tool versions
         if: steps.semantic.outputs.skip_release != 'true'


### PR DESCRIPTION
- docker-image.ymlのbuild-push-actionにno-cache: trueを追加
- これによりビルド時に常に最新のnpmパッケージがインストールされる
- claude-codeの古いバージョンがビルドされる問題を解決

🤖 Generated with [Claude Code](https://claude.ai/code)