### PR TITLE
feat: ビルドに script/*.sh ファイルを含める

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -75,7 +75,8 @@ RUN echo "alias gco='git checkout'" >> /home/vscode/.bashrc \
  && echo "alias gad='git add'" >> /home/vscode/.bashrc \
  && echo "alias gcm='git commit -m'" >> /home/vscode/.bashrc \
  && echo "alias gps='git push'" >> /home/vscode/.bashrc \
- && echo "alias gpl='git pull'" >> /home/vscode/.bashrc
+ && echo "alias gpl='git pull'" >> /home/vscode/.bashrc \
+ && echo 'export PATH="/usr/local/script:$PATH"' >> /home/vscode/.bashrc
 
 RUN mkdir -p /home/vscode/.claude /home/vscode/.cursor /home/vscode/.openai /home/vscode/.codex \
  && chown -R vscode:vscode /home/vscode/.claude /home/vscode/.cursor /home/vscode/.openai /home/vscode/.codex
@@ -93,7 +94,8 @@ COPY --chown=root:root script/setup-claude.sh /usr/local/bin/setup-claude.sh
 COPY --chown=vscode:vscode script/setup-claude-build.sh /tmp/setup-claude-build.sh
 COPY --chown=vscode:vscode script/lib /tmp/script-lib
 COPY --chown=root:root script/lib /usr/local/script/lib
-RUN chmod +x /usr/local/bin/setup-claude.sh /tmp/setup-claude-build.sh
+COPY --chown=root:root script/*.sh /usr/local/script/
+RUN chmod +x /usr/local/bin/setup-claude.sh /tmp/setup-claude-build.sh /usr/local/script/*.sh
 
 # Install Claude plugins using BuildKit secret or environment variables
 # Build with: DOCKER_BUILDKIT=1 docker build --secret id=claude_credentials,src=$HOME/.claude/.credentials.json .


### PR DESCRIPTION
## Summary
- `script/*.sh` ファイルを `/usr/local/script/` にコピーするよう Dockerfile を更新
- `/usr/local/script` を PATH に追加し、スクリプトを直接実行可能に
- コピーされたスクリプトに実行権限を付与

## Test plan
- [ ] DevContainerイメージのビルドが成功すること
- [ ] ビルド後のコンテナで `setup-team-protection.sh` が実行可能なこと
- [ ] その他の `script/*.sh` ファイルも `/usr/local/script/` に配置されていること

Closes #361

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved development container configuration to enhance script accessibility and streamline utility setup for developers.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->