### PR TITLE
fix: CLAUDE.md symlink の prettier 警告を解消

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -1,2 +1,5 @@
 # External packages
 .agents/skills/
+
+# Symlinks (git core.symlinks=false stores as text files)
+CLAUDE.md


### PR DESCRIPTION
## Summary

- `CLAUDE.md` が AGENTS.md への symlink に変更されたが、`core.symlinks=false` 環境ではテキストファイルとして扱われ prettier チェックが失敗する問題を修正
- `.prettierignore` に `CLAUDE.md` を追加して警告を解消

## Test plan

- [x] `npm run format:check` 通過
- [x] `npm run lint` 通過
- [x] `npm test` 通過（101 tests passed）
- [x] pre-commit hooks 全通過

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated development tooling configuration to exclude additional files from code formatting processes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->