### PR TITLE
fix: run Claude Code native installer as vscode user

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -66,8 +66,11 @@ USER root
 COPY npm/global.json /tmp/npm-global.json
 
 # Install Claude Code using native installer (npm installation deprecated)
+# Must run as vscode user so claude installs to /home/vscode/.claude/local/bin
+USER vscode
 RUN curl -fsSL https://claude.ai/install.sh | bash \
  && echo 'export PATH="$HOME/.claude/local/bin:$PATH"' >> /home/vscode/.bashrc
+USER root
 
 # Install other global npm packages
 RUN CODEX_VERSION=$(node -pe "require('/tmp/npm-global.json').dependencies['@openai/codex'].version") \


### PR DESCRIPTION
## Summary
- Claude Codeのネイティブインストーラーを`vscode`ユーザーとして実行するように修正
- `root`ユーザーでインストールすると`/root/.claude/local/bin`にインストールされ、`vscode`ユーザーからアクセスできない問題を解決

## Test plan
- [ ] DevContainerイメージをビルドして`claude`コマンドが動作することを確認
- [ ] `/home/vscode/.claude/local/bin/claude`にインストールされていることを確認

🤖 Generated with [Claude Code](https://claude.ai/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved development environment setup to ensure consistent configuration for contributors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->