### PR TITLE
fix: include local skills in Docker build and expand trigger paths

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -100,6 +100,8 @@ COPY --chown=vscode:vscode .devcontainer/codex-config.json /home/vscode/.codex/c
 COPY --chown=vscode:vscode .claude/commands /home/vscode/.claude/commands
 COPY --chown=vscode:vscode .claude/agents /home/vscode/.claude/agents
 COPY --chown=vscode:vscode .claude/hooks /home/vscode/.claude/hooks
+# Copy local skill files (*.md) and skills list
+COPY --chown=vscode:vscode .claude/skills/*.md /home/vscode/.claude/skills/
 COPY --chown=vscode:vscode .claude/skills/skills.txt /home/vscode/.claude/skills/skills.txt
 COPY --chown=vscode:vscode .claude/plugins/plugins.txt /home/vscode/.claude/plugins/plugins.txt
 COPY --chown=vscode:vscode .claude/plugins/known_marketplaces.json.template /home/vscode/.claude/plugins/known_marketplaces.json.template

--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -5,6 +5,12 @@ on:
     branches: [main]
     paths:
       - '.devcontainer/**'
+      - '.claude/commands/**'
+      - '.claude/agents/**'
+      - '.claude/hooks/**'
+      - '.claude/skills/**'
+      - '.claude/plugins/**'
+      - 'script/**'
       - 'npm/global.json'
       - 'package.json'
       - 'package-lock.json'


### PR DESCRIPTION
## Summary

- Dockerビルド時にローカルスキルファイル（*.md）がコピーされていなかった問題を修正
- Dockerイメージのビルドトリガーパスを拡張し、Claude設定ファイルの変更を検知するように

## Problem

### 1. ローカルスキルがDockerイメージにコピーされていない

Dockerfileでは `skills.txt` のみコピーしていたため、ローカルスキルファイル（`ci-check.md`、`codex-review.md`）がDockerイメージに含まれていませんでした。

### 2. トリガーパスが不足

`docker-image.yml` のトリガーパスに以下が含まれておらず、これらのファイルを変更してもDockerイメージが再ビルドされませんでした：
- `.claude/commands/**`
- `.claude/agents/**`
- `.claude/hooks/**`
- `.claude/skills/**`
- `.claude/plugins/**`
- `script/**`

## Changes

### Dockerfile
```diff
+# Copy local skill files (*.md) and skills list
+COPY --chown=vscode:vscode .claude/skills/*.md /home/vscode/.claude/skills/
 COPY --chown=vscode:vscode .claude/skills/skills.txt /home/vscode/.claude/skills/skills.txt
```

### docker-image.yml
```diff
 paths:
   - '.devcontainer/**'
+  - '.claude/commands/**'
+  - '.claude/agents/**'
+  - '.claude/hooks/**'
+  - '.claude/skills/**'
+  - '.claude/plugins/**'
+  - 'script/**'
   - 'npm/global.json'
```

## Test plan

- [ ] Dockerイメージをビルドして、ローカルスキルファイルがコピーされていることを確認
- [ ] `.claude/skills/*.md` を変更した際にDockerイメージのビルドがトリガーされることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced container setup to include skill markdown files.
  * Extended automated build process to monitor additional configuration paths for skills, plugins, commands, agents, and hooks.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->