### PR TITLE
docs: 新規プラグイン3つをドキュメントに追加

### DIFF
--- a/.claude/plugins/README.md
+++ b/.claude/plugins/README.md
@@ -102,9 +102,15 @@ make claude-plugins
 
 現在このリポジトリで管理されているマーケットプレイス：
 
-- **anthropics/claude-code** - 公式Claude Codeプラグイン
-- **davila7/claude-code-templates** - コミュニティテンプレート
-- **wshobson/agents** - ワークフロー自動化プラグイン
+- **anthropics/claude-code** (`claude-code-plugins`) - 公式Claude Codeプラグイン
+- **anthropics/claude-plugins-official** (`claude-plugins-official`) - 公式プラグイン（commit-commands, hookify, etc.）
+- **davila7/claude-code-templates** (`claude-code-templates`) - コミュニティテンプレート
+- **wshobson/agents** (`claude-code-workflows`) - ワークフロー自動化プラグイン
+- **supabase/agent-skills** (`supabase-agent-skills`) - Supabase/PostgreSQL開発ベストプラクティス
+- **vercel-labs/agent-browser** (`agent-browser`) - ブラウザ自動化（テスト、フォーム、スクリーンショット）
+- **intellectronica/agent-skills** (`intellectronica-skills`) - ライブラリ・フレームワークの最新ドキュメント
+- **anthropics/skills** (`anthropic-agent-skills`) - Anthropic公式スキル
+- **lackeyjb/playwright-skill** (`playwright-skill`) - Playwright自動化スキル
 
 ## 推奨プラグイン
 

--- a/README.md
+++ b/README.md
@@ -604,10 +604,13 @@ The repository includes a complete DevContainer setup (`.devcontainer/`) that pr
 
 **推奨**: `ghcr.io/keito4/config-base:latest`（常に最新の安定版）
 
-**Pre-installed Plugins** (v1.62.1):
+**Pre-installed Plugins**:
 
 - Official plugins: `commit-commands`, `hookify`, `plugin-dev`, `typescript-lsp`, `code-review`
 - Workflow plugins: `code-refactoring`, `kubernetes-operations`, `javascript-typescript`, `backend-development`, `full-stack-orchestration`, `database-design`, `database-migrations`
+- Supabase plugins: `postgres-best-practices`
+- Vercel plugins: `agent-browser`
+- Community plugins: `context7`
 
 **Recommended Usage**: For new projects, use the pre-built image without mounting host's `~/.claude` directory. This ensures the image configuration works immediately. See [docs/using-config-base-image.md](docs/using-config-base-image.md) for detailed usage instructions.
 


### PR DESCRIPTION
## Summary

PR #474 で追加された新規プラグイン・マーケットプレイス（3つ）をREADMEと.claude/plugins/README.mdに反映。

- supabase-agent-skills: PostgreSQL/Supabase開発のベストプラクティス
- agent-browser: ブラウザ自動化（テスト、フォーム、スクリーンショット）
- intellectronica-skills: ライブラリ・フレームワークの最新ドキュメント取得

Closes #475

🤖 Generated with [Claude Code](https://claude.ai/code)) | [View job run](https://github.com/keito4/config/actions/runs/22028643244) | [Branch: claude/issue-475-20260215-0301](https://github.com/keito4/config/tree/claude/issue-475-20260215-0301

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Documentation
- Added three new plugin categories: Supabase, Vercel, and Community
- Added DevContainer recommendation documentation for improved setup guidance
- Expanded marketplace listings with additional vendors and mapping aliases

<!-- end of auto-generated comment: release notes by coderabbit.ai -->