### PR TITLE
feat: Sync Claude settings from Elu-co-jp projects

### DIFF
--- a/.devcontainer/claude-settings.json
+++ b/.devcontainer/claude-settings.json
@@ -16,6 +16,7 @@
       "WebFetch(domain:raw.githubusercontent.com)",
       "WebFetch(domain:artifacthub.io)",
       "WebFetch(domain:developers.notion.com)",
+      "WebFetch(domain:www.assemblyai.com)",
       "mcp__ide__getDiagnostics",
       "Bash(ls:*)",
       "Bash(cat:*)",
@@ -52,8 +53,10 @@
       "Bash(node:*)",
       "Bash(python3:*)",
       "Bash(deno:*)",
+      "Bash(deno --version)",
       "Bash(deno test:*)",
       "Bash(deno fmt:*)",
+      "Bash(deno lint)",
       "Bash(deno lint:*)",
       "Bash(deno check:*)",
       "Bash(deno run:*)",
@@ -252,7 +255,11 @@
       "Bash(supervisorctl stop:*)",
       "Bash(supervisord:*)",
       "Bash(act:*)",
-      "Bash(afplay:*)"
+      "Bash(afplay:*)",
+      "Bash(brew list:*)",
+      "Read(//tmp/**)",
+      "Read(//workspaces/**)",
+      "Skill(plugin-dev:command-development)"
     ],
     "deny": [
       "Bash(npx supabase db push)",


### PR DESCRIPTION
## Summary

Elu-co-jpの19リポジトリから収集した共通Claudeパーミッション設定を取り込みました。

### 収集結果
- **収集元**: 19リポジトリ
- **収集パターン**: 705 allow + 4 deny
- **ユニークパターン**: 403 allow + 4 deny
- **新規候補**: 173パターン
- **推奨追加**: 7パターン
- **除外**: 165パターン（セキュリティリスク・プロジェクト固有）

### 追加されたパターン

#### WebFetch ドメイン (1件)
- `WebFetch(domain:www.assemblyai.com)` - AI音声認識サービス

#### Bash コマンド (3件)
- `Bash(brew list:*)` - Homebrewパッケージ一覧確認
- `Bash(deno --version)` - Denoバージョン確認
- `Bash(deno lint)` - Denoリンター

#### Read パーミッション (2件)
- `Read(//tmp/**)` - 一時ファイルアクセス
- `Read(//workspaces/**)` - DevContainer標準ワークスペース

#### Skills (1件)
- `Skill(plugin-dev:command-development)` - プラグイン開発スキル

### 除外したパターン例

#### セキュリティリスク
- AWSクレデンシャルを含むexportコマンド
- プロジェクト固有のsecret/token

#### プロジェクト固有
- プロジェクト専用のSupabaseインスタンスURL
- プロジェクト固有のスクリプトパス
- プロジェクト固有のワークスペースパス
- プロジェクト固有のスキル

### 更新後の設定

- **Allow**: 258パターン (251→258, +7)
- **Deny**: 38パターン (変更なし)

## Test plan

- [x] Pre-commit checksが通ること（format, lint, test）
- [ ] DevContainerで新しいパーミッションが正しく動作すること
- [ ] 追加されたパターンが適切に機能すること

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated development environment configuration to enable additional tools and capabilities for developers, including web fetching from specified domains, command-line utilities, file access permissions, and plugin development features.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->