### PR TITLE
feat: difit をデフォルトインストールに追加

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -101,13 +101,15 @@ RUN CODEX_VERSION=$(node -pe "require('/tmp/npm-global.json').dependencies['@ope
  && VERCEL_VERSION=$(node -pe "require('/tmp/npm-global.json').dependencies['vercel'].version") \
  && GEMINI_CLI_VERSION=$(node -pe "require('/tmp/npm-global.json').dependencies['@google/gemini-cli'].version") \
  && HAPPY_CODER_VERSION=$(node -pe "require('/tmp/npm-global.json').dependencies['happy-coder'].version") \
+ && DIFIT_VERSION=$(node -pe "require('/tmp/npm-global.json').dependencies['difit'].version") \
  && npm install -g eslint \
     typescript \
     typescript-language-server \
     @openai/codex@${CODEX_VERSION} \
     vercel@${VERCEL_VERSION} \
     @google/gemini-cli@${GEMINI_CLI_VERSION} \
-    happy-coder@${HAPPY_CODER_VERSION}
+    happy-coder@${HAPPY_CODER_VERSION} \
+    difit@${DIFIT_VERSION}
 
 USER vscode
 RUN bash -lc "cargo install similarity-ts" || true \

--- a/npm/global.json
+++ b/npm/global.json
@@ -53,6 +53,10 @@
       "version": "0.34.6",
       "overridden": false
     },
+    "difit": {
+      "version": "3.1.12",
+      "overridden": false
+    },
     "mcp-remote": {
       "version": "0.1.38",
       "overridden": false


### PR DESCRIPTION
## Summary
- Git diff を GitHub ライクな Files changed ビューで表示する CLI ツール [difit](https://github.com/yoshiko-pg/difit) v3.1.12 をデフォルトインストールに追加
- `npm/global.json` にバージョン管理エントリを追加
- `.devcontainer/Dockerfile` のグローバル npm インストールに追加

## Test plan
- [ ] DevContainer ビルドが正常に完了すること
- [ ] `difit --version` で 3.1.12 が返ること
- [ ] 既存のグローバルパッケージに影響がないこと

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added `difit` (v3.1.12) as a global development dependency, automatically installed during environment setup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->