### PR TITLE
docs: fix command count inconsistencies in documentation

### DIFF
--- a/.devcontainer/README.md
+++ b/.devcontainer/README.md
@@ -60,7 +60,7 @@ On container startup, the following configurations are automatically applied:
 The container includes comprehensive AI-assisted development capabilities:
 
 - **13 Specialized Agents**: Architecture validation, performance analysis, security review, accessibility validation, concurrency safety analysis, and more
-- **14 Automated Commands**: Quality checks, project initialization, CI/CD troubleshooting, dependency management, and PR workflows
+- **13 Automated Commands**: 2 Claude commands (git-sync, Husky setup) + 11 Codex prompts (security analysis, code refactoring, CI/CD troubleshooting, dependency management, and PR workflows)
 - **Quality Standards**: Japanese-language development guidelines with TDD methodology and static quality gates
 
 ## Container Versioning

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -63,7 +63,7 @@ For detailed information about each agent, see [.claude/agents/README.md](.claud
 
 ## Automated Commands
 
-The `.claude/commands/` directory provides 14 pre-configured commands organized by category:
+The `.claude/commands/` directory provides 2 pre-configured commands, with an additional 11 automated prompts available in `.codex/prompts/`, organized by category:
 
 ### Quality & Testing
 

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ It includes settings for various tools, such as the shell (Zsh), Git, npm, and V
 
 - `.claude/`: Comprehensive Claude Code configuration directory with:
   - **13 specialized AI agents**: Architecture validation (DDD, Clean Architecture), accessibility & design validation, concurrency safety analysis, documentation consistency checking, dependency auditing, performance analysis, testability & coverage analysis, and issue resolution workflows
-  - **14 automated commands**: Code coverage checking, CI/CD troubleshooting, project initialization, pull request creation, quality checks, security reviews, test execution, dependency updates, and n8n MCP integration setup
+  - **13 automated commands**: 2 Claude commands (git-sync, Husky setup) + 11 Codex prompts (security analysis, code refactoring, Next.js workflows, dependency management)
   - **Development quality standards**: Japanese-language guidelines for TDD methodology, static quality gates, Git workflow conventions, and AI-assisted development practices
 - `.codex/`: Codex CLI configuration and agent distribution system with:
   - **Agent Settings**: Centralized configuration for 13 specialized AI agents in `AGENTS.md`


### PR DESCRIPTION
Fixes #150

This PR corrects documentation inconsistencies discovered after the recent sync in PR #149.

## Changes

- **CLAUDE.md**: Fixed ".claude/commands/ directory provides 14 pre-configured commands" to accurately describe 2 Claude commands + 11 Codex prompts
- **README.md**: Updated "14 automated commands" to "13 automated commands" with proper component breakdown
- **.devcontainer/README.md**: Corrected "14 Automated Commands" to "13 Automated Commands" with detailed composition

## Context

PR #149 updated the .claude/ and .codex/ structure extensively, but some documentation still referenced outdated counts. The actual configuration consists of:

- **Claude commands**: 2 files in .claude/commands/
- **Codex prompts**: 11 files in .codex/prompts/
- **Total**: 13 automated commands/prompts

----

Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Documentation
* Updated documentation to clarify the automated commands and prompts available in the development setup, providing adjusted counts and a more detailed breakdown of command and prompt composition.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->