### PR TITLE
fix: pin Claude Code version to 2.1.25

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -68,7 +68,7 @@ COPY npm/global.json /tmp/npm-global.json
 # Install Claude Code using native installer (npm installation deprecated)
 # Must run as vscode user so claude installs to /home/vscode/.claude/local/bin
 USER vscode
-RUN curl -fsSL https://claude.ai/install.sh | bash \
+RUN curl -fsSL https://claude.ai/install.sh | bash -s 2.1.25 \
  && echo 'export PATH="$HOME/.claude/local/bin:$PATH"' >> /home/vscode/.bashrc
 USER root
 

--- a/script/update-claude-code.sh
+++ b/script/update-claude-code.sh
@@ -23,7 +23,7 @@ log_info "Claude Code バージョン更新を開始します..."
 # claudeコマンドの存在確認
 if ! command -v claude &> /dev/null; then
     log_error "Claude CLI が見つかりません。"
-    log_info "インストール方法: curl -fsSL https://claude.ai/install.sh | bash"
+    log_info "インストール方法: curl -fsSL https://claude.ai/install.sh | bash -s 2.1.25"
     exit 1
 fi
 
@@ -43,7 +43,7 @@ if claude update; then
     fi
 else
     log_warn "claude update に失敗しました。再インストールを試みます..."
-    if curl -fsSL https://claude.ai/install.sh | bash; then
+    if curl -fsSL https://claude.ai/install.sh | bash -s 2.1.25; then
         new_version=$(claude --version 2>/dev/null | head -1 || echo "unknown")
         log_success "Claude Code を再インストールしました (${new_version})"
     else


### PR DESCRIPTION
## Summary
- 最新バージョンに問題があるため、Claude Code のインストールバージョンを 2.1.25 に固定
- DevContainer Dockerfile のインストールコマンドを更新
- `update-claude-code.sh` の再インストールコマンドと案内メッセージを更新

## Test plan
- [ ] DevContainer をリビルドして Claude Code 2.1.25 がインストールされることを確認
- [ ] `script/update-claude-code.sh` を実行して正しいバージョンがインストールされることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Pinned Claude Code version to 2.1.25 across development environment setup and installation scripts to ensure consistent version deployment.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->