### PR TITLE
fix: BuildKit secret のプレーンテキストトークンを JSON に変換

### DIFF
--- a/script/install-claude-plugins.sh
+++ b/script/install-claude-plugins.sh
@@ -51,9 +51,24 @@ fi
 # --- 認証情報の設定 ---
 mkdir -p "$CLAUDE_DIR"
 
-if [[ -f "$CREDENTIALS_SECRET" ]]; then
+if [[ -f "$CREDENTIALS_SECRET" ]] && [[ -s "$CREDENTIALS_SECRET" ]]; then
     log_info "BuildKit secret から認証情報を読み込み中..."
-    cp "$CREDENTIALS_SECRET" "${CLAUDE_DIR}/.credentials.json"
+    SECRET_CONTENT=$(cat "$CREDENTIALS_SECRET")
+    if echo "$SECRET_CONTENT" | python3 -c "import sys,json; json.load(sys.stdin)" 2>/dev/null; then
+        # JSON 形式: そのままコピー
+        cp "$CREDENTIALS_SECRET" "${CLAUDE_DIR}/.credentials.json"
+    else
+        # プレーンテキスト（トークン文字列）: JSON に変換
+        log_info "トークン文字列を credentials JSON に変換中..."
+        cat > "${CLAUDE_DIR}/.credentials.json" << CRED_EOF
+{
+  "claudeAiOauth": {
+    "accessToken": "${SECRET_CONTENT}",
+    "expiresAt": 9999999999999
+  }
+}
+CRED_EOF
+    fi
     chmod 600 "${CLAUDE_DIR}/.credentials.json"
 elif [[ -n "${CLAUDE_CODE_OAUTH_TOKEN:-}" ]]; then
     log_info "CLAUDE_CODE_OAUTH_TOKEN から認証情報を作成中..."


### PR DESCRIPTION
## Summary

- `install-claude-plugins.sh` で BuildKit secret の内容が JSON かプレーンテキストかを判定し、プレーンテキストの場合は credentials JSON に変換するロジックを追加
- これにより `docker-image.yml` から `CLAUDE_CODE_OAUTH_TOKEN` を BuildKit secret として渡した場合にプラグインが正しくインストールされる

## Why

`docker-image.yml` は `secrets: claude_credentials=${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}` でトークン文字列を渡すが、スクリプト側はそれを JSON ファイルとして `cp` していたため、プラグインインストールが失敗していた。

## How

BuildKit secret ファイルの内容を `python3 -c "import sys,json; json.load(sys.stdin)"` で JSON 判定し:
- JSON → そのままコピー
- プレーンテキスト → `claudeAiOauth` JSON に変換

セキュリティ: secret はレイヤーに残らず、`.credentials.json` はスクリプト末尾で削除される。

## Test plan

- [ ] `workflow_dispatch` でイメージビルドを実行し、プラグインがインストールされることを確認
- [ ] ビルドログに `[INFO] トークン文字列を credentials JSON に変換中...` が表示されること

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved credentials validation during plugin installation with automatic recovery from malformed credentials.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->