### PR TITLE
fix: Claude Code hooks の matcher 構文を修正

### DIFF
--- a/.devcontainer/claude-settings.json
+++ b/.devcontainer/claude-settings.json
@@ -387,7 +387,7 @@
   "hooks": {
     "PreToolUse": [
       {
-        "matcher": "tool_name == 'Bash'",
+        "matcher": "Bash",
         "hooks": [
           {
             "type": "command",
@@ -396,7 +396,7 @@
         ]
       },
       {
-        "matcher": "tool_name == 'Bash'",
+        "matcher": "Bash",
         "hooks": [
           {
             "type": "command",
@@ -405,7 +405,7 @@
         ]
       },
       {
-        "matcher": "tool_name == 'ExitPlanMode'",
+        "matcher": "ExitPlanMode",
         "hooks": [
           {
             "type": "command",
@@ -416,7 +416,7 @@
     ],
     "PostToolUse": [
       {
-        "matcher": "tool_name == 'Bash'",
+        "matcher": "Bash",
         "hooks": [
           {
             "type": "command",
@@ -425,7 +425,7 @@
         ]
       },
       {
-        "matcher": "tool_name == 'Bash'",
+        "matcher": "Bash",
         "hooks": [
           {
             "type": "command",


### PR DESCRIPTION
## Summary

- Claude Code の hooks 設定で使用されていた無効な matcher 構文を修正
- `tool_name == 'Bash'` → `Bash` (正しいパターンマッチ構文)

## 問題

`~/.claude/settings.json` の hooks 設定で、式構文（`tool_name == '...'`）が使用されていたため、
ユーザーレベルのフックが一切実行されていなかった。

### 影響を受けていたフック

| Hook Type | Script | 機能 |
|-----------|--------|------|
| PreToolUse | `block_git_no_verify.py` | `--no-verify` のブロック |
| PreToolUse | `pre_git_quality_gates.py` | Quality Gates の実行 |
| PreToolUse | `pre_exit_plan_ai_review.py` | プラン終了前のAIレビュー |
| PostToolUse | `post_git_push_ci.py` | push後のCI確認 |
| PostToolUse | `post_pr_ai_review.py` | PR作成後のAIレビュー |

## 確認済み

- `Elu-co-jp/cyber_ace_1on1` で手動修正後、正常動作を確認
- 参考PR: https://github.com/Elu-co-jp/cyber_ace_1on1/pull/1494

Closes #454

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Optimized internal configuration structure for improved system efficiency. No user-facing changes or functionality impacts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->