### PR TITLE
fix: update DevContainer base image to 1.43.0

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,6 +1,6 @@
 {
   "name": "Config Base Container",
-  "image": "ghcr.io/keito4/config-base:1.41.0",
+  "image": "ghcr.io/keito4/config-base:1.43.0",
   "features": {
     "ghcr.io/devcontainers-extra/features/homebrew-package:1": {},
     "ghcr.io/eitsupi/devcontainer-features/jq-likes:2": {},


### PR DESCRIPTION
## Summary
- Fix DevContainer startup failure by updating base image from non-existent 1.41.0 to latest 1.43.0

## Problem
DevContainer failed to start with the following error:
```
Error response from daemon: No such image: ghcr.io/keito4/config-base:1.41.0
```

## Root Cause
The `ghcr.io/keito4/config-base:1.41.0` image tag does not exist in GitHub Container Registry.

## Investigation
Checked available image tags in GHCR:
- ✅ 1.40.0
- ✅ 1.40.1
- ❌ 1.41.0 (missing)
- ✅ 1.42.0
- ✅ 1.43.0 (latest)

## Solution
Updated `.devcontainer/devcontainer.json` to use `ghcr.io/keito4/config-base:1.43.0`

## Changes
- Update DevContainer base image from `1.41.0` to `1.43.0`

## Test Plan
- [x] Format check passed (Prettier)
- [x] Lint check passed (ESLint)
- [x] Unit tests passed (Jest)
- [x] Commit message validation passed (commitlint)
- [ ] Verify DevContainer starts successfully with 1.43.0 image
- [ ] Verify all development tools work correctly in new container
- [ ] Run `/devcontainer-checklist` after container restart

## Impact
This is a critical fix that blocks DevContainer usage. Without this fix, developers cannot start the DevContainer environment.

## Related
- Discovered during DevContainer checklist creation
- Related to PR #306 (LSP configuration)

🤖 Generated with [Claude Code](https://claude.com/claude-code)