### PR TITLE
fix: GitHub Actions のバージョンを更新

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -135,7 +135,7 @@ jobs:
           JEST_JUNIT_OUTPUT_NAME: junit.xml
 
       - name: Upload test results
-        uses: actions/upload-artifact@v6.0.0
+        uses: actions/upload-artifact@v7.0.0
         if: always()
         with:
           name: test-results
@@ -189,7 +189,7 @@ jobs:
           bats test/integration/*.bats --formatter tap > reports/bats-results.tap
 
       - name: Upload integration test results
-        uses: actions/upload-artifact@v6.0.0
+        uses: actions/upload-artifact@v7.0.0
         if: always()
         with:
           name: integration-test-results

--- a/.github/workflows/container-security.yml
+++ b/.github/workflows/container-security.yml
@@ -134,14 +134,14 @@ jobs:
           cache-from: type=registry,ref=ghcr.io/${{ github.repository_owner }}/config-base:cache
 
       - name: Generate SBOM with Syft
-        uses: anchore/sbom-action@v0.22.2
+        uses: anchore/sbom-action@v0.23.0
         with:
           image: config-base:sbom
           artifact-name: sbom.spdx.json
           output-file: sbom.spdx.json
 
       - name: Upload SBOM artifact
-        uses: actions/upload-artifact@v6.0.0
+        uses: actions/upload-artifact@v7.0.0
         with:
           name: sbom
           path: sbom.spdx.json

--- a/.github/workflows/coverage-report.yml
+++ b/.github/workflows/coverage-report.yml
@@ -63,7 +63,7 @@ jobs:
           fetch-depth: 0
 
       - name: Download coverage artifact
-        uses: actions/download-artifact@v7.0.0
+        uses: actions/download-artifact@v8.0.0
         with:
           name: ${{ inputs.artifact-name }}
           path: coverage-download
@@ -86,7 +86,7 @@ jobs:
         uses: actions/checkout@v6.0.2
 
       - name: Download coverage artifact
-        uses: actions/download-artifact@v7.0.0
+        uses: actions/download-artifact@v8.0.0
         with:
           name: ${{ inputs.artifact-name }}
           path: coverage-download
@@ -167,7 +167,7 @@ jobs:
         uses: actions/checkout@v6.0.2
 
       - name: Download coverage artifact
-        uses: actions/download-artifact@v7.0.0
+        uses: actions/download-artifact@v8.0.0
         with:
           name: ${{ inputs.artifact-name }}
           path: coverage-download
@@ -200,7 +200,7 @@ jobs:
         uses: actions/checkout@v6.0.2
 
       - name: Download coverage artifact
-        uses: actions/download-artifact@v7.0.0
+        uses: actions/download-artifact@v8.0.0
         with:
           name: ${{ inputs.artifact-name }}
           path: coverage-download

--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -187,7 +187,7 @@ jobs:
         run: |
           docker run --rm -v "$PWD":/workspace -w /workspace ghcr.io/${{ github.repository_owner }}/config-base:latest bash -lc '{ brew --version; terraform --version; jq --version; } > devcontainer-info.txt'
 
-      - uses: actions/upload-artifact@v6.0.0
+      - uses: actions/upload-artifact@v7.0.0
         if: steps.release.outputs.skip_release != 'true'
         with:
           name: devcontainer-info

--- a/.github/workflows/templates/tls-evidence.yml
+++ b/.github/workflows/templates/tls-evidence.yml
@@ -133,7 +133,7 @@ jobs:
             | tee -a cert_expiry.txt || true
 
       - name: Upload TLS Evidence
-        uses: actions/upload-artifact@v6.0.0
+        uses: actions/upload-artifact@v7.0.0
         with:
           name: tls-evidence-${{ github.run_number }}
           path: |

--- a/.github/workflows/templates/unified-ci.yml
+++ b/.github/workflows/templates/unified-ci.yml
@@ -103,7 +103,7 @@ jobs:
 
       - name: Upload coverage artifact
         if: github.event_name == 'pull_request' && hashFiles('coverage/coverage-summary.json') != ''
-        uses: actions/upload-artifact@v6.0.0
+        uses: actions/upload-artifact@v7.0.0
         with:
           name: coverage-report
           path: coverage/coverage-summary.json

--- a/.github/workflows/templates/zap-baseline.yml
+++ b/.github/workflows/templates/zap-baseline.yml
@@ -104,7 +104,7 @@ jobs:
 
       - name: Upload HTML Report
         if: always()
-        uses: actions/upload-artifact@v6.0.0
+        uses: actions/upload-artifact@v7.0.0
         with:
           name: zap-report-html
           path: report_html.html
@@ -112,7 +112,7 @@ jobs:
 
       - name: Upload JSON Report
         if: always()
-        uses: actions/upload-artifact@v6.0.0
+        uses: actions/upload-artifact@v7.0.0
         with:
           name: zap-report-json
           path: report_json.json


### PR DESCRIPTION
## Summary
- `actions/upload-artifact`: v6.0.0 → v7.0.0
- `actions/download-artifact`: v7.0.0 → v8.0.0
- `anchore/sbom-action`: v0.22.2 → v0.23.0

7ファイルのワークフロー定義を更新。

## Test plan
- [x] `npm run lint` パス
- [x] `npm test` 全101テストパス
- [x] `npm run format:check` パス
- [ ] CI ワークフローが正常に動作すること

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated GitHub Actions workflow dependencies to newer versions across multiple CI/CD pipelines for improved compatibility and reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->