### PR TITLE
fix: DevContainerプラグインインストールのパス計算を修正

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -43,6 +43,6 @@
       }
     }
   },
-  "postCreateCommand": "sudo chown -R vscode:vscode /workspaces/config && npm ci && npm run prepare && cp -r /tmp/.husky /workspaces/config/ && cp /tmp/commitlint.config.js /workspaces/config/ && /tmp/setup-claude.sh || true",
+  "postCreateCommand": "sudo chown -R vscode:vscode /workspaces/config && npm ci && npm run prepare && cp -r /tmp/.husky /workspaces/config/ && cp /tmp/commitlint.config.js /workspaces/config/ && /tmp/setup-claude.sh",
   "runArgs": ["--env-file=${localEnv:HOME}/.devcontainer.env"]
 }

--- a/script/setup-claude.sh
+++ b/script/setup-claude.sh
@@ -16,10 +16,8 @@ log_info() { echo -e "${BLUE}[INFO]${NC} $1"; }
 log_success() { echo -e "${GREEN}[SUCCESS]${NC} $1"; }
 log_warn() { echo -e "${YELLOW}[WARN]${NC} $1"; }
 
-# スクリプトのディレクトリを取得
-SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-REPO_ROOT="$(dirname "$SCRIPT_DIR")"
-PLUGINS_FILE="${REPO_ROOT}/.claude/plugins/plugins.txt"
+# DevContainer内の固定パスを使用
+PLUGINS_FILE="/home/vscode/.claude/plugins/plugins.txt"
 
 log_info "Claude Code プラグインセットアップを開始します..."
 


### PR DESCRIPTION
## 問題

DevContainerを再ビルドしてもClaudeプラグインが表示されない問題がありました。

### 根本原因
- `setup-claude.sh`が`/tmp/setup-claude.sh`から実行されるため、REPO_ROOT計算が失敗
- `SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"` → `/tmp`
- `REPO_ROOT="$(dirname "$SCRIPT_DIR")"` → `/`
- `PLUGINS_FILE="${REPO_ROOT}/.claude/plugins/plugins.txt"` → `/.claude/plugins/plugins.txt`（存在しない）

### その他の問題
- `|| true`でエラーが隠蔽され、問題が表面化しない

## 変更内容

### 1. script/setup-claude.sh
**変更前**:
```bash
SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
REPO_ROOT="$(dirname "$SCRIPT_DIR")"
PLUGINS_FILE="${REPO_ROOT}/.claude/plugins/plugins.txt"
```

**変更後**:
```bash
# DevContainer内の固定パスを使用
PLUGINS_FILE="/home/vscode/.claude/plugins/plugins.txt"
```

### 2. .devcontainer/devcontainer.json
**変更前**:
```json
"postCreateCommand": "... && /tmp/setup-claude.sh || true",
```

**変更後**:
```json
"postCreateCommand": "... && /tmp/setup-claude.sh",
```

## 期待される動作

- ✅ DevContainer起動時にプラグインが正しくインストールされる
- ✅ エラー発生時にログで確認できる

## Test plan

- [ ] CI/CDでイメージビルドが成功することを確認
- [ ] 新バージョン（v1.8.1）がリリースされることを確認
- [ ] pulse_surveyで新イメージを使用してプラグインが表示されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved error reporting in development environment setup by preventing silent failures.
  * Fixed plugin file path resolution in the setup script.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->