### PR TITLE
fix: Claude CI ワークフローの cancel-in-progress を無効化

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -12,7 +12,7 @@ on:
 
 concurrency:
   group: claude-${{ github.repository }}-${{ github.event.issue.number || github.event.pull_request.number || github.run_id }}
-  cancel-in-progress: true
+  cancel-in-progress: false
 
 jobs:
   claude:


### PR DESCRIPTION
## 概要

- Claude Code CI ワークフローの `cancel-in-progress` を `true` → `false` に変更

## 背景

同じ Issue/PR に対して新しい `@claude` リクエストが来た際に、`cancel-in-progress: true` により実行中のジョブがキャンセルされ、処理が完了しない問題が頻発していた。

## 変更後の動作

- 実行中のジョブは最後まで完了する
- 新しいリクエストはキューで順番待ちになる

## 変更統計

- 変更ファイル数: 1 件
- 変更行数: 1 行

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated internal workflow configuration for improved handling of concurrent process execution.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->