### PR TITLE
feat: Doppler CLIをDevContainerに追加

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -23,9 +23,20 @@ RUN apt-get update && apt-get install -y \
     python3-pip \
     python3-venv \
     python3-dev \
+    apt-transport-https \
  && apt-get clean \
- && rm -rf /var/lib/apt/lists/* \
- && NODE_VERSION=v22.14.0 \
+ && rm -rf /var/lib/apt/lists/*
+
+# Install Doppler CLI
+# https://docs.doppler.com/docs/install-cli
+RUN curl -sLf --retry 3 --tlsv1.2 --proto "=https" 'https://packages.doppler.com/public/cli/gpg.DE2A7741A397C129.key' | gpg --dearmor -o /usr/share/keyrings/doppler-archive-keyring.gpg \
+ && echo "deb [signed-by=/usr/share/keyrings/doppler-archive-keyring.gpg] https://packages.doppler.com/public/cli/deb/debian any-version main" | tee /etc/apt/sources.list.d/doppler-cli.list \
+ && apt-get update && apt-get install -y doppler \
+ && apt-get clean \
+ && rm -rf /var/lib/apt/lists/*
+
+# Install Node.js
+RUN NODE_VERSION=v22.14.0 \
  && NODE_ARCH=$(dpkg --print-architecture | sed 's/amd64/x64/;s/armhf/armv7l/;s/arm64/arm64/') \
  && wget -q https://nodejs.org/dist/${NODE_VERSION}/node-${NODE_VERSION}-linux-${NODE_ARCH}.tar.xz \
  && tar -xJf node-${NODE_VERSION}-linux-${NODE_ARCH}.tar.xz -C /usr/local --strip-components=1 \


### PR DESCRIPTION
## Summary
- シークレット管理ツール [Doppler CLI](https://docs.doppler.com/docs/install-cli) をベースイメージにインストール
- `doppler` コマンドがDevContainer内で利用可能に

## Changes
- `apt-transport-https` を依存関係に追加
- Dopplerの公式リポジトリからCLIをインストール
- Node.jsインストールを別のRUNレイヤーに分離（可読性向上）

## Usage
```bash
# ログイン
doppler login

# プロジェクト設定
doppler setup

# シークレットを環境変数として実行
doppler run -- your-command
```

## Test plan
- [ ] DevContainerをリビルドして `doppler --version` が動作することを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced development environment configuration with streamlined package management and dependency handling.
  * Integrated Doppler CLI tooling to support deployment and secrets management workflows in the development container.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->