### PR TITLE
feat: update Claude Code to 2.1.33 and sync Dockerfile version automatically

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -68,7 +68,7 @@ COPY npm/global.json /tmp/npm-global.json
 # Install Claude Code using native installer (npm installation deprecated)
 # Must run as vscode user so claude installs to /home/vscode/.claude/local/bin
 USER vscode
-RUN curl -fsSL https://claude.ai/install.sh | bash -s 2.1.25 \
+RUN curl -fsSL https://claude.ai/install.sh | bash -s 2.1.33 \
  && echo 'export PATH="$HOME/.claude/local/bin:$PATH"' >> /home/vscode/.bashrc
 USER root
 

--- a/script/update-claude-code.sh
+++ b/script/update-claude-code.sh
@@ -2,9 +2,15 @@
 # ============================================================================
 # Claude Code Version Update Script
 # Claude Code の最新バージョンに更新します（ネイティブインストーラー使用）
+# Dockerfile のバージョンも同時に更新します
 # ============================================================================
 
 set -euo pipefail
+
+# スクリプトのディレクトリを取得
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_ROOT="$(cd "${SCRIPT_DIR}/.." && pwd)"
+DOCKERFILE="${PROJECT_ROOT}/.devcontainer/Dockerfile"
 
 # カラー出力
 GREEN='\033[0;32m'
@@ -20,36 +26,78 @@ log_error() { echo -e "${RED}[ERROR]${NC} $1"; }
 
 log_info "Claude Code バージョン更新を開始します..."
 
-# claudeコマンドの存在確認
-if ! command -v claude &> /dev/null; then
-    log_error "Claude CLI が見つかりません。"
-    log_info "インストール方法: curl -fsSL https://claude.ai/install.sh | bash -s 2.1.25"
+# npm registry から最新バージョンを取得
+get_latest_version() {
+    curl -s "https://registry.npmjs.org/@anthropic-ai/claude-code/latest" | grep -o '"version":"[^"]*"' | head -1 | cut -d'"' -f4
+}
+
+# Dockerfile から現在のバージョンを取得（claude.ai/install.sh の行から）
+get_dockerfile_version() {
+    grep "claude.ai/install.sh" "${DOCKERFILE}" | grep -o 'bash -s [0-9.]*' | cut -d' ' -f3
+}
+
+# Dockerfile のバージョンを更新
+update_dockerfile_version() {
+    local new_version="$1"
+    local current_version
+    current_version=$(get_dockerfile_version)
+
+    if [[ "${current_version}" == "${new_version}" ]]; then
+        log_info "Dockerfile は既に最新バージョンです (${current_version})"
+        return 1
+    fi
+
+    # claude.ai/install.sh を含む行のみバージョンを更新
+    sed -i "/claude.ai\/install.sh/s|bash -s ${current_version}|bash -s ${new_version}|" "${DOCKERFILE}"
+    log_success "Dockerfile を ${current_version} → ${new_version} に更新しました"
+    return 0
+}
+
+# 最新バージョンを取得
+latest_version=$(get_latest_version)
+if [[ -z "${latest_version}" ]]; then
+    log_error "最新バージョンの取得に失敗しました"
     exit 1
 fi
+log_info "最新バージョン: ${latest_version}"
 
-# 現在のバージョンを取得
-current_version=$(claude --version 2>/dev/null | head -1 || echo "unknown")
-log_info "現在のバージョン: ${current_version}"
+# Dockerfile の現在のバージョンを取得
+dockerfile_version=$(get_dockerfile_version)
+log_info "Dockerfile のバージョン: ${dockerfile_version}"
 
-# 更新を実行
-log_info "Claude Code を更新中..."
+# claudeコマンドの存在確認
+if command -v claude &> /dev/null; then
+    current_version=$(claude --version 2>/dev/null | head -1 || echo "unknown")
+    log_info "インストール済みバージョン: ${current_version}"
 
-if claude update; then
-    new_version=$(claude --version 2>/dev/null | head -1 || echo "unknown")
-    if [[ "$current_version" == "$new_version" ]]; then
-        log_success "Claude Code は既に最新バージョンです (${current_version})"
+    # 更新を実行
+    log_info "Claude Code を更新中..."
+    if claude update; then
+        new_version=$(claude --version 2>/dev/null | head -1 || echo "unknown")
+        if [[ "$current_version" == "$new_version" ]]; then
+            log_success "Claude Code は既に最新バージョンです (${current_version})"
+        else
+            log_success "Claude Code を ${current_version} → ${new_version} に更新しました"
+        fi
     else
-        log_success "Claude Code を ${current_version} → ${new_version} に更新しました"
+        log_warn "claude update に失敗しました。再インストールを試みます..."
+        if curl -fsSL https://claude.ai/install.sh | bash -s "${latest_version}"; then
+            new_version=$(claude --version 2>/dev/null | head -1 || echo "unknown")
+            log_success "Claude Code を再インストールしました (${new_version})"
+        else
+            log_error "Claude Code の更新に失敗しました"
+            exit 1
+        fi
     fi
 else
-    log_warn "claude update に失敗しました。再インストールを試みます..."
-    if curl -fsSL https://claude.ai/install.sh | bash -s 2.1.25; then
-        new_version=$(claude --version 2>/dev/null | head -1 || echo "unknown")
-        log_success "Claude Code を再インストールしました (${new_version})"
-    else
-        log_error "Claude Code の更新に失敗しました"
-        exit 1
-    fi
+    log_warn "Claude CLI が見つかりません。Dockerfile のみ更新します。"
+fi
+
+# Dockerfile のバージョンを更新
+if update_dockerfile_version "${latest_version}"; then
+    echo ""
+    log_info "Dockerfile の変更内容:"
+    git diff "${DOCKERFILE}" 2>/dev/null || true
 fi
 
 # リリースノートのURLを表示


### PR DESCRIPTION
## Summary
- Claude Code を 2.1.25 から 2.1.33 に更新
- `update-claude-code.sh` を改修し、Dockerfile のバージョンも自動更新するように

## Changes
- `.devcontainer/Dockerfile`: Claude Code バージョンを 2.1.33 に更新
- `script/update-claude-code.sh`:
  - npm registry から最新バージョンを取得する機能を追加
  - Dockerfile の `claude.ai/install.sh` 行のバージョンを自動更新
  - バージョン比較と差分表示機能を追加

## Test plan
- [x] `bash script/update-claude-code.sh` でスクリプトが正常に動作することを確認
- [x] Dockerfile の Claude Code 行のみが更新され、他の行（rustup等）に影響がないことを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Claude Code installer to version 2.1.33 in the development environment.
  * Improved update mechanism with enhanced version detection and fallback handling for better reliability when managing tooling versions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->