### PR TITLE
fix: scheduled-maintenance の direct_prompt を prompt に修正

### DIFF
--- a/.github/workflows/scheduled-maintenance.yml
+++ b/.github/workflows/scheduled-maintenance.yml
@@ -42,7 +42,7 @@ jobs:
         uses: anthropics/claude-code-action@d59651bd82c48d81756854675ce4fa4d69722200 # v1
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
-          direct_prompt: |
+          prompt: |
             /repo-maintenance --mode ${{ inputs.mode || 'full' }} --create-pr
 
             After completing maintenance, create a summary issue comment or issue with:
@@ -51,7 +51,6 @@ jobs:
             - What needs manual attention
 
             If no updates are needed, do NOT create an issue.
-          timeout_minutes: 25
           settings: |
             {
               "permissions": {

--- a/templates/workflows/scheduled-maintenance.yml
+++ b/templates/workflows/scheduled-maintenance.yml
@@ -42,7 +42,7 @@ jobs:
         uses: anthropics/claude-code-action@d59651bd82c48d81756854675ce4fa4d69722200 # v1
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
-          direct_prompt: |
+          prompt: |
             /repo-maintenance --mode ${{ inputs.mode || 'full' }} --create-pr
 
             After completing maintenance, create a summary issue comment or issue with:
@@ -51,7 +51,6 @@ jobs:
             - What needs manual attention
 
             If no updates are needed, do NOT create an issue.
-          timeout_minutes: 25
           settings: |
             {
               "permissions": {


### PR DESCRIPTION
## Summary

- `claude-code-action` v1 の有効な input は `prompt` であり、`direct_prompt` / `timeout_minutes` は無効
- 動作確認時の警告を解消

## Test plan

- [ ] `workflow_dispatch` で再実行し、warnings が出ないこと確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)