### PR TITLE
fix: enable all Claude Code plugins and resolve claude.yml conflicts

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -278,6 +278,22 @@
     ]
   },
   "enabledPlugins": {
-    "typescript-lsp@claude-plugins-official": true
+    "typescript-lsp@claude-plugins-official": true,
+    "swift-lsp@claude-plugins-official": true,
+    "devops-automation@claude-code-templates": true,
+    "documentation-generator@claude-code-templates": true,
+    "backend-development@claude-code-workflows": true,
+    "code-refactoring@claude-code-workflows": true,
+    "database-design@claude-code-workflows": true,
+    "database-migrations@claude-code-workflows": true,
+    "full-stack-orchestration@claude-code-workflows": true,
+    "javascript-typescript@claude-code-workflows": true,
+    "kubernetes-operations@claude-code-workflows": true,
+    "feature-dev@claude-code-plugins": true,
+    "frontend-design@claude-code-plugins": true,
+    "hookify@claude-code-plugins": true,
+    "security-guidance@claude-code-plugins": true,
+    "nextjs-vercel-pro@claude-code-templates": true,
+    "supabase-toolkit@claude-code-templates": true
   }
 }

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -13,9 +13,6 @@ on:
 permissions: {}
 
 concurrency:
-<<<<<<< Updated upstream
-  group: claude-${{ github.repository }}-${{ github.event.issue.number || github.event.pull_request.number || github.run_id }}
-=======
   # イベント種別 + トリガーのコメント/レビューIDを含めることで、
   # 同一 PR/Issue 内でも異なるメンションが互いをキャンセルしない
   group: >-
@@ -28,20 +25,13 @@ concurrency:
       || github.event.review.id
       || github.run_id
     }}
->>>>>>> Stashed changes
   cancel-in-progress: false
 
 jobs:
   claude:
     # Bot 全般を除外（sender.type で判定するため、Bot 名のハードコードが不要）
     if: |
-<<<<<<< Updated upstream
-      github.actor != 'github-actions[bot]' &&
-      github.actor != 'dependabot[bot]' &&
-      github.actor != 'claude[bot]' &&
-=======
       github.event.sender.type != 'Bot' &&
->>>>>>> Stashed changes
       (
         (github.event_name == 'issue_comment' && contains(github.event.comment.body || '', '@claude') &&
           !(github.event.issue.pull_request && github.event.issue.pull_request.url && github.event.issue.draft == true)) ||


### PR DESCRIPTION
## Summary
- プロジェクトの `enabledPlugins` に全プラグイン（16個）を追加し、他リポジトリでもデフォルトで有効化
- `claude.yml` に残っていたマージコンフリクトマーカーを解消
  - Bot 判定: `sender.type != 'Bot'` を採用（ハードコード不要）
  - Concurrency group: コメント/レビューID を含む詳細グループを採用

## Test plan
- [ ] CI が緑になること
- [ ] 他リポジトリ（n8n_custom_node 等）で `claude plugins list` が全て enabled であること
- [ ] `claude.yml` ワークフローが正常に動作すること

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Expanded development tool integration ecosystem to enable Swift language support, code documentation generation, backend development workflows, database management operations, frontend design tooling, and security guidance features.
  * Resolved GitHub Actions workflow configuration conflicts and improved bot filtering logic to enhance continuous integration reliability and deployment automation accuracy.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->