### PR TITLE
feat: Tailwind CSS + CVA IntelliSense設定を追加

### DIFF
--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,3 +1,8 @@
 {
-  "recommendations": ["dbaeumer.vscode-eslint", "esbenp.prettier-vscode", "ms-vscode.vscode-typescript-next"]
+  "recommendations": [
+    "dbaeumer.vscode-eslint",
+    "esbenp.prettier-vscode",
+    "ms-vscode.vscode-typescript-next",
+    "bradlc.vscode-tailwindcss"
+  ]
 }

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -24,5 +24,19 @@
   },
   "[markdown]": {
     "editor.defaultFormatter": "esbenp.prettier-vscode"
+  },
+  "tailwindCSS.experimental.classRegex": [
+    ["cva\\(([^)]*)\\)", "[\"'`]([^\"'`]*).*?[\"'`]"],
+    ["cx\\(([^)]*)\\)", "(?:'|\"|`)([^']*)(?:'|\"|`)"]
+  ],
+  "explorer.fileNesting.enabled": true,
+  "explorer.fileNesting.patterns": {
+    "*.ts": "${capture}.js",
+    "*.tsx": "${capture}.js",
+    "package.json": "package-lock.json, yarn.lock, pnpm-lock.yaml, .nvmrc",
+    ".eslintrc.*": ".eslintignore",
+    ".prettierrc.*": ".prettierignore",
+    "tsconfig.json": "tsconfig.*.json",
+    "next.config.*": "next-env.d.ts"
   }
 }


### PR DESCRIPTION
## Summary
- Tailwind CSS IntelliSense のための classRegex 設定を追加
  - `cva()` 関数内でのクラス名補完対応
  - `cx()` 関数内でのクラス名補完対応
- ファイルネスティングパターンを追加
- Tailwind CSS IntelliSense 拡張機能を推奨リストに追加

## Benefits
- CVA（Class Variance Authority）を使用するプロジェクトで Tailwind IntelliSense が正しく動作
- モダンな React/Next.js プロジェクトでの DX 向上

## Test plan
- [ ] VS Code で `cva()` 関数内にカーソルを置いた際に Tailwind クラス補完が動作すること
- [ ] `cx()` 関数内でも同様に補完が動作すること

Closes #365

🤖 Generated with [Claude Code](https://claude.com/claude-code)