### PR TITLE
fix: credentials JSON 生成を python3 に統一し特殊文字問題を解消

### DIFF
--- a/script/install-claude-plugins.sh
+++ b/script/install-claude-plugins.sh
@@ -68,36 +68,33 @@ if [[ -n "$CREDENTIALS_SECRET" ]]; then
     else
         # プレーンテキスト（トークン文字列）: JSON に変換
         log_info "トークン文字列を credentials JSON に変換中..."
-        cat > "${CLAUDE_DIR}/.credentials.json" << CRED_EOF
-{
-  "claudeAiOauth": {
-    "accessToken": "${SECRET_CONTENT}",
-    "expiresAt": 9999999999999
-  }
-}
-CRED_EOF
+        python3 -c "
+import json, sys
+token = sys.argv[1]
+creds = {'claudeAiOauth': {'accessToken': token, 'expiresAt': 9999999999999}}
+with open(sys.argv[2], 'w') as f:
+    json.dump(creds, f, indent=2)
+" "$SECRET_CONTENT" "${CLAUDE_DIR}/.credentials.json"
     fi
     chmod 600 "${CLAUDE_DIR}/.credentials.json"
 elif [[ -n "${CLAUDE_CODE_OAUTH_TOKEN:-}" ]]; then
     log_info "CLAUDE_CODE_OAUTH_TOKEN から認証情報を作成中..."
-    cat > "${CLAUDE_DIR}/.credentials.json" << EOF
-{
-  "claudeAiOauth": {
-    "accessToken": "${CLAUDE_CODE_OAUTH_TOKEN}",
-    "expiresAt": 9999999999999
-  }
-}
-EOF
+    python3 -c "
+import json, sys
+token = sys.argv[1]
+creds = {'claudeAiOauth': {'accessToken': token, 'expiresAt': 9999999999999}}
+with open(sys.argv[2], 'w') as f:
+    json.dump(creds, f, indent=2)
+" "$CLAUDE_CODE_OAUTH_TOKEN" "${CLAUDE_DIR}/.credentials.json"
 elif [[ -n "${ANTHROPIC_API_KEY:-}" ]]; then
     log_info "ANTHROPIC_API_KEY から認証情報を作成中..."
-    cat > "${CLAUDE_DIR}/.credentials.json" << EOF
-{
-  "claudeAiOauth": {
-    "accessToken": "${ANTHROPIC_API_KEY}",
-    "expiresAt": 9999999999999
-  }
-}
-EOF
+    python3 -c "
+import json, sys
+token = sys.argv[1]
+creds = {'claudeAiOauth': {'accessToken': token, 'expiresAt': 9999999999999}}
+with open(sys.argv[2], 'w') as f:
+    json.dump(creds, f, indent=2)
+" "$ANTHROPIC_API_KEY" "${CLAUDE_DIR}/.credentials.json"
 else
     log_warn "認証情報が見つかりません"
     echo "  - BuildKit secret: $CREDENTIALS_SECRET"


### PR DESCRIPTION
## Summary

- トークンの credentials JSON 生成を heredoc から python3 `json.dump` に変更
- トークン文字列に `$` や backtick 等の特殊文字が含まれる場合のシェル展開問題を解消

## Why

前回の修正（PR #635）でビルドは成功したが、プラグインインストールがトークン変換直後にクラッシュしていた。原因は heredoc 内でのトークン展開時にシェルの特殊文字が展開されていたため。

## Test plan

- [ ] ビルドログで `known_marketplaces.json を生成しました` まで到達すること
- [ ] `Claude version: x.x.x` が表示されること

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved the credential installation process for Claude plugins by refactoring token handling logic.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->