### PR TITLE
fix: handle CI workflow skip by path filters

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -56,6 +56,16 @@ jobs:
             QUALITY_GATE=$(echo "$CHECK_RUNS" | jq -r 'select(.name == "Quality Gate")')
 
             if [ -z "$QUALITY_GATE" ]; then
+              # Quality Gateが2分経っても出現しない場合、CIがpath filtersでスキップされた可能性を確認
+              if [ $ELAPSED_TIME -ge 120 ]; then
+                DETECT_CHANGES=$(echo "$CHECK_RUNS" | jq -r 'select(.name == "Detect Changes")')
+                if [ -z "$DETECT_CHANGES" ]; then
+                  echo "ci_passed=true" >> $GITHUB_OUTPUT
+                  echo "✅ CI workflow skipped by path filters (no code changes detected)"
+                  echo "Claude Code Review will proceed without waiting for CI."
+                  exit 0
+                fi
+              fi
               echo "⏳ Quality Gate check has not started yet, waiting..."
               sleep $POLL_INTERVAL
               ELAPSED_TIME=$((ELAPSED_TIME + POLL_INTERVAL))


### PR DESCRIPTION
## Summary

claude-code-review workflow now properly handles cases where CI is skipped by path filters, preventing unnecessary 15-minute timeouts for documentation-only PRs.

## Problem

PR #274 revealed a critical issue:

1. **Documentation-only changes**: `.claude/devcontainer-recommendations.md`
2. **CI workflow path filters**: Don't include `.md` files
3. **Result**: CI workflow not triggered, Quality Gate never appears
4. **check-ci-status behavior**: Waits 15 minutes for Quality Gate, then times out
5. **Impact**: claude-review never runs for doc-only PRs

## Solution

Added intelligent detection for path filter skips:

### Detection Logic

After 2 minutes (120s) of waiting:
1. Check if Quality Gate exists
2. Check if Detect Changes job exists
3. If both are missing → CI skipped by path filters
4. Set `ci_passed=true` to allow review to proceed

### Behavior Matrix

| PR Type | CI Triggered | Behavior |
|---------|-------------|----------|
| Code changes | ✅ Yes | Waits for CI, validates Quality Gate |
| Doc-only changes | ❌ No | Detects skip after 2min, proceeds with review |
| Mixed changes | ✅ Yes | Waits for CI, validates Quality Gate |

### Status Messages

**CI Running:**
```
⏳ Quality Gate is still running: in_progress, waiting...
⏱️  Elapsed time: 30s / 900s
✅ All CI checks passed
```

**CI Skipped by Path Filters:**
```
⏱️  Elapsed time: 120s / 900s
✅ CI workflow skipped by path filters (no code changes detected)
Claude Code Review will proceed without waiting for CI.
```

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] CI/CD changes

## Impact

### Before
- Doc-only PRs wait 15 minutes → timeout → no review
- Wastes GitHub Actions minutes
- Poor user experience

### After
- Doc-only PRs wait 2 minutes → proceed with review
- Code PRs still validate CI properly
- Optimal balance between safety and efficiency

## Testing

This PR will test the detection logic:
1. If CI runs → validates polling works
2. If CI skips → validates skip detection works

Expected for PR #274:
1. check-ci-status detects CI skip after 2 minutes
2. Sets ci_passed=true
3. claude-review runs successfully

## Related Issues

Fixes the timeout issue discovered in #274

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)