### PR TITLE
fix: claude ワークフローの bot 自己トリガーループを防止

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -120,7 +120,7 @@ jobs:
 
   claude-review:
     # CIが成功した場合のみ実行（Draft PR、Dependabotはスキップ）
-    if: github.event.pull_request.draft == false && needs.check-ci-status.outputs.ci_passed == 'true' && github.actor != 'dependabot[bot]'
+    if: github.event.pull_request.draft == false && needs.check-ci-status.outputs.ci_passed == 'true' && github.event.sender.type != 'Bot'
     needs: [check-ci-status]
     runs-on: ubuntu-latest
     timeout-minutes: 20

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -13,15 +13,35 @@ on:
 permissions: {}
 
 concurrency:
+<<<<<<< Updated upstream
   group: claude-${{ github.repository }}-${{ github.event.issue.number || github.event.pull_request.number || github.run_id }}
+=======
+  # イベント種別 + トリガーのコメント/レビューIDを含めることで、
+  # 同一 PR/Issue 内でも異なるメンションが互いをキャンセルしない
+  group: >-
+    claude-${{ github.repository }}-${{
+      github.event.issue.number
+      || github.event.pull_request.number
+      || github.run_id
+    }}-${{
+      github.event.comment.id
+      || github.event.review.id
+      || github.run_id
+    }}
+>>>>>>> Stashed changes
   cancel-in-progress: false
 
 jobs:
   claude:
+    # Bot 全般を除外（sender.type で判定するため、Bot 名のハードコードが不要）
     if: |
+<<<<<<< Updated upstream
       github.actor != 'github-actions[bot]' &&
       github.actor != 'dependabot[bot]' &&
       github.actor != 'claude[bot]' &&
+=======
+      github.event.sender.type != 'Bot' &&
+>>>>>>> Stashed changes
       (
         (github.event_name == 'issue_comment' && contains(github.event.comment.body || '', '@claude') &&
           !(github.event.issue.pull_request && github.event.issue.pull_request.url && github.event.issue.draft == true)) ||


### PR DESCRIPTION
## Summary
- Claude Code Action の「working...」コメントが issue_comment イベントを再トリガーし、既存のワークフロー実行がキャンセルされる問題を修正
- Bot フィルタ `github.event.sender.type != 'Bot'` を追加（全 Bot 一括除外）
- concurrency group に `comment.id` / `review.id` を追加

## Test plan
- [ ] Bot のコメントでワークフローがトリガーされないことを確認
- [ ] 人間の `@claude` メンションで正常に起動することを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated internal CI/CD workflow configuration to improve automated bot detection and prevent unnecessary cancellations across multiple workflow triggers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->