### PR TITLE
docs: update config-base image version references to 1.62.2

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -103,7 +103,7 @@ PR作成後にCIが失敗した場合、**そのブランチで解決できる�
 ## 5. 環境作成
 
 基本的にdevcontainerを使用する。
-またベースはghcr.io/keito4/config-base:1.54.0を使用する。
+またベースはghcr.io/keito4/config-base:1.62.2を使用する。
 
 ## 6. デプロイ
 

--- a/README.md
+++ b/README.md
@@ -579,7 +579,7 @@ The repository includes a complete DevContainer setup (`.devcontainer/`) that pr
 - Integrated Claude Code configuration with specialized agents and commands
 - Bell notification system for development workflow events
 
-**Latest Version**: `ghcr.io/keito4/config-base:1.62.1`
+**Latest Version**: `ghcr.io/keito4/config-base:1.62.2`
 
 **Pre-installed Plugins** (v1.62.1):
 

--- a/docs/using-config-base-image.md
+++ b/docs/using-config-base-image.md
@@ -19,7 +19,7 @@
 // .devcontainer/devcontainer.json
 {
   "name": "My Project",
-  "image": "ghcr.io/keito4/config-base:1.54.0",
+  "image": "ghcr.io/keito4/config-base:1.62.2",
   "remoteEnv": {
     "TMPDIR": "/home/vscode/.claude/tmp"
   }
@@ -82,7 +82,7 @@ claude --help
 // .devcontainer/devcontainer.json
 {
   "name": "My Project",
-  "image": "ghcr.io/keito4/config-base:1.54.0",
+  "image": "ghcr.io/keito4/config-base:1.62.2",
   "remoteEnv": {
     "TMPDIR": "/home/vscode/.claude/tmp"
   },
@@ -133,7 +133,7 @@ my-plugin@marketplace
 ```json
 {
   "name": "My Project",
-  "image": "ghcr.io/keito4/config-base:1.54.0",
+  "image": "ghcr.io/keito4/config-base:1.62.2",
   "remoteEnv": {
     "TMPDIR": "/home/vscode/.claude/tmp"
   },


### PR DESCRIPTION
## 概要

直近のPR #434で更新されたDevContainerイメージバージョンに合わせて、ドキュメント内のバージョン参照を統一しました。

## 変更内容

- README.md: 1.62.1 → 1.62.2
- .claude/CLAUDE.md: 1.54.0 → 1.62.2
- docs/using-config-base-image.md: 1.54.0 → 1.62.2 (3箇所)

## 関連Issue

Closes #435

---

Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated development container image version to the latest stable release across configuration and documentation files.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->