### PR TITLE
docs: Biome の noConsole ルールを推奨設定に追加

### DIFF
--- a/docs/setup/web-app-nextjs.md
+++ b/docs/setup/web-app-nextjs.md
@@ -81,7 +81,15 @@ npx @biomejs/biome init
   },
   "linter": {
     "rules": {
-      "recommended": true
+      "recommended": true,
+      "suspicious": {
+        "noConsole": {
+          "level": "error",
+          "options": {
+            "allow": ["error", "warn"]
+          }
+        }
+      }
     }
   },
   "files": {
@@ -89,6 +97,9 @@ npx @biomejs/biome init
   }
 }
 ```
+
+> `noConsole` は `console.log` / `console.debug` をエラーにし、`console.error` / `console.warn` は許可する。
+> ログ出力は `@vercel/logger`、エラー通知は Sentry に統一する。
 
 **推奨スクリプト**:
 
@@ -358,7 +369,7 @@ export async function GET() {
 
 - `@vercel/logger` で操作ログを記録し、Vercel Dashboard で確認
 - 例外・エラーは Sentry に `captureException` してアラートを受け取る
-- `console.log` の本番利用は禁止（`@vercel/logger` または Sentry に置き換える）
+- `console.log` の本番利用は禁止 → Biome の `noConsole` ルールで CI がブロック
 
 ## 関連ドキュメント
 


### PR DESCRIPTION
## 概要

Next.js プロジェクトの推奨 `biome.json` に `suspicious.noConsole` ルールを追加します。

## 変更内容

- `biome.json` 推奨設定に `suspicious.noConsole` を追記
  - `console.log` / `console.debug` → `error`（CI でブロック）
  - `console.error` / `console.warn` → 許可
- ロギング設計指針の原則を「Biome で CI がブロック」に更新

## 背景

- ログ出力は `@vercel/logger`、エラー通知は Sentry に統一する方針（前 PR #525 で追加）
- `console.log` の混入を lint レベルで機械的に防ぐ

## テスト

- ✅ Format Check: 通過
- ✅ Lint: 通過
- ✅ Test: 101 tests 通過

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Documentation**
  * Updated web app setup documentation to reflect console logging restrictions enforced in CI.
  * Documented the noConsole rule that restricts console.log and console.debug while allowing console.error and console.warn.
  * Added guidance on recommended logging approaches.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->