### PR TITLE
fix: update devcontainer image to v1.62.1 and add gemini mount

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,6 +1,6 @@
 {
   "name": "Config Base Container",
-  "image": "ghcr.io/keito4/config-base:1.61.2",
+  "image": "ghcr.io/keito4/config-base:1.62.1",
   "features": {
     "ghcr.io/devcontainers-extra/features/homebrew-package:1": {},
     "ghcr.io/eitsupi/devcontainer-features/jq-likes:2": {},
@@ -38,7 +38,8 @@
     "source=${localEnv:HOME}/.cursor,target=/home/vscode/.cursor,type=bind,consistency=cached",
     "source=${localEnv:HOME}/.gitconfig,target=/home/vscode/.gitconfig,type=bind,consistency=cached",
     "source=${localEnv:HOME}/.config/gh,target=/home/vscode/.config/gh,type=bind,consistency=cached",
-    "source=${localEnv:HOME}/.codex,target=/home/vscode/.codex,type=bind,consistency=cached"
+    "source=${localEnv:HOME}/.codex,target=/home/vscode/.codex,type=bind,consistency=cached",
+    "source=${localEnv:HOME}/.gemini,target=/home/vscode/.gemini,type=bind,consistency=cached"
   ],
   "customizations": {
     "vscode": {


### PR DESCRIPTION
## Summary
- DevContainerのconfig-baseイメージをv1.61.2からv1.62.1に更新
- Gemini CLIの設定ディレクトリ（~/.gemini）のマウントを追加

## Changes
- `image`: `ghcr.io/keito4/config-base:1.61.2` → `ghcr.io/keito4/config-base:1.62.1`
- `mounts`: `~/.gemini` ディレクトリを追加

## Test plan
- [x] Pre-commitフックがパス
- [ ] DevContainerが正常に起動することを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)