### PR TITLE
fix: DevContainerでpre-builtイメージを使用

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,9 +1,6 @@
 {
   "name": "Config Base Container",
-  "build": {
-    "dockerfile": "Dockerfile",
-    "context": ".."
-  },
+  "image": "ghcr.io/keito4/config-base:latest",
   "features": {
     "ghcr.io/devcontainers-extra/features/homebrew-package:1": {},
     "ghcr.io/eitsupi/devcontainer-features/jq-likes:2": {},


### PR DESCRIPTION
## 概要

DevContainerの設定をローカルビルドからpre-builtイメージの使用に変更し、古いキャッシュによるプラグイン設定の不整合を解消します。

## 問題

- DevContainerがローカルの `Dockerfile` からビルドしていたため、古いDockerレイヤーキャッシュが残存
- PR #177で15個→11個のプラグインに修正したが、ローカルビルドでは古い15個の設定が使用される状態が継続
- v1.6.4のイメージは正しく11個のプラグインでビルドされているが、DevContainerでは反映されていない

## 解決策

`.devcontainer/devcontainer.json` を修正：

```diff
- "build": {
-   "dockerfile": "Dockerfile",
-   "context": ".."
- },
+ "image": "ghcr.io/keito4/config-base:latest",
```

## 影響

- ✅ CI/CDでビルドされた最新イメージ（v1.6.4）を使用
- ✅ 11個の有効なプラグインのみがインストールされる
- ✅ ローカルビルドキャッシュの問題を回避
- ✅ 環境の一貫性が向上（全開発者が同じイメージを使用）
- ✅ DevContainer起動が高速化（プルのみ、ビルド不要）

## テスト計画

- [ ] DevContainerを再起動
- [ ] `/plugin` コマンドで11個のプラグインのみが表示されることを確認
- [ ] エラーメッセージが表示されないことを確認

## 関連

- PR #177: 無効なマーケットプレイスとプラグインを削除
- Docker Image: ghcr.io/keito4/config-base:1.6.4

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Sonnet 4.5 <noreply@anthropic.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated development container configuration to use a prebuilt image.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->