### PR TITLE
fix: マーケットプレイス追加でHTTPS URLを使用 (v1.6.4)

### DIFF
--- a/script/install-claude-plugins.sh
+++ b/script/install-claude-plugins.sh
@@ -49,10 +49,10 @@ echo "[INFO] マーケットプレイスを初期化中..."
 if [[ -f "${CLAUDE_DIR}/plugins/known_marketplaces.json" ]]; then
     echo "[INFO] known_marketplaces.jsonが見つかりました"
 
-    # 必須マーケットプレイスを追加（正しいコマンド: claude plugin marketplace add）
-    claude plugin marketplace add anthropic/claude-code 2>&1 || echo "[WARN] claude-code-plugins already exists or failed to add"
+    # 必須マーケットプレイスを追加（完全なHTTPS URLを使用）
+    claude plugin marketplace add https://github.com/anthropics/claude-code.git 2>&1 || echo "[WARN] claude-code-plugins already exists or failed to add"
     claude plugin marketplace add https://github.com/davila7/claude-code-templates.git 2>&1 || echo "[WARN] claude-code-templates already exists or failed to add"
-    claude plugin marketplace add wshobson/agents 2>&1 || echo "[WARN] claude-code-workflows already exists or failed to add"
+    claude plugin marketplace add https://github.com/wshobson/agents.git 2>&1 || echo "[WARN] claude-code-workflows already exists or failed to add"
 else
     echo "[WARN] known_marketplaces.jsonが見つかりません"
 fi


### PR DESCRIPTION
## 問題

v1.6.3のDockerイメージでも`claude-code-plugins`マーケットプレイスの追加に失敗し、4つのプラグインがインストールできていませんでした。

### ビルドログに記録されたエラー

```
Adding marketplace...
SSH not configured, cloning via HTTPS: https://github.com/anthropic/claude-code.git
Cloning repository: https://github.com/anthropic/claude-code.git
HTTPS clone failed, retrying with SSH: git@github.com:anthropic/claude-code.git
Cloning repository: git@github.com:anthropic/claude-code.git
✘ Failed to add marketplace: Failed to clone marketplace repository: SSH authentication failed
[WARN] claude-code-plugins already exists or failed to add
```

### v1.6.3のインストール結果

| マーケットプレイス | 状態 |
|-------------------|------|
| claude-code-plugins | ❌ 失敗 (SSH認証エラー) |
| claude-code-templates | ✅ 成功 |
| claude-code-workflows | ✅ 成功 |

**プラグイン**: 11/15成功、4失敗

失敗したプラグイン（すべて`claude-code-plugins`）:
- frontend-design
- hookify
- feature-dev
- security-guidance

### 根本原因の詳細分析

1. **短縮形の問題**
   ```bash
   # 使用していたコマンド
   claude plugin marketplace add anthropic/claude-code
   claude plugin marketplace add wshobson/agents
   ```
   
2. **Claude CLIの動作**
   - GitHub短縮形 (`owner/repo`) を検出
   - HTTPS URL (`https://github.com/owner/repo.git`) に変換してクローン試行
   - HTTPS失敗時、SSH (`git@github.com:owner/repo.git`) にフォールバック
   - Dockerコンテナ内にSSHキーがないため失敗

3. **結果**
   - `claude-code-plugins`マーケットプレイスが追加されない
   - 4つのプラグインインストールが失敗

## 解決策

### URL修正

すべてのマーケットプレイスで**完全なHTTPS URL**を使用:

**Before** (v1.6.3):
```bash
claude plugin marketplace add anthropic/claude-code
claude plugin marketplace add https://github.com/davila7/claude-code-templates.git
claude plugin marketplace add wshobson/agents
```

**After** (v1.6.4):
```bash
claude plugin marketplace add https://github.com/anthropics/claude-code.git
claude plugin marketplace add https://github.com/davila7/claude-code-templates.git
claude plugin marketplace add https://github.com/wshobson/agents.git
```

### 変更ポイント

| 項目 | Before | After | 効果 |
|------|--------|-------|------|
| claude-code-plugins | `anthropic/claude-code` | `https://github.com/anthropics/claude-code.git` | SSHフォールバック回避 |
| claude-code-workflows | `wshobson/agents` | `https://github.com/wshobson/agents.git` | SSHフォールバック回避 |

**重要**: `anthropic` → `anthropics` (sが必要)

## 期待効果

### マーケットプレイス追加

| マーケットプレイス | v1.6.3 | v1.6.4 (This PR) |
|-------------------|--------|------------------|
| claude-code-plugins | ❌ SSH認証失敗 | ✅ HTTPS成功 |
| claude-code-templates | ✅ 成功 | ✅ 成功 |
| claude-code-workflows | ✅ 成功 | ✅ 成功 |

### プラグインインストール

| 項目 | v1.6.3 | v1.6.4 (This PR) |
|------|--------|------------------|
| インストール成功 | 11/15 (73%) | ✅ 15/15 (100%) |
| 失敗したプラグイン | 4個 | 0個 |

### ビルド時間

**変更なし** - URL形式の変更のみ

### ビルドログ（成功時の期待出力）

```
[INFO] マーケットプレイスを初期化中...
Adding marketplace...
Cloning repository: https://github.com/anthropics/claude-code.git
Clone complete, validating marketplace…
✔ Successfully added marketplace: claude-code-plugins

Adding marketplace...
Cloning repository: https://github.com/davila7/claude-code-templates.git
Clone complete, validating marketplace…
✔ Successfully added marketplace: claude-code-templates

Adding marketplace...
Cloning repository: https://github.com/wshobson/agents.git
Clone complete, validating marketplace…
✔ Successfully added marketplace: claude-code-workflows

[INFO] プラグインをインストール中...
[SUCCESS]   完了: frontend-design@claude-code-plugins
[SUCCESS]   完了: hookify@claude-code-plugins
[SUCCESS]   完了: feature-dev@claude-code-plugins
[SUCCESS]   完了: security-guidance@claude-code-plugins
...
[INFO] プラグイン: 15 インストール完了、0 失敗/スキップ
```

## テスト計画

### フェーズ1: ローカルでの確認
1. ✅ スクリプトの文法チェック
2. ✅ pre-commit フック通過

### フェーズ2: CI/CD ビルド
1. ⏳ Docker ビルド実行
2. ⏳ ビルドログで3つすべてのマーケットプレイス追加成功確認
3. ⏳ ビルドログで15個すべてのプラグインインストール成功確認
4. ⏳ エラーログに「SSH authentication failed」が出ないことを確認

### フェーズ3: DevContainer 起動確認
1. ⏳ v1.6.4 イメージで DevContainer 起動
2. ⏳ `/plugin` コマンドでエラーが出ないか確認
3. ⏳ 15個のプラグインすべてが正常動作するか確認

## 影響範囲

### Dockerビルド
- ✅ すべてのマーケットプレイスが正しく追加される
- ✅ すべてのプラグインが正しくインストールされる
- ✅ ビルド時間は変わらず

### ローカル環境
- ✅ 影響なし

### DevContainer 環境
- ✅ すべてのプラグインが利用可能になる
- ✅ `/plugin` コマンドでエラーが出なくなる

## 関連PR

- **PR #171**: プラグイン追加 (v1.6.0) - マーケットプレイス未初期化
- **PR #172**: ビルドキャッシュ有効化 (v1.6.1) - ビルド時間87-94%削減成功
- **PR #173**: プラグインインストール改善 (v1.6.1) - コマンドエラー発生
- **PR #174**: Secret 権限修正 (v1.6.2) - Secret アクセス成功、コマンドエラー継続
- **PR #175**: コマンド修正 (v1.6.3) - マーケットプレイス追加部分成功（11/15プラグイン）
- **PR #176** (This): HTTPS URL修正 - 🎯 最終修正（5回目、完全成功想定）

## ロールバック手順

問題が発生した場合:

```bash
# v1.6.3 に戻す
git revert <commit-hash>

# または、スクリプトを v1.6.3 に戻す
git checkout v1.6.3 -- script/install-claude-plugins.sh
```

## 検証ポイント

マージ後のビルドログで以下を確認:

- [ ] `✔ Successfully added marketplace: claude-code-plugins`
- [ ] `✔ Successfully added marketplace: claude-code-templates`
- [ ] `✔ Successfully added marketplace: claude-code-workflows`
- [ ] `[SUCCESS]   完了: frontend-design@claude-code-plugins`
- [ ] `[SUCCESS]   完了: hookify@claude-code-plugins`
- [ ] `[SUCCESS]   完了: feature-dev@claude-code-plugins`
- [ ] `[SUCCESS]   完了: security-guidance@claude-code-plugins`
- [ ] `[INFO] プラグイン: 15 インストール完了、0 失敗/スキップ`
- [ ] `SSH authentication failed` が出ないこと

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated plugin installation configuration for improved dependency sourcing. Specific marketplace component source identifiers have been revised to use alternative repository sources during setup processes. All installation workflows, error handling procedures, system functionality, and compatibility features remain fully operational and unchanged. There is no impact to user experience or current setup processes.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->