### PR TITLE
fix: 残りの hooks に flush=True を追加

### DIFF
--- a/.claude/hooks/post_git_push_ci.py
+++ b/.claude/hooks/post_git_push_ci.py
@@ -62,10 +62,10 @@ is_success = any(re.search(p, combined_output) for p in success_patterns)
 if not is_success:
     sys.exit(0)
 
-print("", file=sys.stderr)
-print("=" * 60, file=sys.stderr)
-print("🚀 Push完了。GitHub Actions CIを確認中...", file=sys.stderr)
-print("=" * 60, file=sys.stderr)
+print("", file=sys.stderr, flush=True)
+print("=" * 60, file=sys.stderr, flush=True)
+print("🚀 Push完了。GitHub Actions CIを確認中...", file=sys.stderr, flush=True)
+print("=" * 60, file=sys.stderr, flush=True)
 
 
 def get_current_branch():
@@ -108,13 +108,13 @@ def get_latest_run():
         return None
 
     except Exception as e:
-        print(f"⚠️  CI状態取得エラー: {e}", file=sys.stderr)
+        print(f"⚠️  CI状態取得エラー: {e}", file=sys.stderr, flush=True)
         return None
 
 
 def watch_ci_run(run_id, timeout_seconds=300):
     """CIの実行を監視（最大5分）"""
-    print(f"\n🔄 CI実行を監視中... (最大{timeout_seconds // 60}分)", file=sys.stderr)
+    print(f"\n🔄 CI実行を監視中... (最大{timeout_seconds // 60}分)", file=sys.stderr, flush=True)
 
     start_time = time.time()
     check_interval = 15  # 15秒ごとにチェック
@@ -140,11 +140,11 @@ def watch_ci_run(run_id, timeout_seconds=300):
 
             # 進行中の場合は待機
             elapsed = int(time.time() - start_time)
-            print(f"   ⏳ {elapsed}秒経過... (status: {status})", file=sys.stderr)
+            print(f"   ⏳ {elapsed}秒経過... (status: {status})", file=sys.stderr, flush=True)
             time.sleep(check_interval)
 
         except Exception as e:
-            print(f"⚠️  監視エラー: {e}", file=sys.stderr)
+            print(f"⚠️  監視エラー: {e}", file=sys.stderr, flush=True)
             break
 
     return "timeout", []
@@ -154,8 +154,8 @@ def watch_ci_run(run_id, timeout_seconds=300):
 run = get_latest_run()
 
 if not run:
-    print("⚠️  GitHub Actions ワークフローが見つかりません", file=sys.stderr)
-    print("   （CI未設定、またはpush直後でまだ起動していない可能性があります）", file=sys.stderr)
+    print("⚠️  GitHub Actions ワークフローが見つかりません", file=sys.stderr, flush=True)
+    print("   （CI未設定、またはpush直後でまだ起動していない可能性があります）", file=sys.stderr, flush=True)
     sys.exit(0)
 
 run_id = run.get("databaseId")
@@ -163,42 +163,42 @@ workflow_name = run.get("workflowName", run.get("name", "Unknown"))
 status = run.get("status", "")
 conclusion = run.get("conclusion", "")
 
-print(f"\n📋 ワークフロー: {workflow_name}", file=sys.stderr)
-print(f"   Run ID: {run_id}", file=sys.stderr)
-print(f"   Status: {status}", file=sys.stderr)
+print(f"\n📋 ワークフロー: {workflow_name}", file=sys.stderr, flush=True)
+print(f"   Run ID: {run_id}", file=sys.stderr, flush=True)
+print(f"   Status: {status}", file=sys.stderr, flush=True)
 
 if status == "completed":
     # 既に完了している場合
     if conclusion == "success":
-        print("\n✅ CI成功！", file=sys.stderr)
+        print("\n✅ CI成功！", file=sys.stderr, flush=True)
     elif conclusion == "failure":
-        print("\n❌ CI失敗", file=sys.stderr)
-        print(f"   詳細: gh run view {run_id}", file=sys.stderr)
+        print("\n❌ CI失敗", file=sys.stderr, flush=True)
+        print(f"   詳細: gh run view {run_id}", file=sys.stderr, flush=True)
     else:
-        print(f"\n⚠️  CI結果: {conclusion}", file=sys.stderr)
+        print(f"\n⚠️  CI結果: {conclusion}", file=sys.stderr, flush=True)
 else:
     # 実行中の場合は監視
     conclusion, jobs = watch_ci_run(run_id)
 
     if conclusion == "success":
-        print("\n✅ CI成功！", file=sys.stderr)
+        print("\n✅ CI成功！", file=sys.stderr, flush=True)
     elif conclusion == "failure":
-        print("\n❌ CI失敗", file=sys.stderr)
+        print("\n❌ CI失敗", file=sys.stderr, flush=True)
         # 失敗したジョブを表示
         failed_jobs = [j for j in jobs if j.get("conclusion") == "failure"]
         if failed_jobs:
-            print("\n失敗したジョブ:", file=sys.stderr)
+            print("\n失敗したジョブ:", file=sys.stderr, flush=True)
             for job in failed_jobs:
-                print(f"   - {job.get('name', 'Unknown')}", file=sys.stderr)
-        print(f"\n   詳細: gh run view {run_id}", file=sys.stderr)
+                print(f"   - {job.get('name', 'Unknown')}", file=sys.stderr, flush=True)
+        print(f"\n   詳細: gh run view {run_id}", file=sys.stderr, flush=True)
     elif conclusion == "timeout":
-        print("\n⏰ CI監視タイムアウト（まだ実行中）", file=sys.stderr)
-        print(f"   詳細: gh run view {run_id} --watch", file=sys.stderr)
+        print("\n⏰ CI監視タイムアウト（まだ実行中）", file=sys.stderr, flush=True)
+        print(f"   詳細: gh run view {run_id} --watch", file=sys.stderr, flush=True)
     else:
-        print(f"\n⚠️  CI結果: {conclusion}", file=sys.stderr)
+        print(f"\n⚠️  CI結果: {conclusion}", file=sys.stderr, flush=True)
 
-print("", file=sys.stderr)
-print("=" * 60, file=sys.stderr)
+print("", file=sys.stderr, flush=True)
+print("=" * 60, file=sys.stderr, flush=True)
 
 # PostToolUseフックは常に成功で終了（ブロックしない）
 sys.exit(0)

--- a/.claude/hooks/post_pr_ai_review.py
+++ b/.claude/hooks/post_pr_ai_review.py
@@ -61,7 +61,7 @@ has_codex = shutil.which("codex") is not None
 has_gemini = shutil.which("gemini") is not None
 
 if not has_codex and not has_gemini:
-    print("⚠️  AIレビューツール（Codex/Gemini）がインストールされていません。スキップします。", file=sys.stderr)
+    print("⚠️  AIレビューツール（Codex/Gemini）がインストールされていません。スキップします。", file=sys.stderr, flush=True)
     sys.exit(0)
 
 # レビュープロンプト（日本語で出力）
@@ -76,18 +76,18 @@ git merge-baseを使用してマージベースを見つけ、そのマージベ
 
 **重要: 必ず日本語で回答してください。**"""
 
-print("", file=sys.stderr)
-print("=" * 60, file=sys.stderr)
-print("🔍 PR作成完了。AIレビューを実行中...", file=sys.stderr)
-print(f"📎 PR: {pr_url}", file=sys.stderr)
-print("=" * 60, file=sys.stderr)
+print("", file=sys.stderr, flush=True)
+print("=" * 60, file=sys.stderr, flush=True)
+print("🔍 PR作成完了。AIレビューを実行中...", file=sys.stderr, flush=True)
+print(f"📎 PR: {pr_url}", file=sys.stderr, flush=True)
+print("=" * 60, file=sys.stderr, flush=True)
 
 
 def run_codex_review():
     """Codexによるレビューを実行し、結果を返す"""
-    print("", file=sys.stderr)
-    print("## 🤖 Codex Review", file=sys.stderr)
-    print("-" * 40, file=sys.stderr)
+    print("", file=sys.stderr, flush=True)
+    print("## 🤖 Codex Review", file=sys.stderr, flush=True)
+    print("-" * 40, file=sys.stderr, flush=True)
 
     codex_command = ["codex", "exec", "--sandbox", "read-only"]
     if CODEX_MODEL:
@@ -105,19 +105,19 @@ def run_codex_review():
 
         # returncode == 0 の場合のみ結果を返す
         if result.returncode == 0 and result.stdout:
-            print(result.stdout, file=sys.stderr)
+            print(result.stdout, file=sys.stderr, flush=True)
             return result.stdout.strip()
 
         if result.returncode != 0:
             error_msg = result.stderr[:300] if result.stderr else "不明なエラー"
-            print(f"⚠️  Codexエラー: {error_msg}", file=sys.stderr)
+            print(f"⚠️  Codexエラー: {error_msg}", file=sys.stderr, flush=True)
             return None
 
     except subprocess.TimeoutExpired:
-        print("⚠️  Codexレビューがタイムアウトしました（10分）", file=sys.stderr)
+        print("⚠️  Codexレビューがタイムアウトしました（10分）", file=sys.stderr, flush=True)
         return None
     except Exception as e:
-        print(f"⚠️  Codexレビュー実行エラー: {e}", file=sys.stderr)
+        print(f"⚠️  Codexレビュー実行エラー: {e}", file=sys.stderr, flush=True)
         return None
 
     return None
@@ -125,9 +125,9 @@ def run_codex_review():
 
 def run_gemini_review():
     """Geminiによるレビューを実行し、結果を返す"""
-    print("", file=sys.stderr)
-    print("## ✨ Gemini Review", file=sys.stderr)
-    print("-" * 40, file=sys.stderr)
+    print("", file=sys.stderr, flush=True)
+    print("## ✨ Gemini Review", file=sys.stderr, flush=True)
+    print("-" * 40, file=sys.stderr, flush=True)
 
     try:
         # マージベースを取得
@@ -140,7 +140,7 @@ def run_gemini_review():
         merge_base = merge_base_result.stdout.strip()
 
         if not merge_base:
-            print("⚠️  マージベースの取得に失敗しました", file=sys.stderr)
+            print("⚠️  マージベースの取得に失敗しました", file=sys.stderr, flush=True)
             return None
 
         # diffを取得
@@ -153,7 +153,7 @@ def run_gemini_review():
         diff_content = diff_result.stdout
 
         if not diff_content:
-            print("⚠️  diffが空です", file=sys.stderr)
+            print("⚠️  diffが空です", file=sys.stderr, flush=True)
             return None
 
         # Gemini用のプロンプト（diffを含める、日本語で出力）
@@ -185,19 +185,19 @@ def run_gemini_review():
 
         # returncode == 0 の場合のみ結果を返す
         if result.returncode == 0 and result.stdout:
-            print(result.stdout, file=sys.stderr)
+            print(result.stdout, file=sys.stderr, flush=True)
             return result.stdout.strip()
 
         if result.returncode != 0:
             error_msg = result.stderr[:300] if result.stderr else "不明なエラー"
-            print(f"⚠️  Geminiエラー: {error_msg}", file=sys.stderr)
+            print(f"⚠️  Geminiエラー: {error_msg}", file=sys.stderr, flush=True)
             return None
 
     except subprocess.TimeoutExpired:
-        print("⚠️  Geminiレビューがタイムアウトしました（10分）", file=sys.stderr)
+        print("⚠️  Geminiレビューがタイムアウトしました（10分）", file=sys.stderr, flush=True)
         return None
     except Exception as e:
-        print(f"⚠️  Geminiレビュー実行エラー: {e}", file=sys.stderr)
+        print(f"⚠️  Geminiレビュー実行エラー: {e}", file=sys.stderr, flush=True)
         return None
 
     return None
@@ -213,13 +213,13 @@ def post_pr_comment(pr_url: str, comment_body: str):
             timeout=60
         )
         if result.returncode == 0:
-            print("✅ PRコメント投稿成功", file=sys.stderr)
+            print("✅ PRコメント投稿成功", file=sys.stderr, flush=True)
             return True
         else:
-            print(f"⚠️  PRコメント投稿失敗: {result.stderr[:200]}", file=sys.stderr)
+            print(f"⚠️  PRコメント投稿失敗: {result.stderr[:200]}", file=sys.stderr, flush=True)
             return False
     except Exception as e:
-        print(f"⚠️  PRコメント投稿エラー: {e}", file=sys.stderr)
+        print(f"⚠️  PRコメント投稿エラー: {e}", file=sys.stderr, flush=True)
         return False
 
 
@@ -239,7 +239,7 @@ with ThreadPoolExecutor(max_workers=2) as executor:
         try:
             review_results[reviewer] = future.result()
         except Exception as e:
-            print(f"⚠️  {reviewer}レビュー実行エラー: {e}", file=sys.stderr)
+            print(f"⚠️  {reviewer}レビュー実行エラー: {e}", file=sys.stderr, flush=True)
 
 def check_for_issues(review_text: str) -> bool:
     """レビュー結果から問題が検出されたかをチェック"""
@@ -284,20 +284,20 @@ if review_results["codex"] or review_results["gemini"]:
     comment_parts.append("*🤖 Generated by post_pr_ai_review.py hook*")
     comment_body = "\n".join(comment_parts)
 
-    print("", file=sys.stderr)
-    print("📝 PRにレビューコメントを投稿中...", file=sys.stderr)
+    print("", file=sys.stderr, flush=True)
+    print("📝 PRにレビューコメントを投稿中...", file=sys.stderr, flush=True)
     post_pr_comment(pr_url, comment_body)
 else:
-    print("", file=sys.stderr)
-    print("⚠️  レビュー結果がないため、PRコメントはスキップします", file=sys.stderr)
+    print("", file=sys.stderr, flush=True)
+    print("⚠️  レビュー結果がないため、PRコメントはスキップします", file=sys.stderr, flush=True)
 
-print("", file=sys.stderr)
-print("=" * 60, file=sys.stderr)
+print("", file=sys.stderr, flush=True)
+print("=" * 60, file=sys.stderr, flush=True)
 if issues_found:
-    print("⚠️  AIレビュー完了 - 問題が検出されました。修正を検討してください。", file=sys.stderr)
+    print("⚠️  AIレビュー完了 - 問題が検出されました。修正を検討してください。", file=sys.stderr, flush=True)
 else:
-    print("✅ AIレビュー完了", file=sys.stderr)
-print("=" * 60, file=sys.stderr)
+    print("✅ AIレビュー完了", file=sys.stderr, flush=True)
+print("=" * 60, file=sys.stderr, flush=True)
 
 # PostToolUseフックは常に成功で終了（ブロックしない）
 sys.exit(0)

--- a/.claude/hooks/pre_exit_plan_ai_review.py
+++ b/.claude/hooks/pre_exit_plan_ai_review.py
@@ -26,7 +26,7 @@ has_codex = shutil.which("codex") is not None
 has_gemini = shutil.which("gemini") is not None
 
 if not has_codex and not has_gemini:
-    print("⚠️  AIレビューツール（Codex/Gemini）がインストールされていません。スキップします。", file=sys.stderr)
+    print("⚠️  AIレビューツール（Codex/Gemini）がインストールされていません。スキップします。", file=sys.stderr, flush=True)
     sys.exit(0)
 
 # プランファイルを検出
@@ -41,7 +41,7 @@ if os.path.isdir(plan_dir):
     )
 
 if not plan_files:
-    print("⚠️  プランファイルが見つかりません。スキップします。", file=sys.stderr)
+    print("⚠️  プランファイルが見つかりません。スキップします。", file=sys.stderr, flush=True)
     sys.exit(0)
 
 latest_plan = plan_files[0]
@@ -52,13 +52,13 @@ try:
     with open(latest_plan, 'r', encoding='utf-8') as f:
         plan_content = f.read()
 except Exception as e:
-    print(f"⚠️  プランファイル読み込みエラー: {e}", file=sys.stderr)
+    print(f"⚠️  プランファイル読み込みエラー: {e}", file=sys.stderr, flush=True)
     sys.exit(0)
 
-print("", file=sys.stderr)
-print("=" * 60, file=sys.stderr)
-print(f"🔍 プラン '{plan_name}' をAIでレビュー中...", file=sys.stderr)
-print("=" * 60, file=sys.stderr)
+print("", file=sys.stderr, flush=True)
+print("=" * 60, file=sys.stderr, flush=True)
+print(f"🔍 プラン '{plan_name}' をAIでレビュー中...", file=sys.stderr, flush=True)
+print("=" * 60, file=sys.stderr, flush=True)
 
 # レビュープロンプト
 review_prompt = f"""You are reviewing a software implementation plan before it is approved for execution.
@@ -99,9 +99,9 @@ review_results = {
 
 def run_codex_review():
     """Codexによるプランレビューを実行"""
-    print("", file=sys.stderr)
-    print("## 🤖 Codex Plan Review", file=sys.stderr)
-    print("-" * 40, file=sys.stderr)
+    print("", file=sys.stderr, flush=True)
+    print("## 🤖 Codex Plan Review", file=sys.stderr, flush=True)
+    print("-" * 40, file=sys.stderr, flush=True)
 
     codex_command = [
         "codex", "exec",
@@ -119,7 +119,7 @@ def run_codex_review():
         )
 
         if result.stdout:
-            print(result.stdout, file=sys.stderr)
+            print(result.stdout, file=sys.stderr, flush=True)
             output = result.stdout.lower()
 
             review_results["codex"]["success"] = True
@@ -129,19 +129,19 @@ def run_codex_review():
                 review_results["codex"]["ready"] = True
 
         if result.returncode != 0:
-            print(f"⚠️  Codex実行エラー (exit code: {result.returncode})", file=sys.stderr)
+            print(f"⚠️  Codex実行エラー (exit code: {result.returncode})", file=sys.stderr, flush=True)
 
     except subprocess.TimeoutExpired:
-        print("⚠️  Codexレビューがタイムアウトしました（10分）", file=sys.stderr)
+        print("⚠️  Codexレビューがタイムアウトしました（10分）", file=sys.stderr, flush=True)
     except Exception as e:
-        print(f"⚠️  Codexレビュー実行エラー: {e}", file=sys.stderr)
+        print(f"⚠️  Codexレビュー実行エラー: {e}", file=sys.stderr, flush=True)
 
 
 def run_gemini_review():
     """Geminiによるプランレビューを実行"""
-    print("", file=sys.stderr)
-    print("## ✨ Gemini Plan Review", file=sys.stderr)
-    print("-" * 40, file=sys.stderr)
+    print("", file=sys.stderr, flush=True)
+    print("## ✨ Gemini Plan Review", file=sys.stderr, flush=True)
+    print("-" * 40, file=sys.stderr, flush=True)
 
     gemini_command = [
         "gemini",
@@ -158,7 +158,7 @@ def run_gemini_review():
         )
 
         if result.stdout:
-            print(result.stdout, file=sys.stderr)
+            print(result.stdout, file=sys.stderr, flush=True)
             output = result.stdout.lower()
 
             review_results["gemini"]["success"] = True
@@ -168,12 +168,12 @@ def run_gemini_review():
                 review_results["gemini"]["ready"] = True
 
         if result.returncode != 0:
-            print(f"⚠️  Gemini実行エラー (exit code: {result.returncode})", file=sys.stderr)
+            print(f"⚠️  Gemini実行エラー (exit code: {result.returncode})", file=sys.stderr, flush=True)
 
     except subprocess.TimeoutExpired:
-        print("⚠️  Geminiレビューがタイムアウトしました（10分）", file=sys.stderr)
+        print("⚠️  Geminiレビューがタイムアウトしました（10分）", file=sys.stderr, flush=True)
     except Exception as e:
-        print(f"⚠️  Geminiレビュー実行エラー: {e}", file=sys.stderr)
+        print(f"⚠️  Geminiレビュー実行エラー: {e}", file=sys.stderr, flush=True)
 
 
 # 利用可能なツールでレビューを実行
@@ -198,20 +198,20 @@ any_success = (
 )
 
 # 結果の表示と判定
-print("", file=sys.stderr)
-print("=" * 60, file=sys.stderr)
+print("", file=sys.stderr, flush=True)
+print("=" * 60, file=sys.stderr, flush=True)
 
 if any_needs_revision:
-    print("❌ プランに修正が必要です。上記の指摘を確認してください。", file=sys.stderr)
-    print("=" * 60, file=sys.stderr)
+    print("❌ プランに修正が必要です。上記の指摘を確認してください。", file=sys.stderr, flush=True)
+    print("=" * 60, file=sys.stderr, flush=True)
     sys.exit(2)
 
 if any_ready:
-    print("✅ AIプランレビュー完了 - 問題なし", file=sys.stderr)
+    print("✅ AIプランレビュー完了 - 問題なし", file=sys.stderr, flush=True)
 elif any_success:
-    print("⚠️  AIプランレビュー完了 - 明確な承認なし（続行を許可）", file=sys.stderr)
+    print("⚠️  AIプランレビュー完了 - 明確な承認なし（続行を許可）", file=sys.stderr, flush=True)
 else:
-    print("⚠️  AIレビューが実行できませんでした（続行を許可）", file=sys.stderr)
+    print("⚠️  AIレビューが実行できませんでした（続行を許可）", file=sys.stderr, flush=True)
 
-print("=" * 60, file=sys.stderr)
+print("=" * 60, file=sys.stderr, flush=True)
 sys.exit(0)


### PR DESCRIPTION
## Summary
- 残りの 3 つの hooks スクリプトにも `flush=True` を追加
- 出力がバッファリングされて途中で切れる問題を修正

## Changes
- `.claude/hooks/post_git_push_ci.py`: すべての `print()` に `flush=True` 追加
- `.claude/hooks/post_pr_ai_review.py`: すべての `print()` に `flush=True` 追加
- `.claude/hooks/pre_exit_plan_ai_review.py`: すべての `print()` に `flush=True` 追加

## Related
- 前のPR #458 で `block_git_no_verify.py` と `pre_git_quality_gates.py` を修正済み

## Test plan
- [ ] hooks 実行時に出力が途中で切れないことを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved real-time output handling in internal CI and review infrastructure for better logging and monitoring responsiveness.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->