### PR TITLE
feat: スケジュールエージェント設定スクリプトを追加

### DIFF
--- a/script/setup-scheduled-agents.sh
+++ b/script/setup-scheduled-agents.sh
@@ -21,7 +21,7 @@ echo "リポジトリ: $REPO"
 echo ""
 
 # 既存スケジュール一覧を取得（冪等性確保）
-existing_schedules="$(claude schedule list 2>/dev/null | grep -oP '(?<=Name: ).*' || true)"
+existing_schedules="$(claude schedule list 2>/dev/null | sed -n 's/^Name: //p' || true)"
 
 # スケジュールが未登録の場合のみ作成するヘルパー関数
 create_schedule_if_not_exists() {
@@ -40,7 +40,6 @@ create_schedule_if_not_exists() {
 # 1. 依存関係の健全性レビュー（毎週月曜 10:00 JST = 1:00 UTC）
 echo "[1/9] 依存関係健全性レビュー（毎週月曜 10:00 JST）"
 create_schedule_if_not_exists "依存関係健全性レビュー" \
-  --name "依存関係健全性レビュー" \
   --cron "0 1 * * 1" \
   --repo "$REPO" \
   --prompt "このリポジトリの依存関係の健全性をチェックしてください。
@@ -133,7 +132,7 @@ create_schedule_if_not_exists "新規Issueトリアージ" \
   --cron "0 2 * * *" \
   --repo "$REPO" \
   --prompt "未トリアージのIssueを整理してください。
-1. gh issue list --label '' --state open でラベルなしのIssueを取得
+1. gh issue list --search 'no:label' --state open でラベルなしのIssueを取得
 2. Issue内容を分析し、適切なラベルを提案（bug, enhancement, documentation, maintenance等）
 3. 優先度を判定（critical/high/medium/low）
 4. 関連するファイルやコンポーネントを特定


### PR DESCRIPTION
## Summary
- Claude Code Remote Trigger API で定期実行するエージェント9種のセットアップスクリプトを追加
- プラン上限（3トリガー）のため、現在は依存関係・config-base同期・コード複雑度の3つを登録済み

### 登録済みトリガー（3/3）
| 名前 | スケジュール | 目的 |
|---|---|---|
| 依存関係健全性レビュー | 毎週月曜 10:00 JST | npm audit/outdated で脆弱性・古いパッケージを検出 |
| config-base同期チェック | 毎週水曜 10:00 JST | DevContainer ベースイメージの更新検知・PR作成 |
| コード複雑度監視 | 毎週金曜 10:00 JST | 循環的複雑度の監視・Issue作成 |

### スクリプトに含まれる未登録トリガー（6/9）
- テンプレート乖離チェック（月次）
- ドキュメント鮮度チェック（月次）
- CI失敗分析（毎日）
- 未テストパス検出（週次）
- 新規Issueトリアージ（毎日）
- 週次リリースノート（週次）

## Test plan
- [ ] `bash script/setup-scheduled-agents.sh` の構文確認（`bash -n`）
- [ ] 登録済み3トリガーの動作確認: https://claude.ai/code/scheduled

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a setup script to enable scheduled automated repository maintenance tasks: dependency security reviews, config sync checks, code complexity monitoring, template divergence checks, document freshness checks, daily CI failure analysis, uncovered-test-path detection, new-issue triage, and weekly release notes.
  * Script is safe to re-run and idempotent, tolerates individual schedule creation errors without stopping, and prints a completion message with the scheduled-agents management URL.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->