### PR TITLE
fix: Claude CI 自己キャンセル防止・enforce_admins 修正・ヘルスチェック追加

### DIFF
--- a/.claude/commands/setup-team-protection.md
+++ b/.claude/commands/setup-team-protection.md
@@ -10,7 +10,7 @@
 
 | ブランチ              | enforce_admins | required_reviews | code_owner_reviews |
 | --------------------- | -------------- | ---------------- | ------------------ |
-| main (default_branch) | true           | 0                | false              |
+| main (default_branch) | false          | 0                | false              |
 | pre-production        | false          | 1                | true               |
 | production            | false          | 1                | true               |
 
@@ -87,7 +87,7 @@ bash script/setup-team-protection.sh --dry-run
 main ブランチ:
 
 ```bash
-# enforce_admins=true, reviewers=0, code_owner_reviews=false
+# enforce_admins=false, reviewers=0, code_owner_reviews=false
 bash script/setup-team-protection.sh --branches main
 ```
 

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -21,6 +21,7 @@ jobs:
     if: |
       github.actor != 'github-actions[bot]' &&
       github.actor != 'dependabot[bot]' &&
+      github.actor != 'claude[bot]' &&
       (
         (github.event_name == 'issue_comment' && contains(github.event.comment.body || '', '@claude') &&
           !(github.event.issue.pull_request && github.event.issue.pull_request.url && github.event.issue.draft == true)) ||

--- a/script/setup-team-protection.sh
+++ b/script/setup-team-protection.sh
@@ -26,7 +26,7 @@
 #
 # Branch-type defaults (when --uniform is NOT set):
 #   main (default_branch):
-#     enforce_admins=true, required_reviews=0, require_code_owner_reviews=false
+#     enforce_admins=false, required_reviews=0, require_code_owner_reviews=false
 #   pre-production / production:
 #     enforce_admins=false, required_reviews=1, require_code_owner_reviews=true
 
@@ -239,11 +239,11 @@ setup_branch_protection() {
         info "Applying environment branch defaults (enforce_admins=false, reviewers=1, code_owner_reviews=true)"
         ;;
       main|master)
-        # Default branch: admin enforcement, no mandatory reviews
-        enforce_admins=true
+        # Default branch: no admin enforcement, no mandatory reviews
+        enforce_admins=false
         reviewers=0
         require_code_owner_reviews=false
-        info "Applying default branch defaults (enforce_admins=true, reviewers=0, code_owner_reviews=false)"
+        info "Applying default branch defaults (enforce_admins=false, reviewers=0, code_owner_reviews=false)"
         ;;
     esac
   fi

--- a/templates/workflows/claude-health-check.yml
+++ b/templates/workflows/claude-health-check.yml
@@ -1,0 +1,60 @@
+name: Claude Code Health Check
+
+on:
+  schedule:
+    - cron: '0 0 * * 1' # Every Monday 00:00 UTC
+  workflow_dispatch:
+
+permissions: {}
+
+jobs:
+  health-check:
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    permissions:
+      issues: write
+    steps:
+      - name: Check Claude Code token validity
+        id: check
+        uses: anthropics/claude-code-action@d59651bd82c48d81756854675ce4fa4d69722200 # v1
+        with:
+          claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          direct_prompt: 'Reply with only: OK'
+          timeout_minutes: 2
+        continue-on-error: true
+
+      - name: Create issue on failure
+        if: steps.check.outcome == 'failure'
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          EXISTING=$(gh issue list --label "claude-health" --state open --json number --jq 'length')
+          if [ "$EXISTING" -gt 0 ]; then
+            echo "Open health check issue already exists. Skipping."
+            exit 0
+          fi
+
+          gh issue create \
+            --title "fix: Claude Code OAuth トークンが無効です" \
+            --label "claude-health,bug" \
+            --body "$(cat <<'BODY'
+          ## 問題
+
+          Claude Code Health Check が失敗しました。
+          `CLAUDE_CODE_OAUTH_TOKEN` が期限切れまたは無効になっている可能性があります。
+
+          ## 対応手順
+
+          1. [Claude Code OAuth](https://console.anthropic.com/) でトークンを再発行
+          2. GitHub Settings → Secrets → `CLAUDE_CODE_OAUTH_TOKEN` を更新
+          3. このワークフローを手動実行して復旧を確認
+
+          ## 影響
+
+          - `claude.yml` (`@claude` メンション) が機能停止
+          - `claude-code-review.yml` (AI コードレビュー) が機能停止
+
+          ---
+          *このIssueは Claude Code Health Check ワークフローにより自動作成されました。*
+          BODY
+          )"


### PR DESCRIPTION
## Summary

Closes #616, Closes #617, Closes #618

3件の CI 関連 Issue をまとめて修正。

## 変更内容

### #617: claude.yml の concurrency 自己キャンセル問題
- `claude[bot]` を actor フィルターに追加
- `claude[bot]` の応答コメントがワークフローをトリガーし、実行中のジョブを自己キャンセルしていた問題を修正

### #616: enforce_admins デフォルトを false に変更
- `setup-team-protection` の main ブランチ保護で `enforce_admins=false` をデフォルトに
- 管理者が自身の PR をマージできなくなる問題を解消
- 影響ファイル: `.claude/commands/setup-team-protection.md`, `script/setup-team-protection.sh`

### #618: Claude Code OAuth ヘルスチェックワークフロー追加
- `templates/workflows/claude-health-check.yml` を新規追加
- 毎週月曜にトークン有効性を確認、失敗時に Issue を自動作成
- 重複 Issue 防止（`claude-health` ラベルで既存チェック）

## Test plan

- [x] 全テスト通過 (95 tests)
- [x] Prettier フォーマット通過
- [ ] claude.yml: `claude[bot]` コメントでワークフローがトリガーされないこと

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added automated health check workflow that runs weekly to validate service connectivity and create notifications if issues are detected.

* **Changes**
  * Branch protection admin enforcement now defaults to disabled for default branches.
  * Updated workflow execution to exclude bot-triggered events, reducing unnecessary job runs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->