### PR TITLE
Feat/update claude code 2.1.15

### DIFF
--- a/npm/global.json
+++ b/npm/global.json
@@ -6,11 +6,11 @@
       "overridden": false
     },
     "@commitlint/cli": {
-      "version": "20.3.0",
+      "version": "20.3.1",
       "overridden": false
     },
     "@commitlint/config-conventional": {
-      "version": "20.3.0",
+      "version": "20.3.1",
       "overridden": false
     },
     "@leonardsellem/n8n-mcp-server": {
@@ -18,7 +18,7 @@
       "overridden": false
     },
     "@openai/codex": {
-      "version": "0.79.0",
+      "version": "0.88.0",
       "overridden": false
     },
     "bash-language-server": {
@@ -54,11 +54,11 @@
       "overridden": false
     },
     "n8n": {
-      "version": "2.2.4",
+      "version": "2.4.4",
       "overridden": false
     },
     "npm": {
-      "version": "11.7.0",
+      "version": "11.8.0",
       "overridden": false
     },
     "pm2": {
@@ -66,7 +66,7 @@
       "overridden": false
     },
     "vercel": {
-      "version": "50.3.0",
+      "version": "50.4.9",
       "overridden": false
     }
   }

--- a/package-lock.json
+++ b/package-lock.json
@@ -22,7 +22,7 @@
         "husky": "9.1.7",
         "jest": "30.2.0",
         "jest-junit": "^16.0.0",
-        "prettier": "3.8.0",
+        "prettier": "3.8.1",
         "semantic-release": "25.0.2"
       }
     },
@@ -96,6 +96,7 @@
       "integrity": "sha512-e7jT4DxYvIDLk1ZHmU/m/mB19rex9sv0c2ftBtjSBv+kVM/902eh0fINUzD7UwLLNR+jU585GxUJ8/EBfAM5fw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.27.1",
         "@babel/generator": "^7.28.5",
@@ -1943,6 +1944,7 @@
       "integrity": "sha512-DhGl4xMVFGVIyMwswXeyzdL4uXD5OGILGX5N8Y+f6W7LhC1Ze2poSNrkF/fedpVDHEEZ+PHFW0vL14I+mm8K3Q==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@octokit/auth-token": "^6.0.0",
         "@octokit/graphql": "^9.0.3",
@@ -2745,6 +2747,7 @@
       "integrity": "sha512-GNWcUTRBgIRJD5zj+Tq0fKOJ5XZajIiBroOF0yvj2bSU1WvNdYS/dn9UxwsujGW4JX06dnHyjV2y9rRaybH0iQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "undici-types": "~7.16.0"
       }
@@ -3062,6 +3065,7 @@
       "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -3431,6 +3435,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.8.25",
         "caniuse-lite": "^1.0.30001754",
@@ -4067,6 +4072,7 @@
       "integrity": "sha512-itvL5h8RETACmOTFc4UfIyB2RfEHi71Ax6E/PivVxq9NseKbOWpeyHEOIbmAw1rs8Ak0VursQNww7lf7YtUwzg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "env-paths": "^2.2.1",
         "import-fresh": "^3.3.0",
@@ -4507,6 +4513,7 @@
       "integrity": "sha512-LEyamqS7W5HB3ujJyvi0HQK/dtVINZvd5mAAp9eT5S/ujByGjiZLCzPcHVzuXbpJDJF/cxwHlfceVUDZ2lnSTw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.1",
@@ -7560,6 +7567,7 @@
       "integrity": "sha512-8dD6FusOQSrpv9Z1rdNMdlSgQOIP880DHqnohobOmYLElGEqAL/JvxvuxZO16r4HtjTlfPRDC1hbvxC9dPN2nA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "marked": "bin/marked.js"
       },
@@ -9887,6 +9895,7 @@
       "dev": true,
       "inBundle": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -10607,9 +10616,9 @@
       }
     },
     "node_modules/prettier": {
-      "version": "3.8.0",
-      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.8.0.tgz",
-      "integrity": "sha512-yEPsovQfpxYfgWNhCfECjG5AQaO+K3dp6XERmOepyPDVqcJm+bjyCVO3pmU+nAPe0N5dDvekfGezt/EIiRe1TA==",
+      "version": "3.8.1",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.8.1.tgz",
+      "integrity": "sha512-UOnG6LftzbdaHZcKoPFtOcCKztrQ57WkHDeRD9t/PTQtmT0NHSeWWepj6pS0z/N7+08BHFDQVUrfmfMRcZwbMg==",
       "dev": true,
       "license": "MIT",
       "bin": {
@@ -10883,6 +10892,7 @@
       "integrity": "sha512-6qGjWccl5yoyugHt3jTgztJ9Y0JVzyH8/Voc/D8PlLat9pwxQYXz7W1Dpnq5h0/G5GCYGUaDSlYcyk3AMh5A6g==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@semantic-release/commit-analyzer": "^13.0.1",
         "@semantic-release/error": "^4.0.0",
@@ -12045,6 +12055,7 @@
       "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=12"
       },

--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "husky": "9.1.7",
     "jest": "30.2.0",
     "jest-junit": "^16.0.0",
-    "prettier": "3.8.0",
+    "prettier": "3.8.1",
     "semantic-release": "25.0.2"
   }
 }


### PR DESCRIPTION
## Summary

<!-- Brief description of the changes (1-3 sentences) -->

## Type of Change

<!-- Check all that apply -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] CI/CD changes
- [ ] Dependencies update

## Related Issues

<!-- Link to related issues: Fixes #123, Closes #456 -->

## Changes Made

<!-- Detailed list of changes -->

-
-
-

## Testing

<!-- Describe the tests you ran -->

- [ ] Unit tests pass (`npm test`)
- [ ] Integration tests pass (`npm run test:integration`)
- [ ] Linting passes (`npm run lint`)
- [ ] Format check passes (`npm run format:check`)

## Checklist

<!-- Ensure all items are checked before requesting review -->

- [ ] My code follows the project's style guidelines
- [ ] I have performed a self-review of my code
- [ ] I have commented my code where necessary
- [ ] I have updated the documentation accordingly
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix/feature works
- [ ] All existing tests still pass
- [ ] This PR has a clear, descriptive title

## Screenshots (if applicable)

<!-- Add screenshots to help explain your changes -->

## Additional Notes

<!-- Any additional information reviewers should know -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Dependencies update**
> 
> - Bumps key versions in `npm/global.json`: `@anthropic-ai/claude-code` → 2.1.15, `@openai/codex` → 0.88.0, `n8n` → 2.4.4, `npm` → 11.8.0, `vercel` → 50.4.9, `@commitlint/*` → 20.3.1
> - Updates `prettier` in `package.json` to `3.8.1`
> - Regenerates `package-lock.json` (reflects `prettier` bump and peer metadata)
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit e96d6090af8423f6d5e74d782c675bc309596c41. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated development dependencies to latest versions, including build tools and code formatting utilities

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->