### PR TITLE
fix: プラグインインストールの PATH 不整合とライブラリパス修正

### DIFF
--- a/.claude/plugins/known_marketplaces.json.template
+++ b/.claude/plugins/known_marketplaces.json.template
@@ -1,4 +1,12 @@
 {
+  "agent-browser": {
+    "source": {
+      "source": "github",
+      "repo": "vercel-labs/agent-browser"
+    },
+    "installLocation": "{{HOME}}/.claude/plugins/marketplaces/agent-browser",
+    "lastUpdated": "2025-01-01T00:00:00.000Z"
+  },
   "anthropic-agent-skills": {
     "source": {
       "source": "git",
@@ -39,12 +47,28 @@
     "installLocation": "{{HOME}}/.claude/plugins/marketplaces/claude-plugins-official",
     "lastUpdated": "2025-01-01T00:00:00.000Z"
   },
+  "intellectronica-skills": {
+    "source": {
+      "source": "github",
+      "repo": "intellectronica/agent-skills"
+    },
+    "installLocation": "{{HOME}}/.claude/plugins/marketplaces/intellectronica-skills",
+    "lastUpdated": "2025-01-01T00:00:00.000Z"
+  },
   "playwright-skill": {
     "source": {
       "source": "github",
       "repo": "lackeyjb/playwright-skill"
     },
     "installLocation": "{{HOME}}/.claude/plugins/marketplaces/playwright-skill",
+    "lastUpdated": "2025-01-01T00:00:00.000Z"
+  },
+  "supabase-agent-skills": {
+    "source": {
+      "source": "github",
+      "repo": "supabase/agent-skills"
+    },
+    "installLocation": "{{HOME}}/.claude/plugins/marketplaces/supabase-agent-skills",
     "lastUpdated": "2025-01-01T00:00:00.000Z"
   }
 }

--- a/.claude/plugins/plugins.txt
+++ b/.claude/plugins/plugins.txt
@@ -23,3 +23,12 @@ backend-development@claude-code-workflows
 full-stack-orchestration@claude-code-workflows
 database-design@claude-code-workflows
 database-migrations@claude-code-workflows
+
+# === Supabase Agent Skills (Plugin) ===
+postgres-best-practices@supabase-agent-skills
+
+# === Vercel Agent Browser (Plugin) ===
+agent-browser@agent-browser
+
+# === Context7 (Plugin) ===
+context7@intellectronica-skills

--- a/.claude/skills/skills.txt
+++ b/.claude/skills/skills.txt
@@ -14,6 +14,7 @@ vercel-labs/agent-skills@vercel-composition-patterns
 
 # === Supabase Agent Skills ===
 # Supabase 開発のベストプラクティス
+# Plugin 併用: postgres-best-practices@supabase-agent-skills
 supabase/agent-skills
 supabase/agent-skills@supabase-postgres-best-practices
 
@@ -23,8 +24,10 @@ vercel-labs/skills
 
 # === Vercel Agent Browser ===
 # ブラウザ自動化（テスト、フォーム、スクリーンショット、データ抽出）
+# Plugin 併用: agent-browser@agent-browser
 vercel-labs/agent-browser
 
 # === Context7 ===
 # ライブラリ・フレームワークの最新ドキュメント取得
+# Plugin 併用: context7@intellectronica-skills
 intellectronica/agent-skills

--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -12,7 +12,7 @@ LABEL org.opencontainers.image.version="${IMAGE_VERSION}" \
       org.opencontainers.image.description="DevContainer base image with Claude Code, Codex, and development tools"
 
 # Install dependencies and Node.js using official binaries
-RUN apt-get update && apt-get install -y \
+RUN apt-get update && apt-get upgrade -y && apt-get install -y \
     curl \
     git \
     alsa-utils \
@@ -77,6 +77,7 @@ COPY npm/global.json /tmp/npm-global.json
 USER vscode
 RUN curl -fsSL https://claude.ai/install.sh | bash -s 2.1.39 \
  && echo 'export PATH="$HOME/.claude/local/bin:$PATH"' >> /home/vscode/.bashrc
+ENV PATH="/home/vscode/.claude/local/bin:${PATH}"
 USER root
 
 # Install other global npm packages
@@ -124,7 +125,7 @@ COPY --chown=vscode:vscode script/install-claude-plugins.sh /tmp/install-claude-
 COPY --chown=vscode:vscode script/install-skills.sh /tmp/install-skills.sh
 COPY --chown=root:root script/setup-claude.sh /usr/local/bin/setup-claude.sh
 COPY --chown=vscode:vscode script/setup-claude-build.sh /tmp/setup-claude-build.sh
-COPY --chown=vscode:vscode script/lib /tmp/script-lib
+COPY --chown=vscode:vscode script/lib /tmp/script/lib
 COPY --chown=root:root script/lib /usr/local/script/lib
 COPY --chown=root:root script/*.sh /usr/local/script/
 RUN chmod +x /usr/local/bin/setup-claude.sh /tmp/setup-claude-build.sh /tmp/install-skills.sh /usr/local/script/*.sh

--- a/.trivyignore
+++ b/.trivyignore
@@ -38,3 +38,16 @@ CVE-2024-24790
 # Expected resolution: Wait for Doppler to rebuild with patched Go version
 # Tracking: https://github.com/DopplerHQ/cli/issues (monitor for Go version update)
 CVE-2025-68121
+
+# Vercel CLI path-to-regexp vulnerability
+# @vercel/node@5.6.3 and @vercel/remix-builder@5.5.10 still depend on path-to-regexp@6.1.0
+# Vercel has started migration (added path-to-regexp-updated@6.3.0 alias) but hasn't removed the old dep
+
+# CVE-2024-45296: path-to-regexp: Backtracking regular expressions cause ReDoS
+# Severity: HIGH
+# Affected: path-to-regexp 6.1.0 (via @vercel/node, @vercel/remix-builder)
+# Fixed in: 6.3.0
+# Reason: Transitive dependency via Vercel CLI, cannot override without upstream fix
+# Expected resolution: Wait for Vercel to complete migration to path-to-regexp@6.3.0+
+# Tracking: https://github.com/vercel/vercel/issues
+CVE-2024-45296

--- a/npm/global.json
+++ b/npm/global.json
@@ -74,7 +74,7 @@
       "overridden": false
     },
     "vercel": {
-      "version": "50.15.1",
+      "version": "50.16.0",
       "overridden": false
     }
   }

--- a/script/lib/claude_plugins.sh
+++ b/script/lib/claude_plugins.sh
@@ -10,12 +10,15 @@ set -euo pipefail
 # Fallback marketplace list (synced with known_marketplaces.json.template)
 # Format: "name:repo" for GitHub repos, "name:url:https://..." for full URLs
 readonly PLUGINS_KNOWN_MARKETPLACES_FALLBACK=(
+    "agent-browser:vercel-labs/agent-browser"
     "anthropic-agent-skills:url:https://github.com/anthropics/skills.git"
     "claude-code-plugins:anthropics/claude-code"
     "claude-code-templates:url:https://github.com/davila7/claude-code-templates.git"
     "claude-code-workflows:wshobson/agents"
     "claude-plugins-official:anthropics/claude-plugins-official"
+    "intellectronica-skills:intellectronica/agent-skills"
     "playwright-skill:lackeyjb/playwright-skill"
+    "supabase-agent-skills:supabase/agent-skills"
 )
 
 # コマンド・エージェント・フックの同期


### PR DESCRIPTION
## Summary

- Docker ビルド時に全12プラグインが `claude: command not found` で失敗していた根本原因を修正
- `ENV PATH` 追加で claude CLI をビルド全体で利用可能に
- lib コピー先パスの不整合（`/tmp/script-lib` → `/tmp/script/lib`）を修正
- `install-claude-plugins.sh` をライブラリ関数利用にリファクタリング
- 3 マーケットプレイス追加（supabase, agent-browser, context7）でスキルと Plugin を併用管理

## Test plan

- [ ] `shellcheck -x script/install-claude-plugins.sh` が警告なしで通ること
- [ ] Docker ビルドログで `claude plugin marketplace add` が成功すること
- [ ] Docker ビルドログで全プラグインのインストールが成功すること
- [ ] CI が green であること

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added three new plugins and skills: postgres-best-practices, agent-browser, and context7 for enhanced functionality.

* **Improvements**
  * Enhanced plugin installation process with improved credential handling and structured logging.
  * Expanded development environment toolchain with additional system dependencies.

* **Chores**
  * Updated Vercel dependency to latest version.
  * Added security vulnerability ignores for path-to-regexp and related CVEs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->