### PR TITLE
fix: setup-claude.shを/usr/local/binに配置してfeatures適用後も保持

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -77,7 +77,8 @@ COPY --chown=vscode:vscode .claude/agents /home/vscode/.claude/agents
 COPY --chown=vscode:vscode .claude/hooks /home/vscode/.claude/hooks
 COPY --chown=vscode:vscode .claude/plugins/plugins.txt /home/vscode/.claude/plugins/plugins.txt
 COPY --chown=vscode:vscode script/install-claude-plugins.sh /tmp/install-claude-plugins.sh
-COPY --chown=vscode:vscode script/setup-claude.sh /tmp/setup-claude.sh
+COPY --chown=root:root script/setup-claude.sh /usr/local/bin/setup-claude.sh
+RUN chmod +x /usr/local/bin/setup-claude.sh
 
 # Install Claude plugins using BuildKit secret
 # Build with: DOCKER_BUILDKIT=1 docker build --secret id=claude_credentials,src=$HOME/.claude/.credentials.json .

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -43,6 +43,6 @@
       }
     }
   },
-  "postCreateCommand": "sudo chown -R vscode:vscode /workspaces/config && npm ci && npm run prepare && cp -r /tmp/.husky /workspaces/config/ && cp /tmp/commitlint.config.js /workspaces/config/ && /tmp/setup-claude.sh",
+  "postCreateCommand": "sudo chown -R vscode:vscode /workspaces/config && npm ci && npm run prepare && cp -r /tmp/.husky /workspaces/config/ && cp /tmp/commitlint.config.js /workspaces/config/ && /usr/local/bin/setup-claude.sh",
   "runArgs": ["--env-file=${localEnv:HOME}/.devcontainer.env"]
 }


### PR DESCRIPTION
## 問題

DevContainerで`/tmp/setup-claude.sh`が存在しないため、プラグインがインストールされない問題がありました。

### 根本原因

1. **v1.8.1イメージには`/tmp/setup-claude.sh`が含まれている**（確認済み）
2. しかし、`devcontainer.json`で以下のfeaturesを指定：
   - `docker-in-docker`
   - `git`
   - `op` (1Password)
   - `github-cli`
   - `python`

3. **DevContainerがfeaturesを適用する際、新しいレイヤーを作成し、`/tmp`ディレクトリがクリアされる**

## 解決策

`/tmp`ではなく永続的なディレクトリ`/usr/local/bin`にスクリプトを配置します。

### 変更内容

#### 1. Dockerfile

**変更前**:
```dockerfile
COPY --chown=vscode:vscode script/setup-claude.sh /tmp/setup-claude.sh
```

**変更後**:
```dockerfile
COPY --chown=root:root script/setup-claude.sh /usr/local/bin/setup-claude.sh
RUN chmod +x /usr/local/bin/setup-claude.sh
```

#### 2. devcontainer.json

**変更前**:
```json
"postCreateCommand": "... && /tmp/setup-claude.sh",
```

**変更後**:
```json
"postCreateCommand": "... && /usr/local/bin/setup-claude.sh",
```

## 期待される動作

- ✅ `/usr/local/bin/setup-claude.sh`がfeatures適用後も保持される
- ✅ DevContainer起動時にプラグインが正しくインストールされる
- ✅ `/plugin`コマンドで9個のプラグインが表示される

## Test plan

- [ ] CI/CDでイメージビルドが成功することを確認
- [ ] 新バージョン（v1.8.2）がリリースされることを確認
- [ ] pulse_surveyで新イメージを使用してプラグインが表示されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated development environment initialization to ensure proper setup script execution and consistency across development container instances.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->