### PR TITLE
fix: sync codex and claude-code versions

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -43,7 +43,14 @@ RUN bash -c "pnpm setup" \
 
 USER root
 
-RUN npm install -g typescript eslint @anthropic-ai/claude-code@2.0.37 @openai/codex@0.58.0 vercel
+COPY npm/global.json /tmp/npm-global.json
+
+RUN CLAUDE_CODE_VERSION=$(node -pe "require('/tmp/npm-global.json').dependencies['@anthropic-ai/claude-code'].version") \
+ && CODEX_VERSION=$(node -pe "require('/tmp/npm-global.json').dependencies['@openai/codex'].version") \
+ && npm install -g typescript eslint \
+    @anthropic-ai/claude-code@${CLAUDE_CODE_VERSION} \
+    @openai/codex@${CODEX_VERSION} \
+    vercel
 
 USER vscode
 RUN bash -lc "cargo install similarity-ts" || true \

--- a/README.md
+++ b/README.md
@@ -89,6 +89,13 @@ Run the `commit_changes.sh` script with `REPO_PATH` set to this repository to ch
 - `.github/workflows/update-libraries.yml` executes the same script weekly and opens a PR whenever it produces changes, ensuring Codex/Claude Code tooling stays current without manual effort.
 - Commits that touch release-critical files (`package*.json`, `npm/global.json`, `.devcontainer/codex*`, `.codex/**`) **must** use a release-triggering Conventional Commit type (`feat`, `fix`, `perf`, `revert`, or `docs`). Commitlint enforces this so semantic-release can publish automatically when tooling versions change.
 
+#### Global CLI version source of truth
+
+- `npm/global.json` is the single source of truth for both `@openai/codex` and `@anthropic-ai/claude-code` versions.
+- The DevContainer Dockerfile copies this file into the build context and reads the versions at build time, guaranteeing that `npm install -g ...` pins to the same versions used by local setups.
+- When bumping either CLI, update the version in `npm/global.json` (or run `npm run update:libs`) and rebuild the DevContainer image. No manual edits in `.devcontainer/Dockerfile` are required anymore.
+- Re-run `.codex/setup-agents.sh` or `~/.codex/scripts/sync-agents.sh --update` after rebuilding if you want the new CLI versions reflected in developer machines outside the container.
+
 ### Claude Agent Configuration Setup
 
 The `.codex/` directory contains a comprehensive agent distribution system for Claude Code. To set up the specialized agents on your system:


### PR DESCRIPTION
## Summary
- read Codex/Claude Code CLI versions from `npm/global.json` during DevContainer image build so the image always matches the repository
- document the new single source of truth for global CLI versions in the README

## Testing
- `npm run test`
- `npm run lint`
- `npm run format:check`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added guidance on global CLI version management, establishing a single source of truth for tool versions in development environments.

* **Chores**
  * Updated dev container configuration for improved version management of development tools.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->