### PR TITLE
fix: add hooks configuration to DevContainer image

### DIFF
--- a/.devcontainer/claude-settings.local.json
+++ b/.devcontainer/claude-settings.local.json
@@ -322,6 +322,48 @@
   },
   "enableAllProjectMcpServers": true,
   "enabledMcpjsonServers": ["playwright", "o3"],
+  "hooks": {
+    "PreToolUse": [
+      {
+        "matcher": "tool_name == 'Bash'",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "python3 .claude/hooks/block_git_no_verify.py"
+          }
+        ]
+      },
+      {
+        "matcher": "tool_name == 'Bash'",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "python3 .claude/hooks/pre_git_quality_gates.py"
+          }
+        ]
+      }
+    ],
+    "PostToolUse": [
+      {
+        "matcher": "tool_name == 'Bash'",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "python3 .claude/hooks/post_git_push_ci.py"
+          }
+        ]
+      },
+      {
+        "matcher": "tool_name == 'Bash'",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "python3 .claude/hooks/post_pr_ai_review.py"
+          }
+        ]
+      }
+    ]
+  },
   "enabledPlugins": {
     "kubernetes-operations@claude-code-workflows": true
   }


### PR DESCRIPTION
## Summary
- Add PreToolUse and PostToolUse hooks to `.devcontainer/claude-settings.local.json`
- Ensures hooks are properly included in the built DevContainer image

## Hooks Added
| Hook | Type | Purpose |
|------|------|---------|
| `block_git_no_verify.py` | PreToolUse | Block `--no-verify` flag usage |
| `pre_git_quality_gates.py` | PreToolUse | Run quality gates before git operations |
| `post_git_push_ci.py` | PostToolUse | Monitor CI after git push |
| `post_pr_ai_review.py` | PostToolUse | Run Codex/Gemini AI review after PR creation |

## Problem
Hooks were configured in `.claude/settings.local.json` (project local) but not in `.devcontainer/claude-settings.local.json` which is copied to the DevContainer image during build.

## Test plan
- [ ] Rebuild DevContainer image
- [ ] Verify hooks are present in `~/.claude/settings.local.json` inside container
- [ ] Test `gh pr create` triggers AI review hook

🤖 Generated with [Claude Code](https://claude.com/claude-code)