### PR TITLE
fix: add bash-compatible short aliases to output.sh

### DIFF
--- a/script/lib/output.sh
+++ b/script/lib/output.sh
@@ -147,3 +147,10 @@ errors::success() { output::success "$@"; }
 errors::require_command() { output::require_command "$@"; }
 errors::require_file() { output::require_file "$@"; }
 errors::require_directory() { output::require_directory "$@"; }
+
+# Bash-compatible short aliases
+info() { output::info "$@"; }
+success() { output::success "$@"; }
+warning() { output::warning "$@"; }
+error() { output::error "$@"; }
+fatal() { output::fatal "$@"; }


### PR DESCRIPTION
## Summary

Add direct function aliases (info, success, warning, error, fatal) to support bash scripts that call these functions without the output:: namespace prefix.

## Problem

The `setup-team-protection.sh` script was failing with "command not found" errors when calling `info()`, `success()`, `warning()`, and `error()` functions because:
- `script/lib/output.sh` is a zsh script that defines functions with the `output::` namespace prefix
- Bash scripts like `setup-team-protection.sh` were calling these functions without the namespace prefix
- The existing aliases in output.sh only worked for zsh, not bash

## Solution

Add bash-compatible short aliases at the end of output.sh:
```bash
info() { output::info "$@"; }
success() { output::success "$@"; }
warning() { output::warning "$@"; }
error() { output::error "$@"; }
fatal() { output::fatal "$@"; }
```

These aliases ensure bash scripts can use the same simple function names without modification.

## Testing

Tested with `setup-team-protection.sh --dry-run` - now successfully runs without "command not found" errors.

## Impact

- Fixes compatibility issues with bash scripts that source output.sh
- No breaking changes to existing code
- Both zsh and bash scripts can now use the library

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Five new shorthand functions added for message output (info, success, warning, error, fatal) to streamline command usage in scripts.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->