### PR TITLE
fix: set -e 互換性のあるシェル算術式に修正

### DIFF
--- a/script/branch-cleanup.sh
+++ b/script/branch-cleanup.sh
@@ -217,7 +217,7 @@ DELETED_COUNT=0
 for branch in "${MERGED_BRANCHES[@]}" "${STALE_BRANCHES[@]}"; do
   if git branch -D "$branch" > /dev/null 2>&1; then
     echo -e "  ${GREEN}✓${NC} Deleted $branch"
-    ((DELETED_COUNT++))
+    DELETED_COUNT=$((DELETED_COUNT + 1))
   else
     echo -e "  ${RED}✗${NC} Failed to delete $branch"
   fi

--- a/script/container-health.sh
+++ b/script/container-health.sh
@@ -84,7 +84,7 @@ check_tool() {
   else
     TOOL_STATUS["$tool"]="missing"
     if [ "$required" = true ]; then
-      ((HEALTH_SCORE -= 10)) || true
+      HEALTH_SCORE=$((HEALTH_SCORE - 10))
     fi
     return 1
   fi
@@ -130,7 +130,7 @@ if [ -z "$CHECK_COMPONENT" ] || [ "$CHECK_COMPONENT" = "tools" ]; then
     if [ "$JSON_OUTPUT" = false ]; then
       echo -e "  ${YELLOW}⚠${NC} claude (not installed)"
     fi
-    ((HEALTH_SCORE -= 5)) || true
+    HEALTH_SCORE=$((HEALTH_SCORE - 5))
     RECOMMENDATIONS+=("Install Claude Code: npm install -g @anthropic-ai/claude-code")
   fi
 
@@ -153,7 +153,7 @@ if [ -z "$CHECK_COMPONENT" ] || [ "$CHECK_COMPONENT" = "tools" ]; then
       if [ "$JSON_OUTPUT" = false ]; then
         echo -e "  ${YELLOW}⚠${NC} $tool (not in PATH)"
       fi
-      ((HEALTH_SCORE -= 2)) || true
+      HEALTH_SCORE=$((HEALTH_SCORE - 2))
     fi
   done
 
@@ -210,14 +210,14 @@ if [ -z "$CHECK_COMPONENT" ] || [ "$CHECK_COMPONENT" = "config" ]; then
       if [ "$JSON_OUTPUT" = false ]; then
         echo -e "  ${RED}✗${NC} package.json invalid JSON"
       fi
-      ((HEALTH_SCORE -= 10)) || true
+      HEALTH_SCORE=$((HEALTH_SCORE - 10))
     fi
   else
     CONFIG_STATUS["package.json"]="missing"
     if [ "$JSON_OUTPUT" = false ]; then
       echo -e "  ${YELLOW}⚠${NC} package.json not found"
     fi
-    ((HEALTH_SCORE -= 5)) || true
+    HEALTH_SCORE=$((HEALTH_SCORE - 5))
   fi
 
   # Git config
@@ -232,7 +232,7 @@ if [ -z "$CHECK_COMPONENT" ] || [ "$CHECK_COMPONENT" = "config" ]; then
       echo -e "  ${YELLOW}⚠${NC} git user not configured"
     fi
     RECOMMENDATIONS+=("Set git user: git config --global user.name 'Your Name'")
-    ((HEALTH_SCORE -= 5)) || true
+    HEALTH_SCORE=$((HEALTH_SCORE - 5))
   fi
 
   if git config user.email > /dev/null 2>&1; then
@@ -246,7 +246,7 @@ if [ -z "$CHECK_COMPONENT" ] || [ "$CHECK_COMPONENT" = "config" ]; then
       echo -e "  ${YELLOW}⚠${NC} git email not configured"
     fi
     RECOMMENDATIONS+=("Set git email: git config --global user.email 'you@example.com'")
-    ((HEALTH_SCORE -= 5)) || true
+    HEALTH_SCORE=$((HEALTH_SCORE - 5))
   fi
 
   if [ "$JSON_OUTPUT" = false ]; then
@@ -306,7 +306,7 @@ else
     i=1
     for rec in "${RECOMMENDATIONS[@]}"; do
       echo "  $i. $rec"
-      ((i++))
+      i=$((i + 1))
     done
     echo ""
   fi

--- a/script/security-credential-scan.sh
+++ b/script/security-credential-scan.sh
@@ -233,7 +233,7 @@ else
         echo "   Content: $content"
         echo -e "   ${RED}🔥 Action: Remove or move to environment variable${NC}"
         echo ""
-        ((i++))
+        i=$((i + 1))
       fi
     done
   fi
@@ -252,7 +252,7 @@ else
         echo "   Content: $content"
         echo -e "   ${YELLOW}ℹ️ Note: Review if this is intentional${NC}"
         echo ""
-        ((i++))
+        i=$((i + 1))
       fi
     done
   fi

--- a/script/setup-lsp.sh
+++ b/script/setup-lsp.sh
@@ -43,11 +43,11 @@ verify_command() {
 }
 
 errors=0
-verify_command "typescript-language-server" "TypeScript LSP" || ((errors++))
-verify_command "bash-language-server" "Bash LSP" || ((errors++))
-verify_command "yaml-language-server" "YAML LSP" || ((errors++))
-verify_command "vscode-json-language-server" "JSON LSP" || ((errors++))
-verify_command "tsc" "TypeScript Compiler" || ((errors++))
+verify_command "typescript-language-server" "TypeScript LSP" || errors=$((errors + 1))
+verify_command "bash-language-server" "Bash LSP" || errors=$((errors + 1))
+verify_command "yaml-language-server" "YAML LSP" || errors=$((errors + 1))
+verify_command "vscode-json-language-server" "JSON LSP" || errors=$((errors + 1))
+verify_command "tsc" "TypeScript Compiler" || errors=$((errors + 1))
 
 echo ""
 if [ $errors -eq 0 ]; then

--- a/script/test-coverage-trend.sh
+++ b/script/test-coverage-trend.sh
@@ -139,7 +139,7 @@ for file in "${HISTORY_FILES[@]}"; do
 
     if (( $(echo "$COV > 0" | bc -l) )); then
       TOTAL=$(echo "$TOTAL + $COV" | bc)
-      ((COUNT++))
+      COUNT=$((COUNT + 1))
 
       if (( $(echo "$COV < $MIN" | bc -l) )); then
         MIN=$COV


### PR DESCRIPTION
## Summary

- `(( var++ ))` や `(( var -= N ))` はbash算術式の評価結果が 0 のとき exit code 1 を返すため、`set -e` 環境下でスクリプトが予期せず異常終了するバグを修正
- POSIX安全な `var=$((var + 1))` / `var=$((var - N))` 形式に統一
- `|| true` ガードも不要になったため削除

## Changes

対象: 5スクリプト・17箇所

| ファイル | 箇所数 | 変更内容 |
|---|---|---|
| `script/security-credential-scan.sh` | 2 | `((i++))` → `i=$((i + 1))` |
| `script/container-health.sh` | 8 | `((HEALTH_SCORE -= N)) \|\| true` → `HEALTH_SCORE=$((HEALTH_SCORE - N))`, `((i++))` → `i=$((i + 1))` |
| `script/setup-lsp.sh` | 5 | `\|\| ((errors++))` → `\|\| errors=$((errors + 1))` |
| `script/test-coverage-trend.sh` | 1 | `((COUNT++))` → `COUNT=$((COUNT + 1))` |
| `script/branch-cleanup.sh` | 1 | `((DELETED_COUNT++))` → `DELETED_COUNT=$((DELETED_COUNT + 1))` |

## Background

bash の `(( expr ))` は算術式を評価し、結果が0の場合にexit code 1を返します。例えば `((i++))` は `i` が0のとき（インクリメント前の値が0）exit code 1となり、`set -e` が有効なスクリプトでは即座に終了してしまいます。`var=$((expr))` 形式は代入文のため常にexit code 0を返し、この問題を回避できます。

## Test plan

- [x] `bash script/security-credential-scan.sh --help` 正常動作確認
- [x] `bash script/container-health.sh --json` 正常動作確認（score: 96）
- [x] `bash script/test-coverage-trend.sh --help` 正常動作確認
- [x] ShellCheck パス
- [x] 全ユニットテスト パス

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Refactor**
  * Updated shell script syntax for improved compatibility across different shell environments. All scripts maintain existing functionality with no changes to user-facing behavior or features.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->