### PR TITLE
docs: Update config-base image version references to 1.48.0

### DIFF
--- a/.claude/commands/devcontainer-checklist.md
+++ b/.claude/commands/devcontainer-checklist.md
@@ -350,4 +350,4 @@ npm run format:check && npm run lint && npm test
 ---
 
 **最終更新**: 2026-01-04
-**対象バージョン**: Claude Code 2.0.76+, DevContainer config-base 1.43.0+
+**対象バージョン**: Claude Code 2.0.76+, DevContainer config-base 1.48.0+

--- a/.claude/devcontainer-recommendations.md
+++ b/.claude/devcontainer-recommendations.md
@@ -10,12 +10,12 @@ Elu-co-jp配下の全リポジトリで統一されたDevContainer環境を提�
 
 ```json
 {
-  "image": "ghcr.io/keito4/config-base:1.43.0"
+  "image": "ghcr.io/keito4/config-base:1.48.0"
 }
 ```
 
-**最新バージョン**: 1.43.0
-**推奨バージョン**: 1.43.0+（安定版として広く採用）
+**最新バージョン**: 1.48.0
+**推奨バージョン**: 1.48.0+（安定版として広く採用）
 
 ## Claude Code動作のための必須設定
 
@@ -25,12 +25,12 @@ Claude Code（AI開発アシスタント）を動作させるための最小限�
 
 ```json
 {
-  "image": "ghcr.io/keito4/config-base:1.43.0"
+  "image": "ghcr.io/keito4/config-base:1.48.0"
 }
 ```
 
 - config-baseイメージには`@anthropic-ai/claude-code` CLIが既にインストール済み
-- バージョン1.43.0以降を推奨
+- バージョン1.48.0以降を推奨
 
 ### 2. 必須mounts
 
@@ -155,7 +155,7 @@ OPENAI_API_KEY=***  # o3 MCP用
 ```json
 {
   "name": "Project Name",
-  "image": "ghcr.io/keito4/config-base:1.43.0",
+  "image": "ghcr.io/keito4/config-base:1.48.0",
   "mounts": [
     "source=${localEnv:HOME}/.codex,target=/home/vscode/.codex,type=bind,consistency=cached",
     "source=${localEnv:HOME}/.claude,target=/home/vscode/.claude,type=bind,consistency=cached",
@@ -696,7 +696,7 @@ NODE_ENV=development
 
 ### 1. バージョン管理
 
-- **ベースイメージ**: セマンティックバージョニング（例: `1.43.0`）を明示
+- **ベースイメージ**: セマンティックバージョニング（例: `1.48.0`）を明示
 - **Features**: `latest`使用は最小限に、安定性重視の場合はバージョン固定
 - **更新頻度**: 四半期ごとにベースイメージ見直し
 
@@ -737,7 +737,7 @@ NODE_ENV=development
 
    ```json
    - "image": "ghcr.io/keito4/config-base:1.0.40"
-   + "image": "ghcr.io/keito4/config-base:1.43.0"
+   + "image": "ghcr.io/keito4/config-base:1.48.0"
    ```
 
 2. **非推奨Feature削除**

--- a/.devcontainer/README.md
+++ b/.devcontainer/README.md
@@ -76,7 +76,7 @@ This DevContainer image is automatically built and versioned using semantic-rele
 - **Minor versions**: New features and enhancements (1.0.0 → 1.1.0)
 - **Major versions**: Breaking changes (1.0.0 → 2.0.0)
 
-**Latest Version**: `v1.45.3`
+**Latest Version**: `v1.48.0`
 
 Images are published to GitHub Container Registry: `ghcr.io/keito4/config-base`
 
@@ -101,7 +101,7 @@ Use the pre-built image without mounting host's `~/.claude` directory:
 ```json
 {
   "name": "My Project",
-  "image": "ghcr.io/keito4/config-base:1.45.3",
+  "image": "ghcr.io/keito4/config-base:1.48.0",
   "remoteEnv": {
     "TMPDIR": "/home/vscode/.claude/tmp"
   }
@@ -123,7 +123,7 @@ Mount host's `~/.claude` to persist custom plugin installations:
 ```json
 {
   "name": "My Project",
-  "image": "ghcr.io/keito4/config-base:1.45.3",
+  "image": "ghcr.io/keito4/config-base:1.48.0",
   "remoteEnv": {
     "TMPDIR": "/home/vscode/.claude/tmp"
   },

--- a/.devcontainer/VERSIONING.md
+++ b/.devcontainer/VERSIONING.md
@@ -73,7 +73,7 @@ The workflow is triggered by:
 
 Each release creates two tags:
 
-- `ghcr.io/keito4/config-base:{version}` (e.g., `1.43.0`)
+- `ghcr.io/keito4/config-base:{version}` (e.g., `1.48.0`)
 - `ghcr.io/keito4/config-base:latest`
 
 ### Usage Example
@@ -82,7 +82,7 @@ Each release creates two tags:
 
 ```json
 {
-  "image": "ghcr.io/keito4/config-base:1.43.0"
+  "image": "ghcr.io/keito4/config-base:1.48.0"
 }
 ```
 

--- a/README.md
+++ b/README.md
@@ -640,9 +640,9 @@ The repository includes a complete DevContainer setup (`.devcontainer/`) that pr
 - Integrated Claude Code configuration with specialized agents and commands
 - Bell notification system for development workflow events
 
-**Latest Version**: `ghcr.io/keito4/config-base:1.45.3`
+**Latest Version**: `ghcr.io/keito4/config-base:1.48.0`
 
-**Pre-installed Plugins** (v1.45.3):
+**Pre-installed Plugins** (v1.48.0):
 
 - Official plugins: `commit-commands`, `hookify`, `plugin-dev`, `typescript-lsp`, `code-review`
 - Workflow plugins: `code-refactoring`, `kubernetes-operations`, `javascript-typescript`, `backend-development`, `full-stack-orchestration`, `database-design`, `database-migrations`

--- a/docs/using-config-base-image.md
+++ b/docs/using-config-base-image.md
@@ -19,7 +19,7 @@
 // .devcontainer/devcontainer.json
 {
   "name": "My Project",
-  "image": "ghcr.io/keito4/config-base:1.45.3",
+  "image": "ghcr.io/keito4/config-base:1.48.0",
   "remoteEnv": {
     "TMPDIR": "/home/vscode/.claude/tmp"
   }
@@ -82,7 +82,7 @@ claude --help
 // .devcontainer/devcontainer.json
 {
   "name": "My Project",
-  "image": "ghcr.io/keito4/config-base:1.45.3",
+  "image": "ghcr.io/keito4/config-base:1.48.0",
   "remoteEnv": {
     "TMPDIR": "/home/vscode/.claude/tmp"
   },
@@ -133,7 +133,7 @@ my-plugin@marketplace
 ```json
 {
   "name": "My Project",
-  "image": "ghcr.io/keito4/config-base:1.45.3",
+  "image": "ghcr.io/keito4/config-base:1.48.0",
   "remoteEnv": {
     "TMPDIR": "/home/vscode/.claude/tmp"
   },


### PR DESCRIPTION
## Summary
- ドキュメント内の古いconfig-baseイメージバージョン参照を最新の1.48.0に更新

## Changes
- README.md: Latest Versionとプラグインバージョンを1.45.3→1.48.0に更新
- .devcontainer/README.md: Latest Versionと各オプション例を1.45.3→1.48.0に更新
- docs/using-config-base-image.md: 全てのバージョン参照を1.45.3→1.48.0に更新
- .devcontainer/VERSIONING.md: 例示バージョンを1.43.0→1.48.0に更新
- .claude/devcontainer-recommendations.md: 推奨バージョンと各種例を1.43.0→1.48.0に更新
- .claude/commands/devcontainer-checklist.md: 対象バージョンを1.43.0→1.48.0に更新

## Context
PR #347 (2026-01-16) でconfig-baseイメージが1.48.0に更新されましたが、ドキュメント内に古いバージョン番号が残っていたため、これらを最新バージョンに統一しました。

## Test Plan
- [ ] ドキュメントの記述が正確であることを確認
- [ ] バージョン番号の一貫性を確認
- [ ] リンク切れがないことを確認

Closes #348

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Synchronizes documentation with the latest DevContainer base image.
> 
> - Updates `ghcr.io/keito4/config-base` version references to `1.48.0` in `README.md`, `.devcontainer/README.md`, `.devcontainer/VERSIONING.md`, `.claude/devcontainer-recommendations.md`, `docs/using-config-base-image.md`
> - Adjusts “Latest/Recommended” version notes and JSON snippets (devcontainer examples, migration guide)
> - Updates checklist “対象バージョン” to `DevContainer config-base 1.48.0+`
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 06eb174885790647917bf6861d0d9f57cc9eaae4. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated all DevContainer base image version references to the latest release across configuration documentation, setup guides, and code examples.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->