### PR TITLE
feat: repo-maintenanceにhooksPath破損検出・修正ステップを追加

### DIFF
--- a/.claude/commands/repo-maintenance.md
+++ b/.claude/commands/repo-maintenance.md
@@ -308,7 +308,56 @@ Git hooks（pre-commit）の設定状況を確認：
 - ⚠️ Husky 未設定 → セットアップを提案
 - 📝 設定内容: pre-commit, commit-msg
 
-### 3.2.1 Check-file-length Setup Check
+### 3.2.1 Husky hooksPath Validation
+
+`core.hooksPath` が正常な値かどうか確認・修正：
+
+**確認ロジック:**
+
+```bash
+HOOKS_PATH=$(git config core.hooksPath 2>/dev/null || echo "")
+VALID_PATHS=(".husky" ".husky/_")
+
+is_valid=false
+for valid in "${VALID_PATHS[@]}"; do
+  [ "$HOOKS_PATH" = "$valid" ] && is_valid=true && break
+done
+```
+
+**結果パターン:**
+
+| 状態                       | 対応                            |
+| -------------------------- | ------------------------------- |
+| `.husky` または `.husky/_` | ✅ 正常                         |
+| 空（未設定）               | ✅ デフォルト動作のためスキップ |
+| それ以外（壊れたパス）     | ⚠️ → full mode で自動修正       |
+
+**壊れたパスの例（実際に発生したケース）:**
+
+- `--version/_` → git が `sh --version/_/pre-commit` を実行しフックが一切動作しない
+
+**MODE が `full` かつ修正が必要な場合:**
+
+```bash
+echo "⚠️ core.hooksPath が不正です: '$HOOKS_PATH'"
+
+# .husky/ が存在すれば .husky に修正
+if [ -d ".husky" ]; then
+  git config core.hooksPath ".husky"
+  echo "🔧 core.hooksPath を '.husky' に修正しました"
+else
+  echo "❌ .husky ディレクトリが存在しないため自動修正できません"
+fi
+```
+
+**結果:**
+
+- ✅ core.hooksPath が正常（`.husky` または `.husky/_`）
+- ✅ core.hooksPath 未設定（デフォルト動作）
+- 🔧 core.hooksPath を修正しました（壊れたパス → `.husky`）
+- ❌ .husky ディレクトリ不在のため手動対応が必要
+
+### 3.2.2 Check-file-length Setup Check
 
 pre-commit フックに `check-file-length` が含まれているか確認・追加：
 
@@ -646,7 +695,7 @@ npm install -D @biomejs/biome knip
 
 ## Setup (2/4)
 ├── Team Protection: ✅ Branch protection enabled
-├── Husky: ✅ Git hooks configured
+├── Husky: ✅ Git hooks configured\n├── hooksPath: ✅ Valid (.husky) (or 🔧 Fixed / ❌ Manual required)
 ├── check-file-length: ✅ Configured in pre-commit (or 🔧 Added / ⏭️ Skipped)
 ├── Pre-PR Checklist: ✅ CI workflow exists
 ├── CLAUDE.md: ✅ Symlink to AGENTS.md


### PR DESCRIPTION
## Summary

- Step 3.2.1 として `core.hooksPath` の破損を検出・自動修正するステップを追加
- 有効値（`.husky` / `.husky/_` / 未設定）以外の場合に `full` モードで自動修正
- サマリーレポートに `hooksPath` 項目を追加

## 背景

`OYKOT-jp/nomad_japan` で `core.hooksPath = --version/_` という破損が発生。  
git が `sh --version/_/pre-commit` を実行しようとしてフックが一切動作しない状態になっていた実例に基づく対応。

## Test plan

- [ ] 正常なリポジトリで `✅ 正常` と表示されることを確認
- [ ] `core.hooksPath` に不正値を設定したリポジトリで `🔧 修正` が実行されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Enhanced repository maintenance documentation with improved Git hooks validation workflow, including detailed Husky hooksPath configuration checks and clearer status reporting for hook configuration integrity verification with auto-fix and manual correction guidance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->