### PR TITLE
chore: shellcheck 除外リストを外部ファイルに分離

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "lint:fix": "npm run lint -- --fix",
     "format": "prettier --write .",
     "format:check": "prettier --check .",
-    "shellcheck": "find script -name '*.sh' -type f | grep -v 'import.sh\\|export.sh\\|credentials.sh\\|brew-deps.sh\\|codespaces-secrets.sh\\|credentials/providers/\\|lib/config.sh\\|lib/devcontainer.sh\\|lib/output.sh\\|lib/platform.sh' | xargs -r shellcheck -x",
+    "shellcheck": "find script -name '*.sh' -type f | grep -vFf script/.shellcheck-exclude | xargs -r shellcheck -x",
     "test": "jest --runInBand",
     "test:integration": "bats test/integration/",
     "test:all": "npm test && npm run test:integration",

--- a/script/.shellcheck-exclude
+++ b/script/.shellcheck-exclude
@@ -1,0 +1,10 @@
+import.sh
+export.sh
+credentials.sh
+brew-deps.sh
+codespaces-secrets.sh
+credentials/providers/
+lib/config.sh
+lib/devcontainer.sh
+lib/output.sh
+lib/platform.sh


### PR DESCRIPTION
## Summary

- `package.json` の `shellcheck` スクリプトにハードコードされていた 10 個の `grep -v` 除外パターンを `script/.shellcheck-exclude` ファイルに外部化
- スクリプト値を `grep -vFf script/.shellcheck-exclude` に置き換え、保守性とレビュー性を改善
- 動作は変更前と同一（除外対象ファイルの追加・削除が外部ファイルの編集だけで完結するようになった）

## Changes

| ファイル | 変更内容 |
|---------|---------|
| `script/.shellcheck-exclude` | 新規: 除外パターン 10 行 |
| `package.json` | shellcheck スクリプトを `grep -vFf` 方式に変更 |

## Test plan

- [x] `npm run shellcheck` が変更前と同じ結果になることを確認
- [x] 全ユニットテスト（101件）がパス
- [x] Format / Lint / ShellCheck の Quality Gates がパス

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Refactored development tooling configuration to improve maintainability and streamline script exclusion management.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->