### PR TITLE
feat: add CLI auth restore for Codespaces persistence

### DIFF
--- a/.claude/hooks/post_pr_ai_review.py
+++ b/.claude/hooks/post_pr_ai_review.py
@@ -15,9 +15,9 @@ import os
 import re
 from concurrent.futures import ThreadPoolExecutor, as_completed
 
-# 最上位モデルの設定
-CODEX_MODEL = "gpt-5.2-codex"  # OpenAI最上位モデル
-GEMINI_MODEL = "gemini-2.5-pro"  # Google最上位モデル
+# モデル設定（空文字列の場合はCLIのデフォルトモデルを使用）
+CODEX_MODEL = ""  # デフォルトモデルを使用（ChatGPTアカウント互換）
+GEMINI_MODEL = ""  # デフォルトモデルを使用
 
 # Read input from Claude
 data = json.load(sys.stdin)
@@ -89,12 +89,10 @@ def run_codex_review():
     print("## 🤖 Codex Review", file=sys.stderr)
     print("-" * 40, file=sys.stderr)
 
-    codex_command = [
-        "codex", "exec",
-        "-m", CODEX_MODEL,
-        "--sandbox", "read-only",
-        review_prompt
-    ]
+    codex_command = ["codex", "exec", "--sandbox", "read-only"]
+    if CODEX_MODEL:
+        codex_command.extend(["-m", CODEX_MODEL])
+    codex_command.append(review_prompt)
 
     try:
         result = subprocess.run(
@@ -172,7 +170,10 @@ def run_gemini_review():
 
 {diff_content[:50000]}"""
 
-        gemini_command = ["gemini", "-m", GEMINI_MODEL, "-p", gemini_prompt]
+        gemini_command = ["gemini", "-p", gemini_prompt]
+        if GEMINI_MODEL:
+            gemini_command.insert(1, GEMINI_MODEL)
+            gemini_command.insert(1, "-m")
 
         result = subprocess.run(
             gemini_command,
@@ -251,7 +252,9 @@ def check_for_issues(review_text: str) -> bool:
 
 # PRコメント用のマークダウンを生成
 comment_parts = [f"## 🔍 AI Code Review (Local Hook)\n"]
-comment_parts.append(f"**Models:** Codex ({CODEX_MODEL}) / Gemini ({GEMINI_MODEL})\n")
+codex_model_display = CODEX_MODEL or "default"
+gemini_model_display = GEMINI_MODEL or "default"
+comment_parts.append(f"**Models:** Codex ({codex_model_display}) / Gemini ({gemini_model_display})\n")
 
 issues_found = False
 

--- a/.devcontainer/codespaces/devcontainer.json
+++ b/.devcontainer/codespaces/devcontainer.json
@@ -56,7 +56,16 @@
     },
     "CLAUDE_CODE_OAUTH_TOKEN": {
       "description": "Claude Code OAuth token"
+    },
+    "CODEX_AUTH_JSON": {
+      "description": "Codex CLI auth.json (base64 encoded)"
+    },
+    "GEMINI_OAUTH_CREDS": {
+      "description": "Gemini CLI oauth_creds.json (base64 encoded)"
+    },
+    "GEMINI_GOOGLE_ACCOUNTS": {
+      "description": "Gemini CLI google_accounts.json (base64 encoded)"
     }
   },
-  "postStartCommand": "/usr/local/script/install-skills.sh"
+  "postStartCommand": "/usr/local/script/install-skills.sh && /usr/local/script/restore-cli-auth.sh"
 }

--- a/script/restore-cli-auth.sh
+++ b/script/restore-cli-auth.sh
@@ -1,0 +1,43 @@
+#!/usr/bin/env bash
+# ============================================================================
+# CLI Authentication Restore Script
+# Codespaces Secretsから認証情報を復元
+# ============================================================================
+
+set -euo pipefail
+
+echo "[INFO] CLI認証情報の復元を開始します..."
+
+# Codex認証情報の復元
+if [[ -n "${CODEX_AUTH_JSON:-}" ]]; then
+    echo "[INFO] Codex認証情報を復元中..."
+    mkdir -p ~/.codex
+    echo "$CODEX_AUTH_JSON" | base64 -d > ~/.codex/auth.json
+    chmod 600 ~/.codex/auth.json
+    echo "[SUCCESS] Codex認証情報を復元しました"
+else
+    echo "[INFO] CODEX_AUTH_JSON が設定されていません。スキップします。"
+fi
+
+# Gemini認証情報の復元
+if [[ -n "${GEMINI_OAUTH_CREDS:-}" ]]; then
+    echo "[INFO] Gemini OAuth認証情報を復元中..."
+    mkdir -p ~/.gemini
+    echo "$GEMINI_OAUTH_CREDS" | base64 -d > ~/.gemini/oauth_creds.json
+    chmod 600 ~/.gemini/oauth_creds.json
+    echo "[SUCCESS] Gemini OAuth認証情報を復元しました"
+else
+    echo "[INFO] GEMINI_OAUTH_CREDS が設定されていません。スキップします。"
+fi
+
+if [[ -n "${GEMINI_GOOGLE_ACCOUNTS:-}" ]]; then
+    echo "[INFO] Gemini Googleアカウント情報を復元中..."
+    mkdir -p ~/.gemini
+    echo "$GEMINI_GOOGLE_ACCOUNTS" | base64 -d > ~/.gemini/google_accounts.json
+    chmod 644 ~/.gemini/google_accounts.json
+    echo "[SUCCESS] Gemini Googleアカウント情報を復元しました"
+else
+    echo "[INFO] GEMINI_GOOGLE_ACCOUNTS が設定されていません。スキップします。"
+fi
+
+echo "[SUCCESS] CLI認証情報の復元が完了しました"


### PR DESCRIPTION
## Summary
- Codex/Gemini CLI認証情報をCodespaces間で永続化する機能を追加
- ChatGPTアカウント互換のためデフォルトモデルを使用するよう修正

## Changes

### 1. `script/restore-cli-auth.sh`
Codespaces起動時にSecretsから認証情報を復元するスクリプト

### 2. `.devcontainer/codespaces/devcontainer.json`
- 新しいSecrets追加:
  - `CODEX_AUTH_JSON`: Codex認証情報 (base64)
  - `GEMINI_OAUTH_CREDS`: Gemini OAuth認証情報 (base64)
  - `GEMINI_GOOGLE_ACCOUNTS`: Geminiアカウント情報 (base64)
- `postStartCommand`: 認証情報復元スクリプトを追加

### 3. `.claude/hooks/post_pr_ai_review.py`
- モデル指定を空文字列に変更（デフォルトモデル使用）
- ChatGPTアカウントでも動作するよう修正

## Setup Instructions
1. GitHub Settings → Secrets → Codespaces で以下を設定:
   ```bash
   # 認証情報をBase64エンコードして設定
   cat ~/.codex/auth.json | base64 -w0  # → CODEX_AUTH_JSON
   cat ~/.gemini/oauth_creds.json | base64 -w0  # → GEMINI_OAUTH_CREDS
   cat ~/.gemini/google_accounts.json | base64 -w0  # → GEMINI_GOOGLE_ACCOUNTS
   ```

2. 新しいCodespacesを起動すると自動的に認証情報が復元される

## Test plan
- [ ] Secretsを設定後、新しいCodespacesで認証情報が復元されることを確認
- [ ] `codex login status` で認証状態を確認
- [ ] `gemini -p "test"` で動作確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)