### PR TITLE
fix: devcontainer内のPython環境とhookifyプラグインのモジュールエラーを修正

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -17,6 +17,8 @@ RUN apt-get update && apt-get install -y \
     shellcheck \
     python3 \
     python3-pip \
+    python3-venv \
+    python3-dev \
  && apt-get clean \
  && rm -rf /var/lib/apt/lists/* \
  && NODE_VERSION=v22.14.0 \


### PR DESCRIPTION
## Summary
- devcontainer起動時にhookifyプラグインで`ModuleNotFoundError: No module named 'json'`エラーが発生する問題を修正
- Python環境を完全にインストールし、hookifyプラグインのshebangを正しく設定

## Changes
### `.devcontainer/Dockerfile`
- `python3-venv`を追加: 仮想環境サポート
- `python3-dev`を追加: 開発用ヘッダーファイルとツール
- Ubuntuの最小構成python3に標準ライブラリの完全なサポートを提供

### `script/setup-claude.sh`
- hookifyパッチを両方のマーケットプレイス（claude-code-plugins/claude-plugins-official）に対応
- hooks/ディレクトリ内の全Pythonスクリプトのshebangを`#!/usr/bin/env python3`に統一
- shebangがない場合は自動追加し、実行権限を付与

## Test Plan
- [ ] devcontainerを再ビルド
- [ ] hookifyプラグインのPre/PostToolUseフックエラーが解消されることを確認
- [ ] Python環境で`import json`が正常に動作することを確認
- [ ] CI/CDパイプラインがパスすることを確認

## Related Issues
Fixes https://github.com/keito4/ohana/issues/138

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Enhanced development environment configuration by adding essential Python development packages.
  * Improved setup script with expanded plugin source support, refined error handling, and enhanced logging for setup operations.
  * Optimized Python script execution configuration and initialized package structures for better initialization reliability.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->