### PR TITLE
fix: BuildKit secretへのアクセス権限を修正

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -81,10 +81,10 @@ COPY --chown=vscode:vscode script/install-claude-plugins.sh /tmp/install-claude-
 
 # Install Claude plugins using BuildKit secret
 # Build with: DOCKER_BUILDKIT=1 docker build --secret id=claude_credentials,src=$HOME/.claude/.credentials.json .
-USER vscode
-RUN --mount=type=secret,id=claude_credentials \
-    /tmp/install-claude-plugins.sh /home/vscode/.claude/plugins/plugins.txt || true
-USER root
+# Note: Run as root to access BuildKit secret, then change ownership to vscode
+RUN --mount=type=secret,id=claude_credentials,uid=0,gid=0 \
+    /tmp/install-claude-plugins.sh /home/vscode/.claude/plugins/plugins.txt || true \
+    && chown -R vscode:vscode /home/vscode/.claude
 
 RUN chsh -s /bin/bash vscode
 


### PR DESCRIPTION
## 問題

v1.6.1のDockerイメージでもプラグインが正しくインストールされていませんでした。

### ビルドログに記録されたエラー

```
cp: cannot open '/run/secrets/claude_credentials' for reading: Permission denied
```

### 根本原因の詳細分析

1. **ユーザー切り替えのタイミング**
   ```dockerfile
   USER vscode  # ← ここで vscode ユーザーに切り替え
   RUN --mount=type=secret,id=claude_credentials \  # ← vscode ユーザーで実行
       /tmp/install-claude-plugins.sh ...
   ```

2. **BuildKit secretのデフォルト動作**
   - Secretは **root ユーザー (uid=0, gid=0)** でマウントされる
   - デフォルトのパーミッション: `-r--------` (400)
   - vscode ユーザーには読み取り権限がない

3. **結果**
   - スクリプトが secret ファイルにアクセスできない
   - プラグインインストールが実行されない
   - `|| true` で失敗が無視される

## 解決策

### Dockerfile の修正

**Before** (v1.6.1):
```dockerfile
USER vscode
RUN --mount=type=secret,id=claude_credentials \
    /tmp/install-claude-plugins.sh /home/vscode/.claude/plugins/plugins.txt || true
USER root
```

**After** (v1.6.2):
```dockerfile
RUN --mount=type=secret,id=claude_credentials,uid=0,gid=0 \
    /tmp/install-claude-plugins.sh /home/vscode/.claude/plugins/plugins.txt || true \
    && chown -R vscode:vscode /home/vscode/.claude
```

### 変更ポイント

| 項目 | Before | After | 効果 |
|------|--------|-------|------|
| 実行ユーザー | vscode | **root** | Secret アクセス可能 |
| Secret mount | デフォルト | **uid=0,gid=0 明示** | 明確化 |
| 所有権変更 | なし | **chown 追加** | vscode ユーザーで使用可能 |

## 期待効果

### プラグインインストール

| 項目 | v1.6.0 | v1.6.1 | v1.6.2 (This PR) |
|------|--------|--------|------------------|
| マーケットプレイス追加 | ❌ | ✅ | ✅ |
| Secret アクセス | ❌ | ❌ | ✅ |
| プラグインインストール | ❌ | ❌ | ✅ |
| エラーログ表示 | ❌ | ✅ | ✅ |

### ビルド時間

変更なし（処理内容は同じ）

### セキュリティ

- ✅ root 実行だが、インストール後に所有権を vscode に変更
- ✅ `.credentials.json` は削除される（スクリプト内で実装済み）
- ✅ Secret は一時的にのみアクセス可能

## テスト計画

### フェーズ1: ローカルでの確認
1. ✅ Dockerfile の文法チェック
2. ✅ pre-commit フック通過

### フェーズ2: CI/CD ビルド
1. ⏳ Docker ビルド実行
2. ⏳ ビルドログでプラグインインストールログ確認
3. ⏳ エラーログに「Permission denied」が出ないことを確認

### フェーズ3: DevContainer 起動確認
1. ⏳ v1.6.2 イメージで DevContainer 起動
2. ⏳ `/plugin` コマンドでエラーが出ないか確認
3. ⏳ 15個のプラグインすべてが正常動作するか確認

## ビルドログで確認すべき項目

成功時のログ:
```
[INFO] Claude プラグインのインストールを開始します...
[INFO] BuildKit secret から認証情報を読み込み中...
[INFO] マーケットプレイスを初期化中...
[INFO] プラグインをインストール中...
[SUCCESS]   完了: frontend-design@claude-code-plugins
[SUCCESS]   完了: hookify@claude-code-plugins
...
[INFO] プラグイン: 15 インストール完了、0 失敗/スキップ
```

## 影響範囲

### Dockerビルド
- ✅ プラグインが正しくインストールされる
- ✅ ビルド時間は変わらず

### ローカル環境
- ✅ 影響なし

### DevContainer 環境
- ✅ プラグインが利用可能になる
- ✅ `/plugin` コマンドでエラーが出なくなる

## 関連PR

- **PR #171**: プラグイン追加 (v1.6.0) - プラグインインストール失敗
- **PR #172**: ビルドキャッシュ有効化 - 成功
- **PR #173**: プラグインインストール改善 (v1.6.1) - Secret アクセス失敗
- **PR #174** (This): Secret 権限修正 - 🎯 最終修正

## ロールバック手順

問題が発生した場合:

```bash
# v1.6.1 に戻す
git revert <commit-hash>

# または、Dockerfile を v1.6.1 に戻す
git checkout v1.6.1 -- .devcontainer/Dockerfile
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated development container configuration to improve build process reliability and file permission handling.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->