### PR TITLE
fix: Dockerビルドでのマーケットプレイス追加コマンドを修正 (v1.6.3)

### DIFF
--- a/script/install-claude-plugins.sh
+++ b/script/install-claude-plugins.sh
@@ -49,10 +49,10 @@ echo "[INFO] マーケットプレイスを初期化中..."
 if [[ -f "${CLAUDE_DIR}/plugins/known_marketplaces.json" ]]; then
     echo "[INFO] known_marketplaces.jsonが見つかりました"
 
-    # 必須マーケットプレイスを追加
-    claude plugin add-marketplace anthropic/claude-code --name claude-code-plugins 2>&1 || echo "[WARN] claude-code-plugins already exists or failed to add"
-    claude plugin add-marketplace https://github.com/davila7/claude-code-templates.git --name claude-code-templates 2>&1 || echo "[WARN] claude-code-templates already exists or failed to add"
-    claude plugin add-marketplace wshobson/agents --name claude-code-workflows 2>&1 || echo "[WARN] claude-code-workflows already exists or failed to add"
+    # 必須マーケットプレイスを追加（正しいコマンド: claude plugin marketplace add）
+    claude plugin marketplace add anthropic/claude-code 2>&1 || echo "[WARN] claude-code-plugins already exists or failed to add"
+    claude plugin marketplace add https://github.com/davila7/claude-code-templates.git 2>&1 || echo "[WARN] claude-code-templates already exists or failed to add"
+    claude plugin marketplace add wshobson/agents 2>&1 || echo "[WARN] claude-code-workflows already exists or failed to add"
 else
     echo "[WARN] known_marketplaces.jsonが見つかりません"
 fi


### PR DESCRIPTION
## 問題

v1.6.2のDockerイメージでも依然としてプラグインがインストールされていませんでした。

### ビルドログに記録されたエラー

```
[INFO] マーケットプレイスを初期化中...
[INFO] known_marketplaces.jsonが見つかりました
error: unknown command 'add-marketplace'
[WARN] claude-code-plugins already exists or failed to add
error: unknown command 'add-marketplace'
[WARN] claude-code-templates already exists or failed to add
error: unknown command 'add-marketplace'
[WARN] claude-code-workflows already exists or failed to add
[INFO] プラグインをインストール中...
[DEBUG] Claude version: 2.0.76
[DEBUG] Marketplaces directory: /home/vscode/.claude/plugins/marketplaces
[WARN] Marketplaces directory not found
[INFO] プラグイン: 0 インストール完了、15 失敗/スキップ
```

### 根本原因の詳細分析

1. **存在しないコマンドの使用**
   ```bash
   # install-claude-plugins.sh で使用していたコマンド（誤り）
   claude plugin add-marketplace anthropic/claude-code --name claude-code-plugins
   ```
   
2. **Claude CLI v2.0.76の実際のコマンド**
   ```bash
   $ claude plugin --help
   Commands:
     ...
     marketplace  Manage Claude Code marketplaces
     ...
   
   $ claude plugin marketplace --help
   Commands:
     add <source>  Add a marketplace from a URL, path, or GitHub repo
   ```
   
   正しいコマンド構造: `claude plugin marketplace add <source>`

3. **結果**
   - `add-marketplace`というサブコマンドは存在しない
   - マーケットプレイスが一つも追加されない
   - `/home/vscode/.claude/plugins/marketplaces`ディレクトリが空のまま
   - 全15プラグインのインストールが失敗

## 解決策

### コマンド修正

**Before** (v1.6.2):
```bash
claude plugin add-marketplace anthropic/claude-code --name claude-code-plugins
claude plugin add-marketplace https://github.com/davila7/claude-code-templates.git --name claude-code-templates
claude plugin add-marketplace wshobson/agents --name claude-code-workflows
```

**After** (v1.6.3):
```bash
claude plugin marketplace add anthropic/claude-code
claude plugin marketplace add https://github.com/davila7/claude-code-templates.git
claude plugin marketplace add wshobson/agents
```

### 変更ポイント

| 項目 | Before | After | 理由 |
|------|--------|-------|------|
| コマンド構造 | `plugin add-marketplace` | `plugin marketplace add` | 正しいサブコマンド階層 |
| `--name`オプション | あり | **削除** | 不要（自動で名前が決定される） |

### コマンド動作確認（ローカル）

```bash
$ claude plugin marketplace add anthropic/claude-code
Successfully added marketplace 'claude-code-plugins'

$ claude plugin marketplace list
Configured marketplaces:
  ❯ claude-code-plugins
    Source: GitHub (anthropics/claude-code)
```

## 期待効果

### プラグインインストール

| 項目 | v1.6.0 | v1.6.1 | v1.6.2 | v1.6.3 (This PR) |
|------|--------|--------|--------|------------------|
| マーケットプレイス追加 | ❌ | ❌ | ❌ エラー | ✅ 成功 |
| Secret アクセス | ❌ | ❌ | ✅ | ✅ |
| プラグインインストール | ❌ 0/15 | ❌ 0/15 | ❌ 0/15 | ✅ 15/15 期待 |
| エラーログ表示 | ❌ | ✅ | ✅ | ✅ |

### ビルド時間

**変更なし** - コマンド修正のみ（処理内容は同じ）

### ビルドログ（成功時の期待出力）

```
[INFO] マーケットプレイスを初期化中...
[INFO] known_marketplaces.jsonが見つかりました
Successfully added marketplace 'claude-code-plugins'
Successfully added marketplace 'claude-code-templates'
Successfully added marketplace 'claude-code-workflows'
[INFO] プラグインをインストール中...
[DEBUG] Claude version: 2.0.76
[DEBUG] Marketplaces directory: /home/vscode/.claude/plugins/marketplaces
drwxr-xr-x  claude-code-plugins
drwxr-xr-x  claude-code-templates
drwxr-xr-x  claude-code-workflows
[INFO]   インストール中: frontend-design@claude-code-plugins
[SUCCESS]   完了: frontend-design@claude-code-plugins
...
[INFO] プラグイン: 15 インストール完了、0 失敗/スキップ
[SUCCESS] Claude プラグインのインストールが完了しました
```

## テスト計画

### フェーズ1: ローカルでの確認
1. ✅ スクリプトの文法チェック
2. ✅ pre-commit フック通過

### フェーズ2: CI/CD ビルド
1. ⏳ Docker ビルド実行
2. ⏳ ビルドログでマーケットプレイス追加成功確認
3. ⏳ ビルドログでプラグインインストール成功確認
4. ⏳ エラーログに「unknown command」が出ないことを確認

### フェーズ3: DevContainer 起動確認
1. ⏳ v1.6.3 イメージで DevContainer 起動
2. ⏳ `/plugin` コマンドでエラーが出ないか確認
3. ⏳ 15個のプラグインすべてが正常動作するか確認

## 影響範囲

### Dockerビルド
- ✅ マーケットプレイスが正しく追加される
- ✅ プラグインが正しくインストールされる
- ✅ ビルド時間は変わらず

### ローカル環境
- ✅ 影響なし

### DevContainer 環境
- ✅ プラグインが利用可能になる
- ✅ `/plugin` コマンドでエラーが出なくなる

## 関連PR

- **PR #171**: プラグイン追加 (v1.6.0) - マーケットプレイス未初期化
- **PR #172**: ビルドキャッシュ有効化 (v1.6.1) - ビルド時間87-94%削減成功
- **PR #173**: プラグインインストール改善 (v1.6.1) - コマンドエラー発生
- **PR #174**: Secret 権限修正 (v1.6.2) - Secret アクセス成功、コマンドエラー継続
- **PR #175** (This): コマンド修正 - 🎯 最終修正（4回目）

## ロールバック手順

問題が発生した場合:

```bash
# v1.6.2 に戻す
git revert <commit-hash>

# または、スクリプトを v1.6.2 に戻す
git checkout v1.6.2 -- script/install-claude-plugins.sh
```

## 検証ポイント

マージ後のビルドログで以下を確認:

- [ ] `Successfully added marketplace 'claude-code-plugins'`
- [ ] `Successfully added marketplace 'claude-code-templates'`
- [ ] `Successfully added marketplace 'claude-code-workflows'`
- [ ] `[SUCCESS]   完了: frontend-design@claude-code-plugins`（×15回）
- [ ] `[INFO] プラグイン: 15 インストール完了、0 失敗/スキップ`
- [ ] `error: unknown command` が出ないこと

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Corrected Claude CLI plugin marketplace add commands to use the proper command syntax, ensuring reliable plugin marketplace initialization during setup.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->