### PR TITLE
fix: Codespaces devcontainer イメージを 1.62.3 に更新

### DIFF
--- a/.devcontainer/codespaces/devcontainer.json
+++ b/.devcontainer/codespaces/devcontainer.json
@@ -1,6 +1,6 @@
 {
   "name": "Config Base (Codespaces)",
-  "image": "ghcr.io/keito4/config-base:1.62.2",
+  "image": "ghcr.io/keito4/config-base:1.62.3",
   "features": {
     "ghcr.io/devcontainers/features/sshd:1": {},
     "ghcr.io/devcontainers-extra/features/homebrew-package:1": {},


### PR DESCRIPTION
## Summary

Codespaces用のdevcontainerイメージを最新バージョンに更新します。

## Changes

- `.devcontainer/codespaces/devcontainer.json`: イメージバージョンを `1.62.2` → `1.62.3` に更新

## Test plan

- [ ] Codespaceが正常に起動する
- [ ] 開発環境が正しく構成される

🤖 Generated with [Claude Code](https://claude.com/claude-code)