### PR TITLE
feat: DevContainerベースイメージに1Password CLI (op) を追加

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -31,6 +31,7 @@ RUN apt-get update && apt-get upgrade -y && apt-get install -y \
     python3-venv \
     python3-dev \
     apt-transport-https \
+    unzip \
  && apt-get clean \
  && rm -rf /var/lib/apt/lists/*
 
@@ -41,6 +42,17 @@ RUN DOPPLER_VERSION="3.75.2" \
  && curl -sLo /tmp/doppler.deb "https://github.com/DopplerHQ/cli/releases/download/${DOPPLER_VERSION}/doppler_${DOPPLER_VERSION}_linux_${ARCH}.deb" \
  && dpkg -i /tmp/doppler.deb \
  && rm /tmp/doppler.deb
+
+# Install 1Password CLI (op)
+# https://developer.1password.com/docs/cli/get-started/
+RUN OP_VERSION="2.32.1" \
+ && ARCH=$(dpkg --print-architecture) \
+ && curl -sSfo /tmp/op.zip "https://cache.agilebits.com/dist/1P/op2/pkg/v${OP_VERSION}/op_linux_${ARCH}_v${OP_VERSION}.zip" \
+ && unzip -od /usr/local/bin/ /tmp/op.zip \
+ && rm /tmp/op.zip \
+ && groupadd -f onepassword-cli \
+ && chown root:onepassword-cli /usr/local/bin/op \
+ && chmod g+s /usr/local/bin/op
 
 # Install Node.js
 RUN NODE_VERSION=v22.14.0 \


### PR DESCRIPTION
## Summary
- DevContainerベースイメージに1Password CLI v2.32.1を追加
- `op` コマンドがDevContainer環境で利用可能に
- マルチアーキテクチャ対応（amd64/arm64）

## Changes
- `unzip` パッケージを apt-get に追加
- 1Password CLI インストールセクションを追加

## Test plan
- [ ] DevContainerをビルドして `op --version` が動作することを確認
- [ ] Container Security Scan が通ることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added 1Password CLI integration to the development container environment, enabling credential management capabilities during development across multiple system architectures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->