### PR TITLE
fix: repo-maintenance 定期メンテナンス 2026-03-15

### DIFF
--- a/.github/labels.yml
+++ b/.github/labels.yml
@@ -1,0 +1,100 @@
+# GitHub Labels 標準定義
+#
+# label-sync ワークフローで自動同期される
+# 各プロジェクトに合わせてカスタマイズ可能
+#
+# 使い方:
+#   .github/labels.yml にコピーして配置
+
+# ── Priority ──────────────────────────────────────
+- name: 'P0: Critical'
+  color: 'b60205'
+  description: '即時対応が必要'
+
+- name: 'P1: High'
+  color: 'd93f0b'
+  description: '今スプリントで対応'
+
+- name: 'P2: Medium'
+  color: 'fbca04'
+  description: '次スプリントで対応'
+
+- name: 'P3: Low'
+  color: '0e8a16'
+  description: 'バックログ'
+
+# ── Type ──────────────────────────────────────────
+- name: 'bug'
+  color: 'd73a4a'
+  description: '不具合・バグ'
+
+- name: 'feature'
+  color: 'a2eeef'
+  description: '新機能'
+
+- name: 'enhancement'
+  color: '84b6eb'
+  description: '既存機能の改善'
+
+- name: 'docs'
+  color: '0075ca'
+  description: 'ドキュメントの更新'
+
+- name: 'chore'
+  color: 'e4e669'
+  description: 'メンテナンス・雑務'
+
+- name: 'refactor'
+  color: 'd4c5f9'
+  description: 'リファクタリング'
+
+- name: 'performance'
+  color: 'f9d0c4'
+  description: 'パフォーマンス改善'
+
+- name: 'security'
+  color: 'ee0701'
+  description: 'セキュリティ関連'
+
+- name: 'dependencies'
+  color: '0366d6'
+  description: '依存関係の更新'
+
+# ── Status ────────────────────────────────────────
+- name: 'in-progress'
+  color: 'ededed'
+  description: '作業中'
+
+- name: 'needs-review'
+  color: 'fbca04'
+  description: 'レビュー待ち'
+
+- name: 'blocked'
+  color: 'b60205'
+  description: 'ブロック中'
+
+- name: 'wontfix'
+  color: 'ffffff'
+  description: '対応しない'
+
+- name: 'duplicate'
+  color: 'cfd3d7'
+  description: '重複'
+
+# ── Dependency ────────────────────────────────────
+- name: 'breaking-change'
+  color: 'b60205'
+  description: '破壊的変更あり'
+
+- name: 'auto-discovered'
+  color: 'bfdadc'
+  description: '自動検出された機能・改善'
+
+# ── CI/CD ─────────────────────────────────────────
+- name: 'ci'
+  color: '006b75'
+  description: 'CI/CD パイプライン関連'
+
+- name: 'infrastructure'
+  color: '5319e7'
+  description: 'インフラ関連'

--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -1,0 +1,92 @@
+# Release Drafter 設定
+#
+# Conventional Commits のプレフィックスに基づいてリリースノートを自動生成
+#
+# 使い方:
+#   .github/release-drafter.yml にコピーして配置
+#
+name-template: 'v$RESOLVED_VERSION'
+tag-template: 'v$RESOLVED_VERSION'
+
+# バージョン自動判定
+version-resolver:
+  major:
+    labels:
+      - 'breaking-change'
+  minor:
+    labels:
+      - 'feature'
+      - 'enhancement'
+  patch:
+    labels:
+      - 'bug'
+      - 'chore'
+      - 'dependencies'
+  default: patch
+
+# カテゴリ分類
+categories:
+  - title: '🚀 New Features'
+    labels:
+      - 'feature'
+  - title: '🔧 Improvements'
+    labels:
+      - 'enhancement'
+      - 'performance'
+      - 'refactor'
+  - title: '🐛 Bug Fixes'
+    labels:
+      - 'bug'
+  - title: '📝 Documentation'
+    labels:
+      - 'docs'
+  - title: '🔒 Security'
+    labels:
+      - 'security'
+  - title: '📦 Dependencies'
+    labels:
+      - 'dependencies'
+  - title: '🏗️ Infrastructure'
+    labels:
+      - 'ci'
+      - 'infrastructure'
+  - title: '🧹 Maintenance'
+    labels:
+      - 'chore'
+
+# PR ラベル自動付与（タイトルのプレフィックスから）
+autolabeler:
+  - label: 'feature'
+    title:
+      - '/^feat/i'
+  - label: 'bug'
+    title:
+      - '/^fix/i'
+  - label: 'docs'
+    title:
+      - '/^docs/i'
+  - label: 'chore'
+    title:
+      - '/^chore/i'
+  - label: 'refactor'
+    title:
+      - '/^refactor/i'
+  - label: 'performance'
+    title:
+      - '/^perf/i'
+  - label: 'ci'
+    title:
+      - '/^ci/i'
+  - label: 'dependencies'
+    title:
+      - '/^deps/i'
+
+# リリースノートのテンプレート
+template: |
+  ## Changes
+
+  $CHANGES
+
+  ## Contributors
+
+  $CONTRIBUTORS

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -88,7 +88,7 @@ jobs:
     steps:
       - uses: actions/checkout@v6.0.2
 
-      - uses: actions/setup-node@v6.2.0
+      - uses: actions/setup-node@v6.3.0
         with:
           node-version-file: '.node-version'
           cache: 'npm'
@@ -121,7 +121,7 @@ jobs:
     steps:
       - uses: actions/checkout@v6.0.2
 
-      - uses: actions/setup-node@v6.2.0
+      - uses: actions/setup-node@v6.3.0
         with:
           node-version-file: '.node-version'
           cache: 'npm'
@@ -173,7 +173,7 @@ jobs:
     steps:
       - uses: actions/checkout@v6.0.2
 
-      - uses: actions/setup-node@v6.2.0
+      - uses: actions/setup-node@v6.3.0
         with:
           node-version-file: '.node-version'
           cache: 'npm'
@@ -362,7 +362,7 @@ jobs:
     if: failure() && github.ref == 'refs/heads/main'
     steps:
       - name: Send Slack notification
-        uses: slackapi/slack-github-action@v2.1.1
+        uses: slackapi/slack-github-action@v3.0.1
         with:
           channel-id: ${{ vars.SLACK_CI_CHANNEL_ID }}
           payload-template-file-path: '.github/slack-ci-failure.json'

--- a/.github/workflows/container-security.yml
+++ b/.github/workflows/container-security.yml
@@ -134,7 +134,7 @@ jobs:
           cache-from: type=registry,ref=ghcr.io/${{ github.repository_owner }}/config-base:cache
 
       - name: Generate SBOM with Syft
-        uses: anchore/sbom-action@v0.23.0
+        uses: anchore/sbom-action@v0.23.1
         with:
           image: config-base:sbom
           artifact-name: sbom.spdx.json

--- a/.github/workflows/coverage-report.yml
+++ b/.github/workflows/coverage-report.yml
@@ -63,7 +63,7 @@ jobs:
           fetch-depth: 0
 
       - name: Download coverage artifact
-        uses: actions/download-artifact@v8.0.0
+        uses: actions/download-artifact@v8.0.1
         with:
           name: ${{ inputs.artifact-name }}
           path: coverage-download
@@ -86,7 +86,7 @@ jobs:
         uses: actions/checkout@v6.0.2
 
       - name: Download coverage artifact
-        uses: actions/download-artifact@v8.0.0
+        uses: actions/download-artifact@v8.0.1
         with:
           name: ${{ inputs.artifact-name }}
           path: coverage-download
@@ -167,7 +167,7 @@ jobs:
         uses: actions/checkout@v6.0.2
 
       - name: Download coverage artifact
-        uses: actions/download-artifact@v8.0.0
+        uses: actions/download-artifact@v8.0.1
         with:
           name: ${{ inputs.artifact-name }}
           path: coverage-download
@@ -183,7 +183,7 @@ jobs:
           thresholds: '${{ inputs.min-coverage-overall }} ${{ inputs.min-coverage-changed-files }}'
 
       - name: Post coverage comment
-        uses: marocchino/sticky-pull-request-comment@v2.9.4
+        uses: marocchino/sticky-pull-request-comment@v3.0.2
         with:
           header: ${{ inputs.title }}
           message: |
@@ -200,7 +200,7 @@ jobs:
         uses: actions/checkout@v6.0.2
 
       - name: Download coverage artifact
-        uses: actions/download-artifact@v8.0.0
+        uses: actions/download-artifact@v8.0.1
         with:
           name: ${{ inputs.artifact-name }}
           path: coverage-download

--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -1,0 +1,64 @@
+# Dependabot Auto-merge Workflow
+#
+# Dependabot PR を更新種別に応じて自動処理するワークフロー
+# - patch: CI パス後に自動 squash マージ
+# - minor: 自動承認（マージは手動）
+# - major: ラベル付与してレビュー必須
+#
+# 使い方:
+#   .github/workflows/dependabot-auto-merge.yml にコピーして配置
+#   dependabot.yml と合わせて使用
+#
+name: Dependabot Auto-merge
+
+on:
+  pull_request_target:
+    types: [opened, synchronize, reopened]
+
+permissions:
+  contents: write
+  pull-requests: write
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref }}
+  cancel-in-progress: true
+
+jobs:
+  dependabot-auto:
+    if: github.actor == 'dependabot[bot]'
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      # 更新種別を取得（patch / minor / major）
+      - name: Fetch Dependabot metadata
+        id: metadata
+        uses: dependabot/fetch-metadata@v2
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+
+      # patch: 自動 squash マージ（CI パス後）
+      - name: Auto-merge patch updates
+        if: steps.metadata.outputs.update-type == 'version-update:semver-patch'
+        run: |
+          gh pr merge "$PR_URL" --auto --squash
+        env:
+          PR_URL: ${{ github.event.pull_request.html_url }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      # minor: 自動承認（マージは手動で判断）
+      - name: Auto-approve minor updates
+        if: steps.metadata.outputs.update-type == 'version-update:semver-minor'
+        run: |
+          gh pr review "$PR_URL" --approve --body "Auto-approved: minor version update"
+        env:
+          PR_URL: ${{ github.event.pull_request.html_url }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      # major: ラベル付与してレビュー必須
+      - name: Label major updates for review
+        if: steps.metadata.outputs.update-type == 'version-update:semver-major'
+        run: |
+          gh pr edit "$PR_URL" --add-label "needs-review,breaking-change"
+        env:
+          PR_URL: ${{ github.event.pull_request.html_url }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -51,7 +51,7 @@ jobs:
         with:
           fetch-depth: 0
 
-      - uses: actions/setup-node@v6.2.0
+      - uses: actions/setup-node@v6.3.0
         with:
           node-version-file: '.node-version'
 

--- a/.github/workflows/label-sync.yml
+++ b/.github/workflows/label-sync.yml
@@ -1,0 +1,41 @@
+# Label Sync Workflow
+#
+# GitHub ラベルを YAML ファイルで IaC 管理し、自動同期するワークフロー
+# labels.yml を変更して push するだけで、リポジトリのラベルが自動更新される
+#
+# 使い方:
+#   1. .github/workflows/label-sync.yml にコピーして配置
+#   2. .github/labels.yml にラベル定義を配置（テンプレート: templates/github/labels.yml）
+#
+name: Label Sync
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - '.github/labels.yml'
+  workflow_dispatch:
+
+permissions:
+  issues: write
+  pull-requests: write
+
+concurrency:
+  group: ${{ github.workflow }}
+  cancel-in-progress: true
+
+jobs:
+  sync:
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Sync labels
+        uses: EndBug/label-sync@v2
+        with:
+          config-file: .github/labels.yml
+          # 既存ラベルを保持（false = labels.yml にないラベルを削除しない）
+          delete-other-labels: false
+          token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/manual-release.yml
+++ b/.github/workflows/manual-release.yml
@@ -31,7 +31,7 @@ jobs:
           fetch-depth: 0
           token: ${{ secrets.GITHUB_TOKEN }}
 
-      - uses: actions/setup-node@v6.2.0
+      - uses: actions/setup-node@v6.3.0
         with:
           node-version-file: '.node-version'
 

--- a/.github/workflows/rebuild-docker-cache.yml
+++ b/.github/workflows/rebuild-docker-cache.yml
@@ -27,7 +27,7 @@ jobs:
         with:
           fetch-depth: 0
 
-      - uses: actions/setup-node@v6.2.0
+      - uses: actions/setup-node@v6.3.0
         with:
           node-version-file: '.node-version'
 

--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -1,0 +1,35 @@
+# Release Drafter Workflow
+#
+# PR マージ時にリリースノートのドラフトを自動生成する
+# Conventional Commits のプレフィックスに基づいてカテゴリ分類
+#
+# 使い方:
+#   1. .github/workflows/release-drafter.yml にコピーして配置
+#   2. .github/release-drafter.yml に設定ファイルを配置（下記参照）
+#
+# 参考: https://github.com/release-drafter/release-drafter
+#
+name: Release Drafter
+
+on:
+  push:
+    branches: [main]
+  pull_request_target:
+    types: [opened, reopened, synchronize]
+
+permissions:
+  contents: read
+  pull-requests: write
+
+concurrency:
+  group: ${{ github.workflow }}
+  cancel-in-progress: true
+
+jobs:
+  update-release-draft:
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - uses: release-drafter/release-drafter@v6
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -79,7 +79,7 @@ jobs:
         uses: actions/checkout@v6.0.2
 
       - name: Setup Node.js
-        uses: actions/setup-node@v6.2.0
+        uses: actions/setup-node@v6.3.0
         with:
           node-version-file: '.node-version'
           cache: 'npm'
@@ -106,7 +106,7 @@ jobs:
         uses: actions/checkout@v6.0.2
 
       - name: Setup Node.js
-        uses: actions/setup-node@v6.2.0
+        uses: actions/setup-node@v6.3.0
         with:
           node-version-file: '.node-version'
           cache: 'npm'

--- a/.github/workflows/templates/monorepo-release.yml
+++ b/.github/workflows/templates/monorepo-release.yml
@@ -100,7 +100,7 @@ jobs:
           persist-credentials: false
 
       - name: Setup Node.js
-        uses: actions/setup-node@v6.2.0
+        uses: actions/setup-node@v6.3.0
         with:
           node-version: '20'
           cache: 'npm'
@@ -140,7 +140,7 @@ jobs:
           persist-credentials: false
 
       - name: Setup Node.js
-        uses: actions/setup-node@v6.2.0
+        uses: actions/setup-node@v6.3.0
         with:
           node-version: '20'
           cache: 'npm'
@@ -180,7 +180,7 @@ jobs:
           persist-credentials: false
 
       - name: Setup Node.js
-        uses: actions/setup-node@v6.2.0
+        uses: actions/setup-node@v6.3.0
         with:
           node-version: '20'
           cache: 'npm'

--- a/.github/workflows/templates/unified-ci.yml
+++ b/.github/workflows/templates/unified-ci.yml
@@ -76,7 +76,7 @@ jobs:
         uses: actions/checkout@v6.0.2
 
       - name: Setup Node.js
-        uses: actions/setup-node@v6.2.0
+        uses: actions/setup-node@v6.3.0
         with:
           node-version: '20'
           cache: 'npm' # or 'pnpm' if using pnpm

--- a/.github/workflows/templates/update-db-types.yml
+++ b/.github/workflows/templates/update-db-types.yml
@@ -41,7 +41,7 @@ jobs:
       - uses: actions/checkout@v6.0.2
 
       - name: Setup Node.js
-        uses: actions/setup-node@v6.2.0
+        uses: actions/setup-node@v6.3.0
         with:
           node-version: '22'
           cache: 'npm'

--- a/.github/workflows/update-libraries.yml
+++ b/.github/workflows/update-libraries.yml
@@ -20,7 +20,7 @@ jobs:
     steps:
       - uses: actions/checkout@v6.0.2
 
-      - uses: actions/setup-node@v6.2.0
+      - uses: actions/setup-node@v6.3.0
         with:
           node-version-file: '.node-version'
           cache: 'npm'

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,6 +1,1 @@
-# Claude Code Configuration
-
-このファイルは Claude Code がプロジェクトルートで最初に読み込む設定ファイルです。
-詳細なガイドラインは AGENTS.md に集約しています。
-
 AGENTS.md


### PR DESCRIPTION
## Summary

- GitHub Actions を最新版に更新（setup-node v6.3.0, sbom-action v0.23.1, slack v3.0.1）
- CLAUDE.md を AGENTS.md へのシンボリックリンクに変換
- Label Sync ワークフロー + 標準ラベル定義を config リポジトリに適用
- Release Drafter ワークフロー + 設定を適用
- Dependabot Auto-merge ワークフローを適用
- マージ済みブランチ 17件を削除

## Test plan

- [x] 全テスト (101) パス
- [x] Format / Lint パス
- [ ] CI パス確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added automated GitHub label synchronization from standardized configuration.
  * Introduced intelligent Dependabot update automation: auto-merges patches, auto-approves minors, flags majors for review.
  * Added automated release notes generation with semantic versioning support.

* **Chores**
  * Updated GitHub Actions and external action dependencies across multiple workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->