### PR TITLE
docs: ドキュメント全体の整合性修正

### DIFF
--- a/.devcontainer/README.md
+++ b/.devcontainer/README.md
@@ -77,7 +77,7 @@ This DevContainer image is automatically built and versioned using semantic-rele
 - **Minor versions**: New features and enhancements (1.0.0 → 1.1.0)
 - **Major versions**: Breaking changes (1.0.0 → 2.0.0)
 
-**Latest Version**: `v1.81.1`
+**Latest Version**: 最新バージョンは `ghcr.io/keito4/config-base:latest` で自動取得されます
 
 Images are published to GitHub Container Registry: `ghcr.io/keito4/config-base`
 
@@ -102,7 +102,7 @@ Use the pre-built image without mounting host's `~/.claude` directory:
 ```json
 {
   "name": "My Project",
-  "image": "ghcr.io/keito4/config-base:1.81.1",
+  "image": "ghcr.io/keito4/config-base:latest",
   "remoteEnv": {
     "TMPDIR": "/home/vscode/.claude/tmp"
   }
@@ -115,7 +115,7 @@ Use the pre-built image without mounting host's `~/.claude` directory:
 - No conflicts with host configuration
 - Consistent environment across all team members
 
-See [docs/devcontainer.json.example](../docs/devcontainer.json.example) for complete example.
+詳細は [docs/using-config-base-image.md](../docs/using-config-base-image.md) を参照してください。
 
 #### Option 2: With Host Persistence
 
@@ -124,7 +124,7 @@ Mount host's `~/.claude` to persist custom plugin installations:
 ```json
 {
   "name": "My Project",
-  "image": "ghcr.io/keito4/config-base:1.81.1",
+  "image": "ghcr.io/keito4/config-base:latest",
   "remoteEnv": {
     "TMPDIR": "/home/vscode/.claude/tmp"
   },

--- a/.devcontainer/VERSIONING.md
+++ b/.devcontainer/VERSIONING.md
@@ -82,7 +82,7 @@ Each release creates two tags:
 
 ```json
 {
-  "image": "ghcr.io/keito4/config-base:1.81.1"
+  "image": "ghcr.io/keito4/config-base:1.97.0"
 }
 ```
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -28,27 +28,16 @@ This repository implements comprehensive development quality standards and AI-as
 - **Ready**: Acceptance criteria defined, dependencies resolved
 - **Done**: Quality gates passed, documentation updated, monitoring stable, release notes complete
 
-## Slack Notifications
-
-When completing tasks, Claude will automatically send a notification to Slack using the MCP Slack integration.
-
-### Configuration
-
-Claude is configured to send notifications to the Slack workspace when tasks are completed. This uses the MCP (Model Context Protocol) Slack integration.
-
-## Development Tools & Automation
-
-This repository provides comprehensive development tooling through GitHub Actions workflows and automated scripts:
-
 ## GitHub Actions Integration
 
 The repository includes comprehensive automated workflows for continuous integration and AI-assisted development:
 
 ### CI/CD Pipelines
 
-- **CI Pipeline** (`.github/workflows/ci.yml`): Code quality validation with linting, formatting, testing, and building
+- **CI Pipeline** (`.github/workflows/ci.yml`): Code quality validation with linting, formatting, testing, and building. Required status check は `Quality Gate` ジョブで集約
 - **DevContainer Build** (`.github/workflows/docker-image.yml`): Automated container image building with semantic versioning and multi-platform support
 - **Library Auto-Update** (`.github/workflows/update-libraries.yml`): Scheduled execution of `npm run update:libs` that opens a pull request when dependencies or Codex/Claude tooling change
+- **Security Scanning** (`.github/workflows/security.yml`): Dependency review, license compliance, secret detection, and npm audit
 
 ### AI-Assisted Development
 

--- a/docs/tool-catalog.md
+++ b/docs/tool-catalog.md
@@ -227,7 +227,7 @@ Layer 1: ベースイメージ (ghcr.io/keito4/config-base)
 ### 7.1 ベースイメージバージョンの乖離
 
 4 リポジトリ（npm ライブラリ、SPA、モバイル Flutter、モバイル Android）が **1.0.13** のまま。
-最新は **1.81.1** であり、AI CLI やセキュリティパッチが大幅に遅れている。
+最新は **1.97.0** であり、AI CLI やセキュリティパッチが大幅に遅れている。
 
 > **推奨**: `/config-base-sync-update` コマンドで一括更新、または Dependabot/Renovate で自動化。
 

--- a/docs/using-config-base-image.md
+++ b/docs/using-config-base-image.md
@@ -28,7 +28,7 @@
 
 **重要**: ホストの `~/.claude` をマウント**しない**ことで、イメージに含まれている設定がそのまま使えます。
 
-📝 **サンプル**: [devcontainer.json.example](./devcontainer.json.example) を参照してください。
+📝 上記の構成をそのまま `.devcontainer/devcontainer.json` として使用できます。
 
 この構成では以下がすぐに利用できます：
 


### PR DESCRIPTION
## Summary
- `.devcontainer/README.md`: 壊れたリンク (`devcontainer.json.example`) を修正、ハードコードされたバージョン (`1.81.1`) を `latest` に変更
- `.devcontainer/VERSIONING.md`: バージョン例を `1.97.0` に更新
- `docs/tool-catalog.md`: ベースイメージバージョン参照を `1.97.0` に更新
- `docs/using-config-base-image.md`: 存在しない `devcontainer.json.example` へのリンクを削除
- `AGENTS.md`: 見出し階層の修正、冗長セクション削除、CI Quality Gate 集約・Security ワークフロー記載を追加

## Test plan
- [ ] `.devcontainer/README.md` のリンクが正しく `docs/using-config-base-image.md` を参照すること
- [ ] AGENTS.md の見出し階層が正しいこと（`##` の連続がないこと）
- [ ] バージョン参照が最新 (1.97.0 / latest) になっていること

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated base container image version to 1.97.0 across all examples
  * Enhanced devcontainer configuration guidance with streamlined setup instructions
  * Expanded CI/CD pipeline documentation with new Security Scanning workflow
  * Added Claude Code Integration documentation for AI-assisted development
  * Removed outdated Slack notification configuration guidance

<!-- end of auto-generated comment: release notes by coderabbit.ai -->