### PR TITLE
feat: Add coverage comment composite action

### DIFF
--- a/.github/actions/coverage-comment/README.md
+++ b/.github/actions/coverage-comment/README.md
@@ -1,0 +1,118 @@
+# Coverage Comment Action
+
+カバレッジレポートをPRコメントとして自動投稿するGitHub Composite Actionです。
+
+## 機能
+
+- Jest/Istanbul の `coverage-summary.json` からカバレッジ情報を読み取り
+- マークダウンテーブル形式で整形して表示
+- 既存のカバレッジコメントを更新（重複投稿を防止）
+- モノレポ環境で複数パッケージのカバレッジをサポート
+- カバレッジ率に応じた絵文字表示（80%以上: ✅、60-80%: ⚠️、60%未満: ❌）
+
+## 使用方法
+
+### 基本的な使い方
+
+`.github/workflows/ci.yml` の test job に以下のステップを追加します:
+
+```yaml
+- name: Run tests with coverage
+  run: npm run test:coverage
+
+- name: Post Coverage Comment
+  if: github.event_name == 'pull_request'
+  uses: ./.github/actions/coverage-comment
+  with:
+    github-token: ${{ secrets.GITHUB_TOKEN }}
+```
+
+### モノレポでの使用例
+
+複数のパッケージがある場合:
+
+```yaml
+- name: Post Coverage Comment
+  if: github.event_name == 'pull_request'
+  uses: ./.github/actions/coverage-comment
+  with:
+    github-token: ${{ secrets.GITHUB_TOKEN }}
+    coverage-path: 'packages/package1/coverage/coverage-summary.json,packages/package2/coverage/coverage-summary.json'
+```
+
+## 入力パラメータ
+
+| パラメータ | 必須 | デフォルト値 | 説明 |
+|-----------|------|-------------|------|
+| `github-token` | Yes | - | GitHub API アクセス用トークン（通常は `${{ secrets.GITHUB_TOKEN }}`） |
+| `coverage-path` | No | `coverage/coverage-summary.json` | カバレッジファイルのパス（カンマ区切りで複数指定可） |
+
+## カバレッジファイルの生成
+
+このアクションは Jest/Istanbul の `coverage-summary.json` ファイルを使用します。以下の設定が必要です:
+
+### package.json
+
+```json
+{
+  "scripts": {
+    "test:coverage": "jest --coverage"
+  }
+}
+```
+
+### jest.config.js
+
+```javascript
+module.exports = {
+  coverageReporters: ['json-summary', 'text', 'lcov'],
+  // その他の設定...
+};
+```
+
+## 出力例
+
+```markdown
+## Test Coverage Report
+
+| Category | Coverage | Covered | Total |
+|----------|----------|---------|-------|
+| ✅ Statements | 85.50% | 342 | 400 |
+| ⚠️ Branches | 75.20% | 188 | 250 |
+| ✅ Functions | 82.00% | 82 | 100 |
+| ✅ Lines | 86.30% | 345 | 400 |
+
+---
+*Updated: 2026-01-02T17:00:00.000Z*
+```
+
+## 統合手順
+
+1. このアクションは既に `.github/actions/coverage-comment/` に配置されています
+2. `.github/workflows/ci.yml` の `test` job に上記の使用例を参考にステップを追加してください
+3. カバレッジレポートが生成されるようテスト実行コマンドを確認してください
+
+## 注意事項
+
+- このアクションは `pull_request` イベントでのみ動作します
+- カバレッジファイルが存在しない場合はスキップされます
+- Bot ユーザーとして投稿されたコメントを自動的に検索・更新します
+- 複数のカバレッジファイルを指定する場合、パッケージ名が自動的に表示されます
+
+## トラブルシューティング
+
+### コメントが投稿されない
+
+- `github.event_name == 'pull_request'` の条件を確認
+- カバレッジファイルのパスが正しいか確認
+- ワークフローログでエラーメッセージを確認
+
+### カバレッジデータが表示されない
+
+- Jest の設定で `json-summary` レポーターが有効か確認
+- `coverage/coverage-summary.json` ファイルが生成されているか確認
+- ファイルの JSON 形式が正しいか確認
+
+## ライセンス
+
+このアクションは MIT ライセンスの下で提供されています。

--- a/.github/actions/coverage-comment/action.yml
+++ b/.github/actions/coverage-comment/action.yml
@@ -1,0 +1,111 @@
+name: 'Coverage Comment'
+description: 'Post test coverage summary as PR comment with update capability'
+author: 'keito4'
+
+inputs:
+  github-token:
+    description: 'GitHub token for API access'
+    required: true
+  coverage-path:
+    description: 'Path to coverage-summary.json file(s) (comma-separated for monorepo)'
+    required: false
+    default: 'coverage/coverage-summary.json'
+
+runs:
+  using: 'composite'
+  steps:
+    - name: Post Coverage Comment
+      uses: actions/github-script@v7
+      with:
+        github-token: ${{ inputs.github-token }}
+        script: |
+          const fs = require('fs');
+
+          // Parse coverage paths (support multiple files for monorepo)
+          const coveragePaths = '${{ inputs.coverage-path }}'.split(',').map(p => p.trim());
+
+          let comment = '## Test Coverage Report\n\n';
+          let hasData = false;
+
+          for (const coveragePath of coveragePaths) {
+            try {
+              if (!fs.existsSync(coveragePath)) {
+                console.log(`Coverage file not found: ${coveragePath}`);
+                continue;
+              }
+
+              const coverageData = JSON.parse(fs.readFileSync(coveragePath, 'utf8'));
+
+              // Extract package name from path if in monorepo
+              const pathParts = coveragePath.split('/');
+              const packageName = pathParts.length > 2 ? pathParts[pathParts.length - 2] : 'Default';
+
+              if (coveragePaths.length > 1) {
+                comment += `### Package: ${packageName}\n\n`;
+              }
+
+              // Get total coverage
+              const total = coverageData.total;
+
+              if (total) {
+                comment += '| Category | Coverage | Covered | Total |\n';
+                comment += '|----------|----------|---------|-------|\n';
+
+                const categories = ['statements', 'branches', 'functions', 'lines'];
+                for (const category of categories) {
+                  if (total[category]) {
+                    const pct = total[category].pct || 0;
+                    const covered = total[category].covered || 0;
+                    const totalCount = total[category].total || 0;
+                    const emoji = pct >= 80 ? '✅' : pct >= 60 ? '⚠️' : '❌';
+
+                    comment += `| ${emoji} ${category.charAt(0).toUpperCase() + category.slice(1)} | ${pct.toFixed(2)}% | ${covered} | ${totalCount} |\n`;
+                  }
+                }
+
+                comment += '\n';
+                hasData = true;
+              }
+            } catch (error) {
+              console.error(`Error processing ${coveragePath}:`, error.message);
+            }
+          }
+
+          if (!hasData) {
+            console.log('No coverage data found');
+            return;
+          }
+
+          comment += '\n---\n*Updated: ' + new Date().toISOString() + '*\n';
+
+          // Find existing coverage comment
+          const { data: comments } = await github.rest.issues.listComments({
+            owner: context.repo.owner,
+            repo: context.repo.repo,
+            issue_number: context.issue.number,
+          });
+
+          const botComment = comments.find(c =>
+            c.user.type === 'Bot' &&
+            c.body.includes('## Test Coverage Report')
+          );
+
+          if (botComment) {
+            // Update existing comment
+            await github.rest.issues.updateComment({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              comment_id: botComment.id,
+              body: comment
+            });
+            console.log('Updated existing coverage comment');
+          } else {
+            // Create new comment
+            await github.rest.issues.createComment({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.issue.number,
+              body: comment
+            });
+            console.log('Created new coverage comment');
+          }

--- a/.github/actions/coverage-comment/example-integration.yml
+++ b/.github/actions/coverage-comment/example-integration.yml
@@ -1,0 +1,49 @@
+# このファイルは参考例です - 実際の .github/workflows/ci.yml への統合方法を示します
+# このファイル自体はワークフローとして実行されません
+
+# 既存の test job に以下のステップを追加してください:
+
+test:
+  name: Unit Tests
+  runs-on: ubuntu-latest
+  timeout-minutes: 15
+  needs: changes
+  if: needs.changes.outputs.code == 'true' || needs.changes.outputs.dependencies == 'true'
+  steps:
+    - uses: actions/checkout@v4
+
+    - uses: actions/setup-node@v6
+      with:
+        node-version: '22'
+        cache: 'npm'
+
+    - name: Install dependencies
+      run: npm ci
+
+    - name: Run tests with coverage
+      run: npm run test:coverage -- --ci --reporters=default --reporters=jest-junit
+      env:
+        JEST_JUNIT_OUTPUT_DIR: ./reports
+        JEST_JUNIT_OUTPUT_NAME: junit.xml
+
+    # ===== ここから追加 =====
+
+    - name: Post Coverage Comment
+      if: github.event_name == 'pull_request'
+      uses: ./.github/actions/coverage-comment
+      with:
+        github-token: ${{ secrets.GITHUB_TOKEN }}
+        # モノレポの場合は以下のように複数パスを指定:
+        # coverage-path: 'packages/pkg1/coverage/coverage-summary.json,packages/pkg2/coverage/coverage-summary.json'
+
+    # ===== ここまで追加 =====
+
+    - name: Upload test results
+      uses: actions/upload-artifact@v6
+      if: always()
+      with:
+        name: test-results
+        path: ./reports/junit.xml
+        retention-days: 30
+
+    # ... 以降は既存の設定


### PR DESCRIPTION
## Summary

PRコメントとしてテストカバレッジレポートを自動投稿するGitHub Composite Actionを追加しました。

## Changes

- `.github/actions/coverage-comment/action.yml`: カバレッジコメント機能の実装
- `.github/actions/coverage-comment/README.md`: 使用方法とドキュメント
- `.github/actions/coverage-comment/example-integration.yml`: CI統合の参考例

## Features

- ✅ Jest/Istanbulの`coverage-summary.json`からカバレッジ情報を読み取り
- ✅ マークダウンテーブル形式で整形表示
- ✅ 既存のカバレッジコメントを更新（重複投稿を防止）
- ✅ モノレポ対応（複数パッケージのカバレッジをサポート）
- ✅ カバレッジ率に応じた絵文字表示（80%以上: ✅、60-80%: ⚠️、60%未満: ❌）

## Integration

既存の`.github/workflows/ci.yml`のtest jobに以下を追加することで使用できます:

```yaml
- name: Post Coverage Comment
  if: github.event_name == 'pull_request'
  uses: ./.github/actions/coverage-comment
  with:
    github-token: ${{ secrets.GITHUB_TOKEN }}
```

詳細な統合方法は`example-integration.yml`を参照してください。

## Important Note

GitHub Appの権限制約により、ワークフローファイル（`.github/workflows/ci.yml`）への直接的な変更は含まれていません。上記の統合ステップを手動で追加する必要があります。

Closes #283

🤖 Generated with [Claude Code](https://claude.ai/code)) | [View job run](https://github.com/keito4/config/actions/runs/20662576355) | [Branch](https://github.com/keito4/config/tree/claude/issue-283-20260102-1701

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a GitHub Actions composite action that automatically posts and updates coverage summary comments on pull requests, with support for multi-package repositories and emoji-based coverage indicators.

* **Documentation**
  * Added comprehensive documentation and integration examples for the coverage comment action.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->