### PR TITLE
feat: add environment variables for Claude Code configuration

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -103,7 +103,10 @@
     "deny": []
   },
   "env": {
-    "CLAUDE_CODE_PROJECT_NAME": "keito4/config"
+    "CLAUDE_CODE_PROJECT_NAME": "keito4/config",
+    "BASH_DEFAULT_TIMEOUT_MS": "300000",
+    "BASH_MAX_TIMEOUT_MS": "1200000",
+    "MAX_THINKING_TOKENS": "31999"
   },
   "hooks": {
     "Stop": [


### PR DESCRIPTION
## Summary
- Add timeout configuration for Bash commands in Claude Code
- Add token limit configuration for thinking mode

## Changes
- BASH_DEFAULT_TIMEOUT_MS: 300000 (5 minutes)
- BASH_MAX_TIMEOUT_MS: 1200000 (20 minutes)
- MAX_THINKING_TOKENS: 31999

## Test plan
- [x] Settings file syntax is valid JSON
- [x] Pre-commit hooks pass
- [x] No linting errors

🤖 Generated with [Claude Code](https://claude.ai/code)