### PR TITLE
refactor: 不要なTypeScript関連設定とnpmスクリプトを削除

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -1,7 +1,5 @@
 module.exports = {
-  extends: ['eslint:recommended', 'plugin:@typescript-eslint/recommended', 'prettier'],
-  parser: '@typescript-eslint/parser',
-  plugins: ['@typescript-eslint'],
+  extends: ['eslint:recommended', 'prettier'],
   env: {
     browser: true,
     es2021: true,
@@ -13,8 +11,7 @@ module.exports = {
   },
   rules: {
     // プロジェクト固有のルールを追加
-    '@typescript-eslint/no-explicit-any': 'warn',
-    '@typescript-eslint/no-unused-vars': [
+    'no-unused-vars': [
       'error',
       {
         argsIgnorePattern: '^_',

--- a/package.json
+++ b/package.json
@@ -8,14 +8,10 @@
     "url": "https://github.com/keito4/config.git"
   },
   "scripts": {
-    "dev": "echo 'No dev server configured'",
-    "build": "echo 'No build process configured'",
-    "test": "echo 'No tests configured'",
-    "lint": "eslint . --ext .js,.jsx,.ts,.tsx",
+    "lint": "eslint . --ext .js,.jsx",
     "lint:fix": "npm run lint -- --fix",
     "format": "prettier --write .",
     "format:check": "prettier --check .",
-    "type-check": "echo 'No TypeScript configured'",
     "prepare": "husky"
   },
   "devDependencies": {
@@ -25,8 +21,6 @@
     "@semantic-release/exec": "^6.0.3",
     "@semantic-release/github": "^11.0.0",
     "@semantic-release/release-notes-generator": "^14.0.1",
-    "@typescript-eslint/eslint-plugin": "^8.19.0",
-    "@typescript-eslint/parser": "^8.19.0",
     "bats": "^1.12.0",
     "bats-assert": "^2.1.0",
     "bats-support": "^0.3.0",


### PR DESCRIPTION
Issue #89の対応で、不要なコードを削除しました。

## 削除した項目

- TypeScript関連devDependencies
- 未使用のnpmスクリプト
- ESLintのTypeScript関連設定
- lintコマンドのTypeScript拡張子

生成された [Claude Code](https://claude.ai/code)