### PR TITLE
feat: add image version tracking to DevContainer

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,8 +1,15 @@
 FROM mcr.microsoft.com/devcontainers/base:ubuntu
 
-# Build arguments for Claude Code authentication
+# Build arguments
 ARG CLAUDE_CODE_OAUTH_TOKEN
 ARG ANTHROPIC_API_KEY
+ARG IMAGE_VERSION="dev"
+
+# OCI Image Labels for version tracking
+LABEL org.opencontainers.image.version="${IMAGE_VERSION}" \
+      org.opencontainers.image.source="https://github.com/keito4/config" \
+      org.opencontainers.image.title="config-base" \
+      org.opencontainers.image.description="DevContainer base image with Claude Code, Codex, and development tools"
 
 # Install dependencies and Node.js using official binaries
 RUN apt-get update && apt-get install -y \
@@ -153,6 +160,10 @@ RUN chsh -s /bin/bash vscode
 
 RUN echo 'source ~/.bashrc' >> /home/vscode/.bash_profile \
  && chown vscode:vscode /home/vscode/.bash_profile
+
+# Write version file for easy version checking
+RUN echo "${IMAGE_VERSION}" > /etc/config-base-version \
+ && chmod 644 /etc/config-base-version
 
 COPY package.json package-lock.json /tmp/
 COPY .husky /tmp/.husky/

--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -177,6 +177,7 @@ jobs:
           cache-from: type=registry,ref=ghcr.io/${{ github.repository_owner }}/config-base:cache
           cache-to: type=registry,ref=ghcr.io/${{ github.repository_owner }}/config-base:cache,mode=max
           build-args: |
+            IMAGE_VERSION=${{ steps.release.outputs.version }}
             CLAUDE_CODE_OAUTH_TOKEN=${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           secrets: |
             claude_credentials=${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}

--- a/script/README.md
+++ b/script/README.md
@@ -4,12 +4,13 @@ This directory contains utility scripts for managing configuration, credentials,
 
 ## Quick Reference
 
-| Script                | Purpose                          | Used By                |
-| --------------------- | -------------------------------- | ---------------------- |
-| `setup-claude.sh`     | Claude Code CLI setup            | Makefile, DevContainer |
-| `credentials.sh`      | 1Password credential management  | Makefile               |
-| `update-libraries.sh` | Library updates for Codex/Claude | package.json           |
-| `version.sh`          | Semantic versioning              | Makefile               |
+| Script                   | Purpose                          | Used By                |
+| ------------------------ | -------------------------------- | ---------------------- |
+| `setup-claude.sh`        | Claude Code CLI setup            | Makefile, DevContainer |
+| `credentials.sh`         | 1Password credential management  | Makefile               |
+| `update-libraries.sh`    | Library updates for Codex/Claude | package.json           |
+| `version.sh`             | Semantic versioning              | Makefile               |
+| `check-image-version.sh` | Show DevContainer image version  | Manual                 |
 
 ## Configuration Management
 
@@ -246,6 +247,19 @@ Comprehensive DevContainer health check.
 **Usage**: `./script/container-health.sh [--json]`
 
 **Claude command**: `/container-health`
+
+### check-image-version.sh
+
+Displays the config-base DevContainer image version.
+
+**Usage**:
+
+```bash
+./script/check-image-version.sh        # Show version
+./script/check-image-version.sh -v     # Show version with additional info
+```
+
+**Note**: Version tracking was added in v1.64.0. Older images will show "unknown".
 
 ### install-npm-globals.sh
 

--- a/script/check-image-version.sh
+++ b/script/check-image-version.sh
@@ -1,0 +1,36 @@
+#!/usr/bin/env bash
+#
+# check-image-version.sh - DevContainer イメージのバージョン情報を表示
+#
+
+set -euo pipefail
+
+VERSION_FILE="/etc/config-base-version"
+
+# バージョンファイルの確認
+if [ -f "$VERSION_FILE" ]; then
+  VERSION=$(cat "$VERSION_FILE")
+  echo "config-base version: $VERSION"
+else
+  echo "config-base version: unknown (version file not found)"
+  echo ""
+  echo "Note: Version tracking was added in v1.64.0"
+  echo "Consider updating to the latest image: ghcr.io/keito4/config-base:latest"
+  exit 1
+fi
+
+# オプション: 詳細表示
+if [ "${1:-}" = "-v" ] || [ "${1:-}" = "--verbose" ]; then
+  echo ""
+  echo "Additional info:"
+  echo "  Image source: https://github.com/keito4/config"
+  echo "  Releases: https://github.com/keito4/config/releases"
+
+  # Docker ラベルから追加情報を取得（コンテナ外で実行時）
+  if command -v docker &> /dev/null; then
+    CURRENT_IMAGE=$(docker inspect --format '{{.Config.Image}}' "$(hostname)" 2>/dev/null || echo "")
+    if [ -n "$CURRENT_IMAGE" ]; then
+      echo "  Current image: $CURRENT_IMAGE"
+    fi
+  fi
+fi


### PR DESCRIPTION
## Summary

- DevContainer イメージにバージョン情報を埋め込む機能を追加
- ユーザーが使用中のイメージバージョンを簡単に確認可能に

## Changes

1. **Dockerfile**
   - OCI イメージラベルを追加（version, source, title, description）
   - `/etc/config-base-version` にバージョンを書き込み

2. **GitHub Actions Workflow**
   - `IMAGE_VERSION` build arg をビルド時に渡すよう修正

3. **check-image-version.sh**
   - バージョン確認用の新規スクリプト
   - `-v` オプションで詳細情報を表示

## Usage

```bash
# DevContainer 内でバージョン確認
cat /etc/config-base-version

# または
./script/check-image-version.sh
./script/check-image-version.sh -v  # 詳細表示
```

## Test plan

- [ ] `docker build` でイメージをビルドしてラベルを確認
- [ ] コンテナ内で `/etc/config-base-version` の内容を確認
- [ ] `check-image-version.sh` スクリプトの動作確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Container images now include version tracking information
  * Added utility script to retrieve and display image version details with optional verbose output for additional metadata

* **Documentation**
  * Updated documentation for the new version-checking utility

<!-- end of auto-generated comment: release notes by coderabbit.ai -->