### PR TITLE
fix: pre-production/production ブランチ保護のデフォルト設定を差別化

### DIFF
--- a/.claude/commands/setup-team-protection.md
+++ b/.claude/commands/setup-team-protection.md
@@ -6,16 +6,22 @@
 
 設定される内容
 
-**ブランチ保護ルール（main/develop）**
+**ブランチ保護ルール（ブランチ種別ごとのデフォルト）**
+
+| ブランチ              | enforce_admins | required_reviews | code_owner_reviews |
+| --------------------- | -------------- | ---------------- | ------------------ |
+| main (default_branch) | true           | 0                | false              |
+| pre-production        | false          | 1                | true               |
+| production            | false          | 1                | true               |
+
 • 直接プッシュ禁止
 • プルリクエスト必須
-• レビュー承認必須（最低1名）
-• CODEOWNERSレビュー必須
 • ステータスチェック必須（CI通過）
 • force pushの禁止
 • ブランチ削除保護
 • 古いレビューの自動却下
 • マージ前のブランチ更新必須
+• `--uniform` で全ブランチ同一設定に切替可能
 
 **リポジトリ設定**
 • マージ方法の設定（デフォルト: Merge commitのみ、オプションで変更可能）
@@ -76,21 +82,30 @@ bash script/setup-team-protection.sh --dry-run
 
 設定の詳細
 
-**main ブランチ保護**
+**ブランチ種別ごとの保護設定**
+
+main ブランチ:
 
 ```bash
-gh api repos/{owner}/{repo}/branches/main/protection \
-  --method PUT \
-  --field required_status_checks[strict]=true \
-  --field required_status_checks[contexts][]="Quality Gate" \
-  --field required_pull_request_reviews[required_approving_review_count]=1 \
-  --field required_pull_request_reviews[dismiss_stale_reviews]=true \
-  --field required_pull_request_reviews[require_code_owner_reviews]=false \
-  --field enforce_admins=false \
-  --field restrictions=null \
-  --field allow_force_pushes[enabled]=false \
-  --field allow_deletions[enabled]=false \
-  --field required_linear_history[enabled]=false
+# enforce_admins=true, reviewers=0, code_owner_reviews=false
+bash script/setup-team-protection.sh --branches main
+```
+
+pre-production / production ブランチ:
+
+```bash
+# enforce_admins=false, reviewers=1, code_owner_reviews=true
+bash script/setup-team-protection.sh \
+  --branches pre-production,production \
+  --create-branches
+```
+
+全ブランチ一括:
+
+```bash
+bash script/setup-team-protection.sh \
+  --branches main,pre-production,production \
+  --create-branches
 ```
 
 **必須ステータスチェック**
@@ -99,11 +114,11 @@ gh api repos/{owner}/{repo}/branches/main/protection \
 • Quality Gate（CI ワークフローの全ジョブ結果を集約するゲートジョブ）
 • セキュリティスキャン（オプション）
 
-**レビュー要件**
+**レビュー要件（デフォルト）**
 
-• 最低1名の承認が必要
+• main: レビュー不要、管理者はルール適用
+• pre-production / production: 最低1名の承認 + CODEOWNERS レビュー必須、管理者は緊急時マージ可能
 • 変更があった場合は承認をリセット
-• コードオーナーのレビューは任意（チーム判断）
 
 ---
 
@@ -123,25 +138,34 @@ bash script/setup-team-protection.sh --reviewers 2
 bash script/setup-team-protection.sh --enforce-admins
 ```
 
-**pre-production / production ブランチも保護（最厳格設定）**
+**pre-production / production ブランチも保護（推奨設定）**
 
 ```bash
-# main, pre-production, production を保護（strictレベル）
+# main, pre-production, production を保護（ブランチ種別ごとの推奨デフォルト）
+bash script/setup-team-protection.sh \
+  --branches main,pre-production,production \
+  --create-branches
+```
+
+**全ブランチに同一設定を適用**
+
+```bash
+# --uniform で全ブランチ同一設定（ブランチ種別デフォルトを無効化）
 bash script/setup-team-protection.sh \
   --branches main,pre-production,production \
   --create-branches \
-  --protection-level strict
+  --uniform --reviewers 1
 ```
 
 **保護レベルの設定**
 
 ```bash
-# standard（デフォルト）: レビュー1名、管理者除外
+# standard（デフォルト）: ブランチ種別ごとの推奨設定を自動適用
 bash script/setup-team-protection.sh --protection-level standard
 
 # strict: レビュー2名以上、管理者も制約、リニア履歴必須、
 #         署名付きコミット必須、最終プッシュ承認必須、
-#         会話解決必須
+#         会話解決必須（ブランチ種別デフォルトより優先）
 bash script/setup-team-protection.sh --protection-level strict
 ```
 

--- a/script/setup-team-protection.sh
+++ b/script/setup-team-protection.sh
@@ -21,7 +21,14 @@
 #   --protection-level LV Protection level: standard or strict (default: standard)
 #                         strict: 2 reviewers, enforce admins, linear history,
 #                         conversation resolution, signed commits, last push approval
+#   --uniform             Apply identical settings to all branches (disable branch-type defaults)
 #   --help                Show this help message
+#
+# Branch-type defaults (when --uniform is NOT set):
+#   main (default_branch):
+#     enforce_admins=true, required_reviews=0, require_code_owner_reviews=false
+#   pre-production / production:
+#     enforce_admins=false, required_reviews=1, require_code_owner_reviews=true
 
 set -euo pipefail
 
@@ -40,6 +47,7 @@ SKIP_STATUS_CHECKS=false
 CREATE_BRANCHES=false
 MERGE_METHOD="merge"  # Options: squash, merge, rebase, all, none
 PROTECTION_LEVEL="standard"  # Options: standard, strict
+UNIFORM=false  # When true, apply identical settings to all branches
 
 # Parse arguments
 REPO=""
@@ -80,6 +88,10 @@ while [[ $# -gt 0 ]]; do
     --protection-level)
       PROTECTION_LEVEL="$2"
       shift 2
+      ;;
+    --uniform)
+      UNIFORM=true
+      shift
       ;;
     --help)
       grep '^#' "$0" | grep -v '#!/usr/bin/env' | sed 's/^# //; s/^#//'
@@ -167,6 +179,7 @@ if [[ "$INTERACTIVE" == "true" ]]; then
   echo "  Skip status checks: $SKIP_STATUS_CHECKS"
   echo "  Merge method: $MERGE_METHOD"
   echo "  Protection level: $PROTECTION_LEVEL"
+  echo "  Uniform mode: $UNIFORM"
   echo ""
   read -p "Continue? (y/N) " -n 1 -r
   echo
@@ -205,20 +218,43 @@ setup_branch_protection() {
     fi
   fi
 
-  # Apply protection level presets
+  # Apply branch-type defaults (similar to cloud_provisioning PR #359 pattern)
+  # Then overlay protection level presets on top
   local reviewers=$REVIEWERS
   local enforce_admins=$ENFORCE_ADMINS
+  local require_code_owner_reviews=true
   local require_linear_history=false
   local require_last_push_approval=false
   local require_conversation_resolution=false
   local require_signed_commits=false
 
+  # Branch-type-aware defaults (when --uniform is NOT set)
+  if [[ "$UNIFORM" == "false" ]]; then
+    case "$branch" in
+      pre-production|production)
+        # Environment branches: stricter review, relaxed admin enforcement
+        enforce_admins=false
+        reviewers=1
+        require_code_owner_reviews=true
+        info "Applying environment branch defaults (enforce_admins=false, reviewers=1, code_owner_reviews=true)"
+        ;;
+      main|master)
+        # Default branch: admin enforcement, no mandatory reviews
+        enforce_admins=true
+        reviewers=0
+        require_code_owner_reviews=false
+        info "Applying default branch defaults (enforce_admins=true, reviewers=0, code_owner_reviews=false)"
+        ;;
+    esac
+  fi
+
   if [[ "$PROTECTION_LEVEL" == "strict" ]]; then
     # Strict: maximum protection for production-grade branches
-    if [[ "$REVIEWERS" -lt 2 ]]; then
+    if [[ "$reviewers" -lt 2 ]]; then
       reviewers=2
     fi
     enforce_admins=true
+    require_code_owner_reviews=true
     require_linear_history=true
     require_last_push_approval=true
     require_conversation_resolution=true
@@ -244,7 +280,7 @@ setup_branch_protection() {
   protection_config+='"required_pull_request_reviews":{'
   protection_config+="\"required_approving_review_count\":$reviewers,"
   protection_config+='"dismiss_stale_reviews":true,'
-  protection_config+='"require_code_owner_reviews":true,'
+  protection_config+="\"require_code_owner_reviews\":$require_code_owner_reviews,"
   protection_config+="\"require_last_push_approval\":$require_last_push_approval"
   protection_config+='},'
 
@@ -266,6 +302,7 @@ setup_branch_protection() {
     echo "[DRY RUN] Would apply branch protection to $branch:"
     echo "  Reviewers: $reviewers"
     echo "  Enforce admins: $enforce_admins"
+    echo "  Code owner reviews: $require_code_owner_reviews"
     echo "  Linear history: $require_linear_history"
     echo "  Last push approval: $require_last_push_approval"
     echo "  Conversation resolution: $require_conversation_resolution"


### PR DESCRIPTION
## Summary
- `setup-team-protection.sh` にブランチ種別ごとのデフォルト保護設定を追加
- `cloud_provisioning` PR #359 と同パターンで `pre-production` / `production` を保護
- `--uniform` オプションで従来の全ブランチ同一設定に切替可能

### 変更後のデフォルト保護

| ブランチ | enforce_admins | required_reviews | code_owner_reviews |
|---|---|---|---|
| main (default_branch) | true | 0 | false |
| pre-production | false | 1 | true |
| production | false | 1 | true |

## Test plan
- [x] `--dry-run` で main / pre-production / production それぞれに適切なデフォルトが適用されることを確認
- [x] `--uniform` で全ブランチ同一設定になることを確認
- [x] `--protection-level strict` がブランチ種別デフォルトより優先されることを確認
- [ ] CI Quality Gate パス

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added `--uniform` flag to apply identical branch protection settings across all branches
  * Introduced type-specific default protection with tailored review requirements per branch

* **Documentation**
  * Expanded setup guides with command examples for multi-branch protection scenarios
  * Clarified default behaviors for admin enforcement, review requirements, and code owner reviews

<!-- end of auto-generated comment: release notes by coderabbit.ai -->