### PR TITLE
feat: add automatic PR creation from Issues

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -47,10 +47,19 @@ jobs:
             actions: read
             checks: read
 
-          # Optional: Give a custom prompt to Claude. If this is not specified, Claude will perform the instructions specified in the comment that tagged it.
-          # prompt: 'Update the pull request description to include a summary of changes.'
+          # Settings for allowed tools and permissions
+          settings: |
+            {
+              "permissions": {
+                "allowedTools": [
+                  "Bash(gh:*)",
+                  "Bash(npm:*)",
+                  "Bash(pnpm:*)",
+                  "Bash(npx:*)"
+                ]
+              }
+            }
 
-          # Optional: Add claude_args to customize behavior and configuration
-          # See https://github.com/anthropics/claude-code-action/blob/main/docs/usage.md
-          # or https://docs.claude.com/en/docs/claude-code/cli-reference for available options
-          # claude_args: '--allowed-tools Bash(gh pr:*)'
+          # System prompt to automatically create PRs when working on Issues
+          claude_args: |
+            --system-prompt "When working on GitHub Issues (not PRs), after completing all code changes and pushing to a branch, you MUST create a Pull Request by running 'gh pr create' command. Do not just provide a link - actually execute the gh pr create command to create the PR automatically."


### PR DESCRIPTION
## Summary

Issue #277で提案されたPR自動作成機能をclaude.ymlに追加しました。

## Changes

### 1. settings パラメータの追加

`settings.permissions.allowedTools` を追加し、以下のBashツールを許可：
- `Bash(gh:*)` - GitHub CLI操作
- `Bash(npm:*)` - npm操作
- `Bash(pnpm:*)` - pnpm操作  
- `Bash(npx:*)` - npx操作

### 2. system-prompt の追加

`claude_args` パラメータに system-prompt を追加し、Issue作業時の自動PR作成を指示：

> When working on GitHub Issues (not PRs), after completing all code changes and pushing to a branch, you MUST create a Pull Request by running 'gh pr create' command.

## Behavior

### Before
- Issueに対する@claudeコメントでコード変更まで完了
- ユーザーが手動でPR作成

### After
- Issueに対する@claudeコメントでコード変更まで完了
- **Claude が自動的に gh pr create を実行してPR作成**
- ユーザーはPRレビューのみ

## Example

keito4-org/n8n_custom_node では既にこの機能が実装されており、以下のように動作しています：
- Issue に @claude でコメント
- Claude がコード変更を実施
- Claude が自動的に PR を作成
- ユーザーは作成されたPRをレビュー・マージ

## Type of Change

- [x] New feature (non-breaking change which adds functionality)
- [x] CI/CD changes

Closes #277

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)