### PR TITLE
refactor: 未使用の platform::is_windows() 関数を削除

### DIFF
--- a/script/lib/platform.sh
+++ b/script/lib/platform.sh
@@ -37,10 +37,6 @@ platform::is_darwin() {
     [[ "$PLATFORM_OS" = "darwin" ]]
 }
 
-platform::is_windows() {
-    [[ "$PLATFORM_OS" = "windows" ]]
-}
-
 platform::is_devcontainer() {
     [[ -f /.dockerenv || -n "${REMOTE_CONTAINERS:-}" || -n "${CODESPACES:-}" ]]
 }


### PR DESCRIPTION
## 概要

未使用の `platform::is_windows()` 関数を `script/lib/platform.sh` から削除しました。

## 変更内容

- コードベース全体で一度も呼び出されていない関数を削除
- `platform::detect_os()` にWindows検出機能は含まれているが、実際の使用箇所なし
- コードの可読性と保守性向上

## テスト結果

✅ すべての Quality Gates に合格:
- Format Check: ✅
- Lint: ✅
- Tests: ✅ (101/101 passed)

Closes #345

🤖 Generated with [Claude Code](https://claude.ai/code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Streamlines platform helpers by deleting an unused Windows check.
> 
> - Removes `platform::is_windows()` from `script/lib/platform.sh`; no other logic paths changed (`platform::detect_os`, `is_linux`, `is_darwin`, and task runner remain as-is).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit f9840a20a6ebde7fef3b731f2301c8784841bd0a. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Internal development tool cleanup and optimization

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->