### PR TITLE
chore: remove unused bell.sh script

### DIFF
--- a/.devcontainer/README.md
+++ b/.devcontainer/README.md
@@ -16,7 +16,6 @@ The DevContainer configuration includes:
 
 - `devcontainer.json`: Main DevContainer configuration
 - `Dockerfile`: Custom container image with development tools
-- `bell.sh`: Notification system for development workflow events
 - `claude-settings.json`: Claude Code configuration for AI-assisted development
 - `VERSIONING.md`: Semantic versioning guidelines for container releases
 

--- a/.devcontainer/bell.sh
+++ b/.devcontainer/bell.sh
@@ -1,3 +1,0 @@
-#!/bin/bash
-echo "タスクが完了しました"
-printf "\a"


### PR DESCRIPTION
## Summary

Remove unused bell.sh script and clean up references in documentation.

## Changes

- 🗑️ Remove `.devcontainer/bell.sh` (not referenced anywhere)
- 📝 Update `.devcontainer/README.md` to remove bell.sh reference
- 🧹 Clean up unused development workflow notification script

## Analysis

The `bell.sh` script was:
- Not referenced in any workflow, script, or configuration
- Only mentioned in `.devcontainer/README.md` documentation
- A simple notification script that was never actually used

## Impact

- No functional impact (script was unused)
- Reduces repository clutter
- Improves documentation accuracy

Fixes #219

🤖 Generated with [Claude Code](https://claude.com/claude-code)