### PR TITLE
fix(devcontainer): プラグインインストール時にHOME環境変数を設定

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -90,9 +90,9 @@ RUN chmod +x /usr/local/bin/setup-claude.sh /tmp/setup-claude-build.sh
 
 # Install Claude plugins using BuildKit secret
 # Build with: DOCKER_BUILDKIT=1 docker build --secret id=claude_credentials,src=$HOME/.claude/.credentials.json .
-# Note: Run as root to access BuildKit secret, then change ownership to vscode
+# Note: Run as root to access BuildKit secret, but use vscode's HOME for plugin installation
 RUN --mount=type=secret,id=claude_credentials,uid=0,gid=0 \
-    /tmp/install-claude-plugins.sh /home/vscode/.claude/plugins/plugins.txt || ( \
+    env HOME=/home/vscode /tmp/install-claude-plugins.sh /home/vscode/.claude/plugins/plugins.txt || ( \
         echo "[WARN] Claude プラグインのインストールに失敗しました（認証情報が不足している可能性があります）" && \
         echo "[INFO] コンテナ起動後に手動でインストールしてください: claude plugin install <plugin>@<marketplace>" \
     ) \
@@ -100,7 +100,7 @@ RUN --mount=type=secret,id=claude_credentials,uid=0,gid=0 \
 
 # ビルド時にClaude設定を完全にセットアップ
 USER vscode
-RUN bash /tmp/setup-claude-build.sh || echo "[WARN] ビルド時セットアップに失敗しました"
+RUN env HOME=/home/vscode bash /tmp/setup-claude-build.sh || echo "[WARN] ビルド時セットアップに失敗しました"
 USER root
 
 RUN chsh -s /bin/bash vscode


### PR DESCRIPTION
## Summary

v1.45.0のビルドで`setup-claude-build.sh`が「プラグインがインストールされていません」と表示する問題を修正します。

## Problem

プラグインインストールがROOTユーザーで実行されるため、`claude`コマンドはデフォルトで`/root/.claude`にプラグインをインストールしています。その後、`setup-claude-build.sh`がUSER vscodeで実行され、`/home/vscode/.claude/plugins/marketplaces`を探しますが、プラグインは`/root/.claude`にあるため見つかりません。

## Changes

- プラグインインストール時に`HOME=/home/vscode`を設定
- setup-claude-build.sh実行時にも`HOME=/home/vscode`を明示的に設定

## Implementation

\`\`\`dockerfile
# Before
RUN --mount=type=secret,id=claude_credentials,uid=0,gid=0 \
    /tmp/install-claude-plugins.sh ...

# After
RUN --mount=type=secret,id=claude_credentials,uid=0,gid=0 \
    env HOME=/home/vscode /tmp/install-claude-plugins.sh ...
\`\`\`

## Expected Result

- setup-claude-build.shが正常に実行される
- hookifyパッチが適用される
- known_marketplaces.jsonが生成される

## Test plan

- [x] Dockerfileの構文が正しいことを確認
- [x] すべてのテストが通過することを確認
- [ ] 新しいイメージのビルドが成功することを確認（CI後）
- [ ] setup-claude-build.shが正常に実行されることを確認（ビルドログ）

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved development container configuration for more reliable environment setup during initialization.
  * Enhanced plugin installation and build script execution with proper environment variable handling.
  * Optimized npm bootstrapping process during container setup.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->