### PR TITLE
docs: update DevContainer image version references to 1.54.0

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -103,7 +103,7 @@ PR作成後にCIが失敗した場合、**そのブランチで解決できる�
 ## 5. 環境作成
 
 基本的にdevcontainerを使用する。
-またベースはghcr.io/keito4/config-base:1.48.0を使用する。
+またベースはghcr.io/keito4/config-base:1.54.0を使用する。
 
 ## 6. デプロイ
 

--- a/.claude/devcontainer-recommendations.md
+++ b/.claude/devcontainer-recommendations.md
@@ -10,12 +10,12 @@ Elu-co-jp配下の全リポジトリで統一されたDevContainer環境を提�
 
 ```json
 {
-  "image": "ghcr.io/keito4/config-base:1.48.0"
+  "image": "ghcr.io/keito4/config-base:1.54.0"
 }
 ```
 
-**最新バージョン**: 1.48.0
-**推奨バージョン**: 1.48.0+（安定版として広く採用）
+**最新バージョン**: 1.54.0
+**推奨バージョン**: 1.54.0+（安定版として広く採用）
 
 ## Claude Code動作のための必須設定
 
@@ -25,7 +25,7 @@ Claude Code（AI開発アシスタント）を動作させるための最小限�
 
 ```json
 {
-  "image": "ghcr.io/keito4/config-base:1.48.0"
+  "image": "ghcr.io/keito4/config-base:1.54.0"
 }
 ```
 
@@ -155,7 +155,7 @@ OPENAI_API_KEY=***  # o3 MCP用
 ```json
 {
   "name": "Project Name",
-  "image": "ghcr.io/keito4/config-base:1.48.0",
+  "image": "ghcr.io/keito4/config-base:1.54.0",
   "mounts": [
     "source=${localEnv:HOME}/.codex,target=/home/vscode/.codex,type=bind,consistency=cached",
     "source=${localEnv:HOME}/.claude,target=/home/vscode/.claude,type=bind,consistency=cached",
@@ -737,7 +737,7 @@ NODE_ENV=development
 
    ```json
    - "image": "ghcr.io/keito4/config-base:1.0.40"
-   + "image": "ghcr.io/keito4/config-base:1.48.0"
+   + "image": "ghcr.io/keito4/config-base:1.54.0"
    ```
 
 2. **非推奨Feature削除**

--- a/.devcontainer/README.md
+++ b/.devcontainer/README.md
@@ -77,7 +77,7 @@ This DevContainer image is automatically built and versioned using semantic-rele
 - **Minor versions**: New features and enhancements (1.0.0 → 1.1.0)
 - **Major versions**: Breaking changes (1.0.0 → 2.0.0)
 
-**Latest Version**: `v1.48.0`
+**Latest Version**: `v1.54.0`
 
 Images are published to GitHub Container Registry: `ghcr.io/keito4/config-base`
 
@@ -102,7 +102,7 @@ Use the pre-built image without mounting host's `~/.claude` directory:
 ```json
 {
   "name": "My Project",
-  "image": "ghcr.io/keito4/config-base:1.48.0",
+  "image": "ghcr.io/keito4/config-base:1.54.0",
   "remoteEnv": {
     "TMPDIR": "/home/vscode/.claude/tmp"
   }
@@ -124,7 +124,7 @@ Mount host's `~/.claude` to persist custom plugin installations:
 ```json
 {
   "name": "My Project",
-  "image": "ghcr.io/keito4/config-base:1.48.0",
+  "image": "ghcr.io/keito4/config-base:1.54.0",
   "remoteEnv": {
     "TMPDIR": "/home/vscode/.claude/tmp"
   },

--- a/.devcontainer/VERSIONING.md
+++ b/.devcontainer/VERSIONING.md
@@ -82,7 +82,7 @@ Each release creates two tags:
 
 ```json
 {
-  "image": "ghcr.io/keito4/config-base:1.48.0"
+  "image": "ghcr.io/keito4/config-base:1.54.0"
 }
 ```
 

--- a/README.md
+++ b/README.md
@@ -573,7 +573,7 @@ The repository includes a complete DevContainer setup (`.devcontainer/`) that pr
 - Integrated Claude Code configuration with specialized agents and commands
 - Bell notification system for development workflow events
 
-**Latest Version**: `ghcr.io/keito4/config-base:1.48.0`
+**Latest Version**: `ghcr.io/keito4/config-base:1.54.0`
 
 **Pre-installed Plugins** (v1.48.0):
 

--- a/docs/devcontainer.json.example
+++ b/docs/devcontainer.json.example
@@ -1,6 +1,6 @@
 {
   "name": "My Project",
-  "image": "ghcr.io/keito4/config-base:1.45.3",
+  "image": "ghcr.io/keito4/config-base:1.54.0",
   "remoteEnv": {
     "TMPDIR": "/home/vscode/.claude/tmp"
   },

--- a/docs/using-config-base-image.md
+++ b/docs/using-config-base-image.md
@@ -19,7 +19,7 @@
 // .devcontainer/devcontainer.json
 {
   "name": "My Project",
-  "image": "ghcr.io/keito4/config-base:1.48.0",
+  "image": "ghcr.io/keito4/config-base:1.54.0",
   "remoteEnv": {
     "TMPDIR": "/home/vscode/.claude/tmp"
   }
@@ -82,7 +82,7 @@ claude --help
 // .devcontainer/devcontainer.json
 {
   "name": "My Project",
-  "image": "ghcr.io/keito4/config-base:1.48.0",
+  "image": "ghcr.io/keito4/config-base:1.54.0",
   "remoteEnv": {
     "TMPDIR": "/home/vscode/.claude/tmp"
   },
@@ -133,7 +133,7 @@ my-plugin@marketplace
 ```json
 {
   "name": "My Project",
-  "image": "ghcr.io/keito4/config-base:1.48.0",
+  "image": "ghcr.io/keito4/config-base:1.54.0",
   "remoteEnv": {
     "TMPDIR": "/home/vscode/.claude/tmp"
   },


### PR DESCRIPTION
## 概要

直近のPR #394でDevContainerイメージが1.54.0に更新されましたが、ドキュメントが旧バージョン(1.48.0や1.45.3)を参照していたため、全ドキュメントのバージョン参照を最新の1.54.0に統一しました。

## 更新ファイル

- README.md
- .claude/CLAUDE.md
- .claude/devcontainer-recommendations.md
- .devcontainer/README.md
- .devcontainer/VERSIONING.md
- docs/using-config-base-image.md
- docs/devcontainer.json.example

Closes #396

🤖 Generated with [Claude Code](https://claude.ai/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated base container image version to 1.54.0 across all configuration and documentation files.
  * Synchronized version references in DevContainer configuration examples and documentation to align with the latest stable release.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->