### PR TITLE
feat: PR作成後のCI自動監視フックを追加

### DIFF
--- a/.claude/commands/repo-maintenance.md
+++ b/.claude/commands/repo-maintenance.md
@@ -1082,6 +1082,51 @@ EOF
 )"
 ```
 
+## Step 7.5: CI Monitoring (Automatic)
+
+PR作成後、自動的にCIステータスを監視します。
+
+### 自動監視の仕組み
+
+`.claude/hooks/post_pr_ci_watch.py` フックにより、`gh pr create` 実行後に自動的にCIを監視:
+
+1. PR作成成功を検出
+2. CIチェック状態を15秒ごとにポーリング
+3. 最大10分間監視
+4. 結果を報告
+
+### 監視結果
+
+| 状態           | 出力                           | 対応                              |
+| -------------- | ------------------------------ | --------------------------------- |
+| 全チェック成功 | ✅ 全CIチェック成功！          | マージ可能                        |
+| チェック失敗   | ❌ CIチェック失敗 + 失敗リスト | このブランチで修正                |
+| タイムアウト   | ⏰ CI監視タイムアウト          | `gh pr checks --watch` で手動確認 |
+| チェックなし   | ⚠️ CIチェックが見つかりません  | CI未設定の可能性                  |
+
+### 手動確認コマンド
+
+```bash
+# CIステータスを確認
+gh pr checks
+
+# リアルタイム監視
+gh pr checks --watch
+
+# 失敗したチェックの詳細
+gh run view <run-id> --log-failed
+```
+
+### CI失敗時の対応
+
+1. 失敗したチェックを特定
+2. このブランチで修正
+3. コミット＆プッシュ
+4. CIが再実行されることを確認
+5. CIが緑になるまで繰り返す
+
+**原則**: CIが緑になるまでPRを放置しない
+
 ## Step 8: Final Report
 
 ```
@@ -1162,3 +1207,4 @@ Run this command regularly to maintain repository health:
 | Cleanup     | `/branch-cleanup`               | ブランチクリーンアップ        |
 | Discovery   | `/config-contribution-discover` | 新機能発見                    |
 | Discovery   | (Package Audit + ni support)    | 推奨パッケージ監査            |
+| PR          | (post_pr_ci_watch.py hook)      | PR作成後のCI自動監視          |

--- a/.claude/hooks/README.md
+++ b/.claude/hooks/README.md
@@ -246,7 +246,47 @@ result = subprocess.run(
 }
 ```
 
-### 5. `pre_exit_plan_ai_review.py`
+### 5. `post_pr_ci_watch.py`
+
+**目的**: PR作成後にGitHub Actions CIの状態を監視し、結果を報告
+
+**トリガー**: `PostToolUse(Bash)` で `gh pr create` の成功を検出
+
+**動作**:
+
+- `gh pr create` 成功後に自動実行
+- PRのCIチェック状態を15秒ごとにポーリング
+- 最大10分間監視
+- 全チェック完了または失敗を検出したら報告
+- 失敗時は修正を促すメッセージを表示
+- ブロックはしない（結果を表示のみ）
+
+**前提条件**:
+
+- GitHub CLI (`gh`) がインストール済み
+- GitHub Actions ワークフローが設定済み
+
+**設定例**:
+
+```json
+{
+  "hooks": {
+    "PostToolUse": [
+      {
+        "matcher": "tool_name == 'Bash'",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "python3 .claude/hooks/post_pr_ci_watch.py"
+          }
+        ]
+      }
+    ]
+  }
+}
+```
+
+### 6. `pre_exit_plan_ai_review.py`
 
 **目的**: プラン作成後、ExitPlanMode実行前にAI（Codex + Gemini）によるプランレビューを実行
 

--- a/.claude/hooks/post_pr_ci_watch.py
+++ b/.claude/hooks/post_pr_ci_watch.py
@@ -1,0 +1,147 @@
+#!/usr/bin/env python3
+"""
+PR作成後にGitHub Actions CIを監視するPostToolUseフック
+
+gh pr create 成功後に自動的にCIの状態を監視し、結果を報告します。
+CI完了まで待機（最大10分）し、失敗時は修正を促します。
+"""
+import sys
+import json
+import subprocess
+import re
+import time
+
+# Read input from Claude
+data = json.load(sys.stdin)
+
+tool_name = data.get("tool_name", "")
+tool_input = data.get("tool_input", {}) or {}
+tool_response = data.get("tool_response", {}) or {}
+
+# Bashツールでない場合はスキップ
+if tool_name != "Bash":
+    sys.exit(0)
+
+# コマンドを取得
+command = tool_input.get("command", "").strip()
+
+# gh pr create コマンドかどうかを判定
+if not command.startswith("gh pr create"):
+    sys.exit(0)
+
+# ヘルプコマンドは除外
+if "--help" in command or "-h" in command:
+    sys.exit(0)
+
+# ツール実行が成功したかチェック
+stdout = tool_response.get("stdout", "")
+stderr = tool_response.get("stderr", "")
+
+# PR URLパターン
+pr_url_pattern = r"https://github\.com/([^/]+)/([^/]+)/pull/(\d+)"
+combined_output = stdout + stderr
+
+# PR URLを抽出
+pr_url_match = re.search(pr_url_pattern, combined_output)
+if not pr_url_match:
+    sys.exit(0)
+
+pr_url = pr_url_match.group(0)
+pr_number = pr_url_match.group(3)
+
+print("", file=sys.stderr, flush=True)
+print("=" * 60, file=sys.stderr, flush=True)
+print("🔄 PR作成完了。CIステータスを監視中...", file=sys.stderr, flush=True)
+print(f"📎 PR: {pr_url}", file=sys.stderr, flush=True)
+print("=" * 60, file=sys.stderr, flush=True)
+
+
+def get_pr_checks(pr_number: str, timeout_seconds: int = 600):
+    """PRのCIチェック状態を監視（最大10分）"""
+    start_time = time.time()
+    check_interval = 15  # 15秒ごとにチェック
+    last_status = None
+
+    while time.time() - start_time < timeout_seconds:
+        try:
+            result = subprocess.run(
+                ["gh", "pr", "checks", pr_number, "--json", "name,state,conclusion"],
+                capture_output=True,
+                text=True,
+                timeout=30
+            )
+
+            if result.returncode != 0:
+                # チェックがまだ登録されていない場合は待機
+                elapsed = int(time.time() - start_time)
+                if elapsed < 30:
+                    print(f"   ⏳ CIチェック待機中... ({elapsed}秒)", file=sys.stderr, flush=True)
+                    time.sleep(check_interval)
+                    continue
+                return "no_checks", []
+
+            checks = json.loads(result.stdout)
+            if not checks:
+                elapsed = int(time.time() - start_time)
+                if elapsed < 30:
+                    print(f"   ⏳ CIチェック待機中... ({elapsed}秒)", file=sys.stderr, flush=True)
+                    time.sleep(check_interval)
+                    continue
+                return "no_checks", []
+
+            # チェック状態を集計
+            pending = [c for c in checks if c.get("state") == "PENDING"]
+            in_progress = [c for c in checks if c.get("state") == "IN_PROGRESS"]
+            completed = [c for c in checks if c.get("state") == "SUCCESS" or c.get("state") == "FAILURE" or c.get("state") == "SKIPPED"]
+            failed = [c for c in checks if c.get("conclusion") == "FAILURE" or c.get("state") == "FAILURE"]
+
+            total = len(checks)
+            done = len(completed)
+
+            # 状態が変わったときだけ表示
+            current_status = f"{done}/{total}"
+            if current_status != last_status:
+                elapsed = int(time.time() - start_time)
+                print(f"   ⏳ {elapsed}秒経過... ({done}/{total} 完了)", file=sys.stderr, flush=True)
+                last_status = current_status
+
+            # 全て完了した場合
+            if done == total:
+                if failed:
+                    return "failure", failed
+                return "success", checks
+
+            time.sleep(check_interval)
+
+        except Exception as e:
+            print(f"⚠️  監視エラー: {e}", file=sys.stderr, flush=True)
+            break
+
+    return "timeout", []
+
+
+# CI監視を実行
+print("\n🔄 CI実行を監視中... (最大10分)", file=sys.stderr, flush=True)
+conclusion, checks = get_pr_checks(pr_number)
+
+if conclusion == "success":
+    print("\n✅ 全CIチェック成功！", file=sys.stderr, flush=True)
+elif conclusion == "failure":
+    print("\n❌ CIチェック失敗", file=sys.stderr, flush=True)
+    print("\n失敗したチェック:", file=sys.stderr, flush=True)
+    for check in checks:
+        print(f"   - {check.get('name', 'Unknown')}", file=sys.stderr, flush=True)
+    print(f"\n詳細: gh pr checks {pr_number}", file=sys.stderr, flush=True)
+    print("\n⚠️  CI修正が必要です。このブランチで修正してください。", file=sys.stderr, flush=True)
+elif conclusion == "timeout":
+    print("\n⏰ CI監視タイムアウト（まだ実行中）", file=sys.stderr, flush=True)
+    print(f"   詳細: gh pr checks {pr_number} --watch", file=sys.stderr, flush=True)
+elif conclusion == "no_checks":
+    print("\n⚠️  CIチェックが見つかりません", file=sys.stderr, flush=True)
+    print("   （CI未設定、またはワークフロー起動中の可能性があります）", file=sys.stderr, flush=True)
+
+print("", file=sys.stderr, flush=True)
+print("=" * 60, file=sys.stderr, flush=True)
+
+# PostToolUseフックは常に成功で終了（ブロックしない）
+sys.exit(0)

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -214,6 +214,15 @@
             "command": "bash -c 'cd \"$(git rev-parse --show-toplevel 2>/dev/null || echo .)\" && python3 .claude/hooks/post_pr_ai_review.py'"
           }
         ]
+      },
+      {
+        "matcher": "Bash",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "bash -c 'cd \"$(git rev-parse --show-toplevel 2>/dev/null || echo .)\" && python3 .claude/hooks/post_pr_ci_watch.py'"
+          }
+        ]
       }
     ]
   },


### PR DESCRIPTION
## Summary
- PR作成後（`gh pr create`）に自動的にCIステータスを監視する機能を追加
- 新しいフック `post_pr_ci_watch.py` がCI完了まで最大10分間監視
- 成功/失敗/タイムアウトを報告

## Changes
- `.claude/hooks/post_pr_ci_watch.py`: 新しい PostToolUse フック
- `.claude/settings.json`: フック登録を追加
- `.claude/commands/repo-maintenance.md`: Step 7.5 に CI 監視のドキュメントを追加
- `.claude/hooks/README.md`: フックのドキュメントを追加

## 動作仕様
1. `gh pr create` 成功を検出
2. PRのCIチェック状態を15秒ごとにポーリング
3. 最大10分間監視
4. 結果を報告:
   - ✅ 全CIチェック成功！
   - ❌ CIチェック失敗（失敗リスト付き）
   - ⏰ CI監視タイムアウト
   - ⚠️ CIチェックが見つかりません

## Test plan
- [ ] PR作成後にCI監視が自動実行されること
- [ ] CIの成功/失敗が正しく報告されること

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Automatic CI status monitoring now runs after pull request creation, polling results every 15 seconds for up to 10 minutes without blocking the workflow.

* **Documentation**
  * Enhanced documentation with CI monitoring workflow and configuration details.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->