### PR TITLE
fix: enforce release commit types

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -9,6 +9,7 @@ This repository implements comprehensive development quality standards and AI-as
 - **Test-Driven Development (TDD)**: Red → Green → Refactor methodology with 70%+ line coverage requirement
 - **Static Quality Gates**: Automated linting, formatting, security analysis, and license checking
 - **Git Workflow**: Conventional commits, branch naming conventions, and pull request requirements
+- **Release Types Required for Tooling Changes**: Commits that touch `.codex/**`, `.devcontainer/codex*`, `package*.json`, or `npm/global.json` must use release-triggering types (`feat` / `fix` / `perf` / `revert` / `docs`). commitlint blocks `chore`など非リリース型のメッセージを防止し、semantic-release の自動リリースと整合させます。
 
 ### AI Prompt Design Guidelines
 

--- a/README.md
+++ b/README.md
@@ -87,6 +87,7 @@ Run the `commit_changes.sh` script with `REPO_PATH` set to this repository to ch
 - The script performs `npm-check-updates`, `npm install`, rebuilds the `dist/` artifacts, and re-synchronizes global CLI versions via `npm view <package> version`.
 - Packages that currently require newer Node.js releases (`semantic-release`, `@semantic-release/github`) are excluded by default. Override the exclusion list with `UPDATE_LIBS_REJECT="pkg1,pkg2" npm run update:libs` when you are ready to bump them.
 - `.github/workflows/update-libraries.yml` executes the same script weekly and opens a PR whenever it produces changes, ensuring Codex/Claude Code tooling stays current without manual effort.
+- Commits that touch release-critical files (`package*.json`, `npm/global.json`, `.devcontainer/codex*`, `.codex/**`) **must** use a release-triggering Conventional Commit type (`feat`, `fix`, `perf`, `revert`, or `docs`). Commitlint enforces this so semantic-release can publish automatically when tooling versions change.
 
 ### Claude Agent Configuration Setup
 

--- a/commitlint.config.js
+++ b/commitlint.config.js
@@ -1,9 +1,52 @@
+const { execSync } = require('child_process');
+
+const releaseTypeAllowList = new Set(['feat', 'fix', 'perf', 'revert', 'docs']);
+const releaseSensitivePatterns = [
+  /^package\.json$/,
+  /^package-lock\.json$/,
+  /^npm\/global\.json$/,
+  /^\.devcontainer\/Dockerfile$/,
+  /^\.devcontainer\/codex-config\.json$/,
+  /^\.codex\//,
+];
+
+const getStagedFiles = () => {
+  try {
+    return execSync('git diff --cached --name-only', { encoding: 'utf8' }).split('\n').filter(Boolean);
+  } catch {
+    return [];
+  }
+};
+
+const releaseTypeRule = (parsed) => {
+  const files = getStagedFiles();
+  const touched = files.filter((file) => releaseSensitivePatterns.some((pattern) => pattern.test(file)));
+
+  if (!touched.length) {
+    return [true];
+  }
+
+  const isReleaseType = releaseTypeAllowList.has(parsed.type || '');
+  return [
+    isReleaseType,
+    `Changes in ${touched.join(', ')} require a release-triggering type (feat|fix|perf|revert|docs) to keep semantic-release automated.`,
+  ];
+};
+
 module.exports = {
   extends: ['@commitlint/config-conventional'],
+  plugins: [
+    {
+      rules: {
+        'codex-release-type': (parsed) => releaseTypeRule(parsed),
+      },
+    },
+  ],
   rules: {
     'subject-case': [0], // 日本語対応のため無効化
     'subject-empty': [2, 'never'],
     'type-empty': [2, 'never'],
     'scope-empty': [0],
+    'codex-release-type': [2, 'always'],
   },
 };


### PR DESCRIPTION
## Summary
- document why the previous Codex update failed to release (semantic-release ignores `chore` commits)
- add a commitlint plugin rule that inspects staged files and forces release-triggering types (`feat|fix|perf|revert|docs`) whenever `.codex/**`, `.devcontainer/codex*`, `package*.json`, or `npm/global.json` change
- update README/CLAUDE so contributors know to use release types for tooling updates

## Testing
- npm test
- npm run lint
- npm run build


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added release commit policy: commits affecting package configuration and tooling files now require release-triggering commit types (feat, fix, perf, revert, or docs).

* **Chores**
  * Enhanced commitlint configuration to enforce new release commit requirements for sensitive files.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->