### PR TITLE
fix: nvm lazy load で claude CLI が動作しない問題を修正

### DIFF
--- a/nix/home/zsh.nix
+++ b/nix/home/zsh.nix
@@ -107,9 +107,17 @@
       text = ''
         export NVM_DIR="$HOME/.nvm"
 
-        # nvm lazy load: node/npm/npx/nvm 初回実行時にロード (~700ms 短縮)
+        # デフォルト Node.js の PATH を即座に設定（claude 等の #!/usr/bin/env node 用）
+        # nvm 本体の初期化のみ遅延させる
+        if [ -d "$NVM_DIR/versions/node" ]; then
+          # 最新のインストール済みバージョンを使用
+          NODE_BIN=$(ls -d "$NVM_DIR/versions/node"/*/bin 2>/dev/null | sort -V | tail -1)
+          [ -d "$NODE_BIN" ] && export PATH="$NODE_BIN:$PATH"
+        fi
+
+        # nvm 本体の遅延読み込み（nvm コマンド初回実行時のみ）
         _nvm_lazy_load() {
-          unset -f nvm node npm npx
+          unset -f nvm
           local brew_prefix="''${HOMEBREW_PREFIX:-/opt/homebrew}"
           local nvm_sh="$brew_prefix/opt/nvm/nvm.sh"
           local nvm_comp="$brew_prefix/opt/nvm/etc/bash_completion.d/nvm"
@@ -117,17 +125,19 @@
             \. "$nvm_sh"
             [ -s "$nvm_comp" ] && \. "$nvm_comp"
           elif [ -s "''${NVM_DIR}/nvm.sh" ]; then
-            # フォールバック: 非Homebrew インストール ($NVM_DIR) を使用
             \. "''${NVM_DIR}/nvm.sh"
           else
             echo "nvm: nvm.sh not found (checked: $nvm_sh, ''${NVM_DIR}/nvm.sh)" >&2
             return 1
           fi
         }
-        nvm()  { _nvm_lazy_load; nvm "$@"; }
-        node() { _nvm_lazy_load; node "$@"; }
-        npm()  { _nvm_lazy_load; npm "$@"; }
-        npx()  { _nvm_lazy_load; npx "$@"; }
+        nvm() { _nvm_lazy_load; nvm "$@"; }
+
+        export PNPM_HOME="$HOME/Library/pnpm"
+        case ":$PATH:" in
+          *":$PNPM_HOME:"*) ;;
+          *) export PATH="$PNPM_HOME:$PATH" ;;
+        esac
       '';
     };
 


### PR DESCRIPTION
## 概要

PR #662 の nvm 遅延読み込みで `claude` CLI が起動できなくなった問題を修正。

## 原因

1. `node`/`npm`/`npx` をシェル関数でラップ → `#!/usr/bin/env node` から見えない
2. nvm alias 解決で `default` → `node`（シンボリック名）を直接バージョンと解釈 → パスが `vnode/bin` になり不正

## 修正内容

- alias 解決ロジックを廃止し、`ls | sort -V | tail -1` で最新バージョンの bin を PATH に追加
- `node`/`npm`/`npx` のシェル関数ラッパーを廃止（バイナリを直接使用）
- `nvm` コマンドのみ遅延読み込みを維持
- 起動時間: 0.37s（変化なし）

## テスト

- ✅ `claude --version` → `2.1.91 (Claude Code)`
- ✅ `node --version` → `v24.4.0`
- ✅ `time zsh -i -c exit` → 0.37s
- ✅ pre-commit: Format, Lint, Test 通過

Closes #663

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Node.js environment initialization in shell configuration for more direct access to development tools.
  * Refactored package manager path setup during shell startup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->