### PR TITLE
fix: move hooks to settings.json for default availability

### DIFF
--- a/.devcontainer/claude-settings.json
+++ b/.devcontainer/claude-settings.json
@@ -381,5 +381,56 @@
       "Bash(npx supabase db reset)",
       "Bash(npx supabase db reset:*)"
     ]
+  },
+  "hooks": {
+    "PreToolUse": [
+      {
+        "matcher": "tool_name == 'Bash'",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "python3 /home/vscode/.claude/hooks/block_git_no_verify.py"
+          }
+        ]
+      },
+      {
+        "matcher": "tool_name == 'Bash'",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "python3 /home/vscode/.claude/hooks/pre_git_quality_gates.py"
+          }
+        ]
+      },
+      {
+        "matcher": "tool_name == 'ExitPlanMode'",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "python3 /home/vscode/.claude/hooks/pre_exit_plan_ai_review.py"
+          }
+        ]
+      }
+    ],
+    "PostToolUse": [
+      {
+        "matcher": "tool_name == 'Bash'",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "python3 /home/vscode/.claude/hooks/post_git_push_ci.py"
+          }
+        ]
+      },
+      {
+        "matcher": "tool_name == 'Bash'",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "python3 /home/vscode/.claude/hooks/post_pr_ai_review.py"
+          }
+        ]
+      }
+    ]
   }
 }

--- a/.devcontainer/claude-settings.local.json
+++ b/.devcontainer/claude-settings.local.json
@@ -322,57 +322,6 @@
   },
   "enableAllProjectMcpServers": true,
   "enabledMcpjsonServers": ["playwright", "o3"],
-  "hooks": {
-    "PreToolUse": [
-      {
-        "matcher": "tool_name == 'Bash'",
-        "hooks": [
-          {
-            "type": "command",
-            "command": "python3 /home/vscode/.claude/hooks/block_git_no_verify.py"
-          }
-        ]
-      },
-      {
-        "matcher": "tool_name == 'Bash'",
-        "hooks": [
-          {
-            "type": "command",
-            "command": "python3 /home/vscode/.claude/hooks/pre_git_quality_gates.py"
-          }
-        ]
-      },
-      {
-        "matcher": "tool_name == 'ExitPlanMode'",
-        "hooks": [
-          {
-            "type": "command",
-            "command": "python3 /home/vscode/.claude/hooks/pre_exit_plan_ai_review.py"
-          }
-        ]
-      }
-    ],
-    "PostToolUse": [
-      {
-        "matcher": "tool_name == 'Bash'",
-        "hooks": [
-          {
-            "type": "command",
-            "command": "python3 /home/vscode/.claude/hooks/post_git_push_ci.py"
-          }
-        ]
-      },
-      {
-        "matcher": "tool_name == 'Bash'",
-        "hooks": [
-          {
-            "type": "command",
-            "command": "python3 /home/vscode/.claude/hooks/post_pr_ai_review.py"
-          }
-        ]
-      }
-    ]
-  },
   "enabledPlugins": {
     "kubernetes-operations@claude-code-workflows": true
   }


### PR DESCRIPTION
## Summary

- DevContainerイメージでhooksがデフォルトで有効にならない問題を修正
- `claude-settings.json` (→ `~/.claude/settings.json`) にhooks設定を移動
- `claude-settings.local.json` からhooks設定を削除

## Why

hooksが `settings.local.json` にのみ設定されていたため、プロジェクト固有の `.claude/settings.local.json` が存在する場合、イメージのhooks設定が上書きされて無効になっていた。

## What

| ファイル | 変更 |
|---------|------|
| `.devcontainer/claude-settings.json` | hooks設定を追加 |
| `.devcontainer/claude-settings.local.json` | hooks設定を削除 |

## How

`settings.json` はベース設定として読み込まれるため、プロジェクト側に独自の `settings.local.json` があっても、hooksが適用される。

## Test plan

- [ ] 新しいプロジェクトでDevContainerを起動し、hooksが動作することを確認
- [ ] `git commit --no-verify` がブロックされることを確認
- [ ] Quality Gatesが `git commit` / `git push` 前に実行されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added pre- and post-tool execution hooks to development container configuration to support automated quality checks and CI/CD integration.
  * Removed corresponding hooks from local development settings to allow standard tool behavior.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->