### PR TITLE
fix: pin @openai/codex version to 0.55.0 in DevContainer

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -43,7 +43,7 @@ RUN bash -c "pnpm setup" \
 
 USER root
 
-RUN npm install -g typescript eslint @anthropic-ai/claude-code @openai/codex vercel
+RUN npm install -g typescript eslint @anthropic-ai/claude-code @openai/codex@0.55.0 vercel
 
 USER vscode
 RUN bash -lc "cargo install similarity-ts" || true \


### PR DESCRIPTION
## Summary
- DevContainerのDockerfileで`@openai/codex`パッケージのバージョンを`0.55.0`に固定
- ビルド時の一貫性と安定性を確保

## Test plan
- [ ] DevContainerを再ビルドして正常に起動することを確認
- [ ] `@openai/codex`が期待通りのバージョンでインストールされることを確認

🤖 Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated development environment configuration with pinned dependency versions to ensure consistent and reproducible builds across development setups.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->