### PR TITLE
fix: setup-huskyのcheck-file-lengthパスをscripts/からscript/に統一

### DIFF
--- a/.claude/commands/setup-husky.md
+++ b/.claude/commands/setup-husky.md
@@ -16,18 +16,18 @@ Husky + lint-staged + commitlint + file-length 最小構成
 npm i -D husky lint-staged @commitlint/cli @commitlint/config-conventional
 npm pkg set scripts.prepare="husky"
 npm run prepare
-npx husky add .husky/pre-commit "npx lint-staged && bash scripts/check-file-length.sh"
+npx husky add .husky/pre-commit "npx lint-staged && bash script/check-file-length.sh"
 npx husky add .husky/commit-msg "npx commitlint --edit \$1"
 npx husky add .husky/pre-push "npm --prefix next run type-check && npm --prefix next run test:ci"
 
 # ファイル行数チェックの設定
 
-mkdir -p scripts
+mkdir -p script
 
 # DevContainer 環境の場合
 
 if [ -f /usr/local/script/check-file-length.sh ]; then
-cp /usr/local/script/check-file-length.sh scripts/
+cp /usr/local/script/check-file-length.sh script/
 fi
 
 # テンプレートから .filelengthignore をコピー
@@ -136,7 +136,7 @@ Husky の再初期化
 
 rm -rf .husky
 npm run prepare
-npx husky add .husky/pre-commit "npx lint-staged && bash scripts/check-file-length.sh"
+npx husky add .husky/pre-commit "npx lint-staged && bash script/check-file-length.sh"
 npx husky add .husky/commit-msg "npx commitlint --edit \$1"
 npx husky add .husky/pre-push "npm --prefix next run type-check && npm --prefix next run test:ci"
 


### PR DESCRIPTION
## Summary

- `setup-husky.md` 内の `scripts/`（複数形）を `script/`（単数形）に統一
- `repo-maintenance` および各リポジトリへの実際の追加で使用している `script/` に合わせた修正

## 変更箇所

- L19: `bash scripts/check-file-length.sh` → `bash script/check-file-length.sh`
- L25: `mkdir -p scripts` → `mkdir -p script`
- L30: `cp ... scripts/` → `cp ... script/`
- L139: `bash scripts/check-file-length.sh` → `bash script/check-file-length.sh`

## Test plan

- [ ] `/setup-husky` 実行時に `script/check-file-length.sh` が正しいパスに配置されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Updated project setup process to automatically configure file-length checking parameters during initialization.
  * Reorganized build and check script directory structure for improved consistency across development environments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->