### PR TITLE
fix: auto-install skills on Codespaces startup

### DIFF
--- a/.devcontainer/codespaces/devcontainer.json
+++ b/.devcontainer/codespaces/devcontainer.json
@@ -57,5 +57,6 @@
     "CLAUDE_CODE_OAUTH_TOKEN": {
       "description": "Claude Code OAuth token"
     }
-  }
+  },
+  "postStartCommand": "/usr/local/script/install-skills.sh"
 }

--- a/script/install-skills.sh
+++ b/script/install-skills.sh
@@ -6,16 +6,28 @@
 
 set -euo pipefail
 
-SKILLS_FILE="${1:-/home/vscode/.claude/skills/skills.txt}"
+# skills.txt のパスを決定（引数 > ワークスペース > ホームディレクトリ）
+if [[ -n "${1:-}" ]]; then
+    SKILLS_FILE="$1"
+elif [[ -f "${PWD}/.claude/skills/skills.txt" ]]; then
+    SKILLS_FILE="${PWD}/.claude/skills/skills.txt"
+elif [[ -f "/home/vscode/.claude/skills/skills.txt" ]]; then
+    SKILLS_FILE="/home/vscode/.claude/skills/skills.txt"
+else
+    SKILLS_FILE=""
+fi
+
 AGENTS_DIR="${HOME}/.agents/skills"
 
 echo "[INFO] Claude スキルのインストールを開始します..."
 
 # スキルリストが存在するか確認
-if [[ ! -f "$SKILLS_FILE" ]]; then
-    echo "[WARN] skills.txt が見つかりません: ${SKILLS_FILE}"
+if [[ -z "$SKILLS_FILE" ]] || [[ ! -f "$SKILLS_FILE" ]]; then
+    echo "[WARN] skills.txt が見つかりません"
     exit 0
 fi
+
+echo "[INFO] 使用するスキルリスト: ${SKILLS_FILE}"
 
 # npx skills コマンドが利用可能か確認
 if ! command -v npx &> /dev/null; then
@@ -38,15 +50,45 @@ while IFS= read -r line || [[ -n "$line" ]]; do
     skill=$(echo "$line" | xargs)
     [[ -z "$skill" ]] && continue
 
-    echo "[INFO]   インストール中: ${skill}"
+    echo "[INFO]   チェック中: ${skill}"
 
-    # スキルがすでにインストールされているか確認
-    skill_name=$(basename "$skill")
-    if [[ -d "${AGENTS_DIR}/${skill_name}" ]] || [[ -d "${AGENTS_DIR}/vercel-composition-patterns" && "$skill" == "vercel-labs/agent-skills" ]]; then
+    # スキルがすでにインストールされているか npx skills list -g で確認
+    # 既知のリポジトリとスキル名のマッピング
+    case "$skill" in
+        "vercel-labs/agent-skills")
+            check_skills=("vercel-composition-patterns" "vercel-react-best-practices" "vercel-react-native-skills" "web-design-guidelines")
+            ;;
+        "supabase/agent-skills")
+            check_skills=("supabase-postgres-best-practices")
+            ;;
+        "vercel-labs/skills")
+            check_skills=("find-skills")
+            ;;
+        "vercel-labs/agent-browser")
+            check_skills=("agent-browser" "skill-creator")
+            ;;
+        *)
+            # 不明なリポジトリは basename を使用
+            check_skills=("$(basename "$skill")")
+            ;;
+    esac
+
+    # いずれかのスキルがインストールされているかチェック
+    all_installed=true
+    for check_skill in "${check_skills[@]}"; do
+        if [[ ! -d "${AGENTS_DIR}/${check_skill}" ]]; then
+            all_installed=false
+            break
+        fi
+    done
+
+    if $all_installed; then
         echo "[INFO]   スキップ: ${skill} (既にインストール済み)"
         skipped=$((skipped + 1))
         continue
     fi
+
+    echo "[INFO]   インストール中: ${skill}"
 
     # npx skills add でインストール（-y で自動確認、-g でグローバル）
     if output=$(npx skills add "$skill" -y -g 2>&1); then


### PR DESCRIPTION
## Summary
- Codespaces起動時にスキルの自動インストール/修復を行う `postStartCommand` を追加
- `install-skills.sh` のskills.txtパス検索を改善（ワークスペース優先）
- リポジトリ→スキル名のマッピングを追加し、インストール済みチェックを正確化

## Background
Dockerイメージビルド時にスキルのインストールが一部失敗することがあり、Codespacesでスキルが読み込まれない問題が発生していました。

## Changes
1. `.devcontainer/codespaces/devcontainer.json` に `postStartCommand` を追加
2. `script/install-skills.sh` を改善:
   - skills.txtのパス検索順序: 引数 > ワークスペース > ホームディレクトリ
   - 既知のリポジトリとスキル名のマッピングを追加

## Test plan
- [ ] Codespacesで起動時にスキルが自動インストールされることを確認
- [ ] 既にインストール済みのスキルがスキップされることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Updated development environment configuration for improved workspace setup.
  * Enhanced skill installation script with better error handling, validation checks for prerequisites, improved file resolution logic, and enhanced tracking of installation outcomes to provide more detailed feedback.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->