### PR TITLE
feat: Add PR Size Check to CI workflow

### DIFF
--- a/.github/actions/coverage-comment/README.md
+++ b/.github/actions/coverage-comment/README.md
@@ -42,10 +42,10 @@
 
 ## 入力パラメータ
 
-| パラメータ | 必須 | デフォルト値 | 説明 |
-|-----------|------|-------------|------|
-| `github-token` | Yes | - | GitHub API アクセス用トークン（通常は `${{ secrets.GITHUB_TOKEN }}`） |
-| `coverage-path` | No | `coverage/coverage-summary.json` | カバレッジファイルのパス（カンマ区切りで複数指定可） |
+| パラメータ      | 必須 | デフォルト値                     | 説明                                                                  |
+| --------------- | ---- | -------------------------------- | --------------------------------------------------------------------- |
+| `github-token`  | Yes  | -                                | GitHub API アクセス用トークン（通常は `${{ secrets.GITHUB_TOKEN }}`） |
+| `coverage-path` | No   | `coverage/coverage-summary.json` | カバレッジファイルのパス（カンマ区切りで複数指定可）                  |
 
 ## カバレッジファイルの生成
 
@@ -75,15 +75,16 @@ module.exports = {
 ```markdown
 ## Test Coverage Report
 
-| Category | Coverage | Covered | Total |
-|----------|----------|---------|-------|
-| ✅ Statements | 85.50% | 342 | 400 |
-| ⚠️ Branches | 75.20% | 188 | 250 |
-| ✅ Functions | 82.00% | 82 | 100 |
-| ✅ Lines | 86.30% | 345 | 400 |
+| Category      | Coverage | Covered | Total |
+| ------------- | -------- | ------- | ----- |
+| ✅ Statements | 85.50%   | 342     | 400   |
+| ⚠️ Branches   | 75.20%   | 188     | 250   |
+| ✅ Functions  | 82.00%   | 82      | 100   |
+| ✅ Lines      | 86.30%   | 345     | 400   |
 
 ---
-*Updated: 2026-01-02T17:00:00.000Z*
+
+_Updated: 2026-01-02T17:00:00.000Z_
 ```
 
 ## 統合手順

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -197,6 +197,87 @@ jobs:
           reporter: github-pr-review
           fail_on_error: true
 
+  pr-size-check:
+    name: PR Size Check
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    if: github.event_name == 'pull_request'
+    steps:
+      - name: Check PR Size
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const { additions, deletions, changed_files } = context.payload.pull_request;
+            const totalChanges = additions + deletions;
+
+            // Define size thresholds
+            const sizes = [
+              { label: 'size/XS', maxLines: 50, maxFiles: 3 },
+              { label: 'size/S', maxLines: 200, maxFiles: 10 },
+              { label: 'size/M', maxLines: 500, maxFiles: 15 },
+              { label: 'size/L', maxLines: 1000, maxFiles: 30 },
+            ];
+
+            // Determine size
+            let sizeLabel = 'size/XL';
+            for (const size of sizes) {
+              if (totalChanges <= size.maxLines && changed_files <= size.maxFiles) {
+                sizeLabel = size.label;
+                break;
+              }
+            }
+
+            // Remove old size labels
+            const currentLabels = context.payload.pull_request.labels.map(l => l.name);
+            for (const label of currentLabels) {
+              if (label.startsWith('size/')) {
+                await github.rest.issues.removeLabel({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  issue_number: context.issue.number,
+                  name: label
+                }).catch(() => {});
+              }
+            }
+
+            // Add new size label
+            await github.rest.issues.addLabels({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.issue.number,
+              labels: [sizeLabel]
+            });
+
+            // Post warning for XL PRs
+            if (sizeLabel === 'size/XL') {
+              const body = `## ⚠️ Large PR Warning
+
+            This PR is quite large with **${totalChanges} lines** changed across **${changed_files} files**.
+
+            Large PRs are harder to review and more likely to introduce bugs. Please consider:
+            - Breaking this into smaller, focused PRs
+            - Separating refactoring from feature changes
+            - Creating a PR series with clear dependencies
+
+            **PR Size Guidelines:**
+            | Size | Lines | Files |
+            |------|-------|-------|
+            | XS | ≤50 | ≤3 |
+            | S | ≤200 | ≤10 |
+            | M | ≤500 | ≤15 |
+            | L | ≤1000 | ≤30 |
+            | XL | >1000 | >30 |`;
+
+              await github.rest.issues.createComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: context.issue.number,
+                body: body
+              });
+            }
+
+            console.log(`PR Size: ${sizeLabel} (${totalChanges} lines, ${changed_files} files)`);
+
   quality-gate:
     name: Quality Gate
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Summary

- PRサイズの自動ラベリングと警告システムを追加
- PRに対して`size/XS`、`size/S`、`size/M`、`size/L`、`size/XL`のラベルを自動付与
- XLサイズのPRには、より小さなPRへの分割を促す警告コメントを投稿

## Size Thresholds

| Size | Lines | Files |
|------|-------|-------|
| XS | ≤50 | ≤3 |
| S | ≤200 | ≤10 |
| M | ≤500 | ≤15 |
| L | ≤1000 | ≤30 |
| XL | >1000 | >30 |

## Benefits

- コードレビューの品質向上（小さなPRの推奨）
- PRサイズの視覚的フィードバック
- プロジェクト全体で一貫したPRサイズ基準

Closes #282

🤖 Generated with [Claude Code](https://claude.com/claude-code)