### PR TITLE
feat: Quality Gates に ni・Biome 対応、setup-husky に .editorconfig 生成を追加

### DIFF
--- a/.claude/commands/repo-maintenance.md
+++ b/.claude/commands/repo-maintenance.md
@@ -747,6 +747,7 @@ check_script() {
 }
 
 check_script "test"        "test" "test:unit"
+# Biome プロジェクトは "check" スクリプトで lint + format を統合する場合がある
 check_script "lint"        "lint" "lint:check"
 check_script "format:check" "format:check"
 check_script "typecheck"   "typecheck" "type-check" "tsc"

--- a/.claude/commands/setup-husky.md
+++ b/.claude/commands/setup-husky.md
@@ -36,6 +36,28 @@ if [ -f /usr/local/share/config-templates/.filelengthignore.template ]; then
 cp /usr/local/share/config-templates/.filelengthignore.template .filelengthignore
 fi
 
+# .editorconfig がなければ生成
+
+if [ ! -f .editorconfig ]; then
+cat > .editorconfig << 'EOF'
+root = true
+
+[*]
+indent_style = space
+indent_size = 2
+end_of_line = lf
+charset = utf-8
+trim_trailing_whitespace = true
+insert_final_newline = true
+
+[*.md]
+trim_trailing_whitespace = false
+
+[Makefile]
+indent_style = tab
+EOF
+fi
+
 ⸻
 
 必要な npm scripts（next/package.json）

--- a/.claude/hooks/pre_git_quality_gates.py
+++ b/.claude/hooks/pre_git_quality_gates.py
@@ -3,11 +3,12 @@
 グローバル Quality Gates: git commit/push 前にローカル CI チェックを実行
 
 リポジトリの package.json を解析し、利用可能なチェックを自動検出して実行する。
-npm / pnpm / yarn / bun に対応。
+npm / pnpm / yarn / bun / ni に対応。Biome による統合チェックにも対応。
 """
 import sys
 import json
 import shlex
+import shutil
 import subprocess
 import os
 from pathlib import Path
@@ -50,7 +51,10 @@ if not repo_root:
 
 
 def detect_package_manager(root: str) -> str:
-    """パッケージマネージャーを検出"""
+    """パッケージマネージャーを検出。ni が利用可能な場合は優先使用"""
+    # ni (antfu/ni) がインストール済みの場合は優先使用（nr = ni's run command）
+    if shutil.which("nr"):
+        return "ni"
     if (Path(root) / "bun.lockb").exists() or (Path(root) / "bun.lock").exists():
         return "bun"
     if (Path(root) / "pnpm-lock.yaml").exists():
@@ -58,6 +62,29 @@ def detect_package_manager(root: str) -> str:
     if (Path(root) / "yarn.lock").exists():
         return "yarn"
     return "npm"
+
+
+def build_run_command(pm: str, script_name: str) -> list:
+    """パッケージマネージャーに応じたスクリプト実行コマンドを生成"""
+    if pm == "ni":
+        return ["nr", script_name]  # nr = ni run
+    return [pm, "run", script_name]
+
+
+def has_biome(root: str) -> bool:
+    """Biome が導入されているか確認"""
+    if (Path(root) / "biome.json").exists() or (Path(root) / "biome.jsonc").exists():
+        return True
+    pkg_path = Path(root) / "package.json"
+    if pkg_path.exists():
+        try:
+            with open(pkg_path) as f:
+                pkg = json.load(f)
+            all_deps = {**pkg.get("dependencies", {}), **pkg.get("devDependencies", {})}
+            return "@biomejs/biome" in all_deps
+        except Exception:
+            pass
+    return False
 
 
 def get_package_scripts(root: str) -> dict:
@@ -131,10 +158,25 @@ for candidate in CHECK_CANDIDATES:
         if script_name in scripts:
             checks.append({
                 "name": candidate["label"],
-                "command": [pm, "run", script_name],
+                "command": build_run_command(pm, script_name),
                 "description": candidate["description"],
             })
             break  # 最初にマッチしたスクリプトを使用
+
+# Biome 対応: biome.json があるが package.json scripts に lint/format:check が定義されていない場合
+# node_modules/.bin/biome を直接実行してカバー
+if has_biome(repo_root):
+    has_lint_check = any(
+        c["name"] in ("Lint", "Format Check") for c in checks
+    )
+    if not has_lint_check:
+        biome_bin = Path(repo_root) / "node_modules" / ".bin" / "biome"
+        if biome_bin.exists():
+            checks.insert(0, {
+                "name": "Biome Check (lint + format)",
+                "command": [str(biome_bin), "check", "."],
+                "description": "Biome による lint + format 統合チェック",
+            })
 
 # スクリプトベースのチェック（リポジトリに存在する場合のみ）
 SCRIPT_CHECKS = [


### PR DESCRIPTION
## 概要

3 つの改善をまとめて実装しました。

## 1. `pre_git_quality_gates.py` — ni（antfu/ni）対応

**変更前**: bun/pnpm/yarn/npm のロックファイルからパッケージマネージャーを検出

**変更後**: `nr`（ni の run コマンド）が PATH にある場合は優先使用

```python
# nr が利用可能な場合は ni を優先
if shutil.which("nr"):
    return "ni"
```

`build_run_command()` ヘルパーを追加し、ni の場合は `["nr", script_name]` を使用します。

## 2. `pre_git_quality_gates.py` — Biome 対応

**問題**: Biome を使うプロジェクトは `lint` / `format:check` スクリプトを持たない場合がある

**対応**:
- `has_biome()` ヘルパーを追加（`biome.json` の存在 または `@biomejs/biome` が deps に含まれるか確認）
- `lint` / `format:check` が scripts に定義されていない Biome プロジェクトに対して、`node_modules/.bin/biome check .` を自動検出・実行

```python
if has_biome(repo_root):
    has_lint_check = any(c["name"] in ("Lint", "Format Check") for c in checks)
    if not has_lint_check:
        biome_bin = Path(repo_root) / "node_modules" / ".bin" / "biome"
        if biome_bin.exists():
            checks.insert(0, {"name": "Biome Check (lint + format)", ...})
```

## 3. `setup-husky.md` — .editorconfig 自動生成

`/setup-husky` 実行時に `.editorconfig` が存在しない場合、標準テンプレートを自動生成：

```ini
root = true

[*]
indent_style = space
indent_size = 2
end_of_line = lf
charset = utf-8
trim_trailing_whitespace = true
insert_final_newline = true

[*.md]
trim_trailing_whitespace = false

[Makefile]
indent_style = tab
```

`repo-maintenance` Step 3.8（.editorconfig チェック）との整合性が取れました。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for `ni` package manager detection in quality gate workflows.
  * Implemented automatic `.editorconfig` file generation during repository setup when missing.
  * Enhanced Biome integration with automatic fallback checks for linting and formatting.

* **Chores**
  * Updated documentation with notes on Biome consolidation capabilities.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->