### PR TITLE
fix: vercel/npm を更新し undici・tar の High CVE を修正

### DIFF
--- a/npm/global.json
+++ b/npm/global.json
@@ -66,7 +66,7 @@
       "overridden": false
     },
     "npm": {
-      "version": "11.11.1",
+      "version": "11.12.0",
       "overridden": false
     },
     "pm2": {
@@ -74,7 +74,7 @@
       "overridden": false
     },
     "vercel": {
-      "version": "50.32.5",
+      "version": "50.34.3",
       "overridden": false
     }
   }


### PR DESCRIPTION
## Summary
- vercel: 50.32.5 → 50.34.3 (CVE-2026-2229, CVE-2026-1526, CVE-2026-31802 の修正)
- npm: 11.11.1 → 11.12.0 (CVE-2026-31802 の修正)

## 対応不可のアラート（上流待ち）
- **CVE-2026-25679** (Go stdlib `net/url`): Doppler CLI / 1Password CLI が Go 1.25.7 でビルドされており、Go 1.25.8+ での修正が必要。両ツールとも現時点で最新版 (Doppler 3.75.3 / op 2.33.0) のため、上流がリビルドするまで保留。

## Test plan
- [ ] Docker イメージビルドが成功すること
- [ ] vercel / npm が正しいバージョンでインストールされること
- [ ] code-scanning で undici・tar 関連の High アラートが解消されること

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated npm tool to version 11.12.0
  * Updated vercel tool to version 50.34.3

<!-- end of auto-generated comment: release notes by coderabbit.ai -->