### PR TITLE
fix: pin tooling versions

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -43,7 +43,7 @@ RUN bash -c "pnpm setup" \
 
 USER root
 
-RUN npm install -g typescript eslint @anthropic-ai/claude-code @openai/codex@0.55.0 vercel
+RUN npm install -g typescript eslint @anthropic-ai/claude-code@2.0.35 @openai/codex@0.55.0 vercel
 
 USER vscode
 RUN bash -lc "cargo install similarity-ts" || true \

--- a/npm/global.json
+++ b/npm/global.json
@@ -2,7 +2,7 @@
   "name": "lib",
   "dependencies": {
     "@anthropic-ai/claude-code": {
-      "version": "1.0.55",
+      "version": "2.0.35",
       "overridden": false
     },
     "@leonardsellem/n8n-mcp-server": {

--- a/package.json
+++ b/package.json
@@ -20,18 +20,18 @@
     "prepare": "husky"
   },
   "devDependencies": {
-    "@commitlint/cli": "^19.8.1",
-    "@commitlint/config-conventional": "^19.8.1",
-    "@semantic-release/commit-analyzer": "^13.0.0",
-    "@semantic-release/exec": "^6.0.3",
-    "@semantic-release/github": "^10.3.5",
-    "@semantic-release/release-notes-generator": "^14.0.1",
-    "conventional-changelog-conventionalcommits": "^8.0.0",
-    "eslint": "^8.57.1",
-    "eslint-config-prettier": "^9.1.0",
-    "husky": "^9.1.7",
-    "jest": "^29.7.0",
-    "prettier": "^3.4.2",
-    "semantic-release": "^24.2.0"
+    "@commitlint/cli": "19.8.1",
+    "@commitlint/config-conventional": "19.8.1",
+    "@semantic-release/commit-analyzer": "13.0.1",
+    "@semantic-release/exec": "6.0.3",
+    "@semantic-release/github": "10.3.5",
+    "@semantic-release/release-notes-generator": "14.0.3",
+    "conventional-changelog-conventionalcommits": "8.0.0",
+    "eslint": "8.57.1",
+    "eslint-config-prettier": "9.1.2",
+    "husky": "9.1.7",
+    "jest": "29.7.0",
+    "prettier": "3.6.2",
+    "semantic-release": "24.2.7"
   }
 }


### PR DESCRIPTION
## Summary\n- pin all devDependencies in package.json\n- pin claude-code global install and devcontainer image to 2.0.35\n- verify build pipeline with npm run build\n\n## Testing\n- npm run build

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Pinned all development dependencies to exact versions instead of range specifications to ensure consistent builds and reproducibility across development environments
  * Updated core tooling dependency to the latest major release version for improved stability and compatibility

<!-- end of auto-generated comment: release notes by coderabbit.ai -->