### PR TITLE
fix: add .claude and script paths to docker build trigger

### DIFF
--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -5,6 +5,8 @@ on:
     branches: [main]
     paths:
       - '.devcontainer/**'
+      - '.claude/**'
+      - 'script/**'
       - 'npm/global.json'
       - 'package.json'
       - 'package-lock.json'


### PR DESCRIPTION
## Summary
- Add `.claude/**` to CI trigger paths (skills.txt, plugins.txt, etc.)
- Add `script/**` to CI trigger paths (install-skills.sh, install-claude-plugins.sh)

This ensures that changes to agent skills and plugins will automatically trigger DevContainer image builds.

## Test plan
- [ ] Merge this PR
- [ ] Verify docker-image.yml workflow is triggered
- [ ] Verify new image is published with skills

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated continuous integration workflow configuration to optimize build triggers.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->