### PR TITLE
fix: update devcontainer image to v1.61.0

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,6 +1,6 @@
 {
   "name": "Config Base Container",
-  "image": "ghcr.io/keito4/config-base:1.54.0",
+  "image": "ghcr.io/keito4/config-base:1.61.0",
   "features": {
     "ghcr.io/devcontainers-extra/features/homebrew-package:1": {},
     "ghcr.io/eitsupi/devcontainer-features/jq-likes:2": {},


### PR DESCRIPTION
## Summary

- DevContainerイメージを `v1.61.0` に更新

## Why

v1.61.0でhooks設定がデフォルトで有効になる修正が含まれているため。

## What

| ファイル | 変更 |
|---------|------|
| `.devcontainer/devcontainer.json` | `1.54.0` → `1.61.0` |

## v1.61.0の変更点

- hooks設定が `settings.json` に移動され、デフォルトで有効に
- `/setup-new-repo` コマンドの追加
- local skillsのDocker build対応

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated development container image to a newer version.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->