### PR TITLE
fix: GitHub Actions を最新バージョンに一括更新

### DIFF
--- a/.claude/agents/issue-resolver-dependencies.md
+++ b/.claude/agents/issue-resolver-dependencies.md
@@ -302,10 +302,10 @@ jobs:
   update:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: '18'
           cache: 'npm'

--- a/.claude/agents/issue-resolver-orchestrator.md
+++ b/.claude/agents/issue-resolver-orchestrator.md
@@ -436,12 +436,12 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: '18'
           cache: 'npm'
@@ -465,7 +465,7 @@ jobs:
           bash .claude/agents/issue-resolver-orchestrator.md
 
       - name: Upload execution report
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v7
         with:
           name: resolution-report
           path: |

--- a/.claude/commands/repo-maintenance.md
+++ b/.claude/commands/repo-maintenance.md
@@ -2127,7 +2127,7 @@ jobs:
   dependency-review:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - uses: actions/dependency-review-action@v4
         with:
           fail-on-severity: critical

--- a/.claude/commands/setup-ci.md
+++ b/.claude/commands/setup-ci.md
@@ -123,8 +123,8 @@ jobs:
   quality:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
+      - uses: actions/checkout@v6
+      - uses: actions/setup-node@v6
         with:
           node-version: '22'
           cache: 'npm'
@@ -153,8 +153,8 @@ jobs:
   quality:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
+      - uses: actions/checkout@v6
+      - uses: actions/setup-node@v6
         with:
           node-version: '22'
           cache: 'npm'
@@ -173,8 +173,8 @@ jobs:
     runs-on: ubuntu-latest
     needs: quality
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
+      - uses: actions/checkout@v6
+      - uses: actions/setup-node@v6
         with:
           node-version: '22'
           cache: 'npm'
@@ -184,7 +184,7 @@ jobs:
         run: npm test -- --coverage
 
       - name: Upload Coverage
-        uses: codecov/codecov-action@v4
+        uses: codecov/codecov-action@v6
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           fail_ci_if_error: false
@@ -193,8 +193,8 @@ jobs:
     runs-on: ubuntu-latest
     needs: [quality, test]
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
+      - uses: actions/checkout@v6
+      - uses: actions/setup-node@v6
         with:
           node-version: '22'
           cache: 'npm'
@@ -204,8 +204,8 @@ jobs:
   security:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
+      - uses: actions/checkout@v6
+      - uses: actions/setup-node@v6
         with:
           node-version: '22'
           cache: 'npm'
@@ -225,8 +225,8 @@ e2e:
   runs-on: ubuntu-latest
   needs: build
   steps:
-    - uses: actions/checkout@v4
-    - uses: actions/setup-node@v4
+    - uses: actions/checkout@v6
+    - uses: actions/setup-node@v6
       with:
         node-version: '22'
         cache: 'npm'
@@ -235,7 +235,7 @@ e2e:
       run: npx playwright install --with-deps chromium
     - name: Run E2E Tests
       run: npm run test:e2e
-    - uses: actions/upload-artifact@v4
+    - uses: actions/upload-artifact@v7
       if: failure()
       with:
         name: playwright-report
@@ -256,8 +256,8 @@ jobs:
   audit:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
+      - uses: actions/checkout@v6
+      - uses: actions/setup-node@v6
         with:
           node-version: '22'
           cache: 'npm'
@@ -272,7 +272,7 @@ jobs:
     permissions:
       security-events: write
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - uses: github/codeql-action/init@v3
         with:
           languages: javascript-typescript
@@ -384,7 +384,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 1
 
@@ -433,8 +433,8 @@ jobs:
       matrix:
         node-version: [18, 20, 22]
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
+      - uses: actions/checkout@v6
+      - uses: actions/setup-node@v6
         with:
           node-version: ${{ matrix.node-version }}
           cache: 'npm'
@@ -443,17 +443,17 @@ jobs:
       - run: npm test -- --coverage
       - name: Upload Coverage
         if: matrix.node-version == 22
-        uses: codecov/codecov-action@v4
+        uses: codecov/codecov-action@v6
 
   release:
     runs-on: ubuntu-latest
     needs: test
     if: github.ref == 'refs/heads/main'
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           fetch-depth: 0
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v6
         with:
           node-version: '22'
           cache: 'npm'
@@ -488,8 +488,8 @@ jobs:
   validate:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: hashicorp/setup-terraform@v3
+      - uses: actions/checkout@v6
+      - uses: hashicorp/setup-terraform@v4
         with:
           terraform_version: '1.9'
 
@@ -508,7 +508,7 @@ jobs:
   security:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - name: Run Checkov
         uses: bridgecrewio/checkov-action@v12
         with:
@@ -523,8 +523,8 @@ jobs:
     runs-on: ubuntu-latest
     needs: [validate, security]
     steps:
-      - uses: actions/checkout@v4
-      - uses: hashicorp/setup-terraform@v3
+      - uses: actions/checkout@v6
+      - uses: hashicorp/setup-terraform@v4
 
       - name: Terraform init
         run: terraform init
@@ -536,7 +536,7 @@ jobs:
         working-directory: terraform
 
       - name: Comment PR
-        uses: actions/github-script@v7
+        uses: actions/github-script@v9
         with:
           script: |
             const output = `#### Terraform Plan
@@ -572,7 +572,7 @@ jobs:
     outputs:
       packages: ${{ steps.filter.outputs.changes }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - uses: dorny/paths-filter@v3
         id: filter
         with:
@@ -590,11 +590,11 @@ jobs:
       matrix:
         package: ${{ fromJson(needs.detect-changes.outputs.packages) }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - uses: pnpm/action-setup@v4
         with:
           version: 9
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v6
         with:
           node-version: '22'
           cache: 'pnpm'
@@ -608,13 +608,13 @@ jobs:
     needs: test
     if: github.ref == 'refs/heads/main'
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           fetch-depth: 0
       - uses: pnpm/action-setup@v4
         with:
           version: 9
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v6
         with:
           node-version: '22'
           cache: 'pnpm'

--- a/.claude/commands/setup-husky.md
+++ b/.claude/commands/setup-husky.md
@@ -136,7 +136,7 @@ pull_request:
 jobs:
 node:
 runs-on: ubuntu-latest
-steps: - uses: actions/checkout@v4 - uses: actions/setup-node@v4
+steps: - uses: actions/checkout@v6 - uses: actions/setup-node@v6
 with:
 node-version: 20
 cache: npm - run: npm ci - run: npm ci

--- a/.claude/commands/setup-tests.md
+++ b/.claude/commands/setup-tests.md
@@ -335,14 +335,14 @@ mkdir -p tests/contract
 unit-tests:
   runs-on: ubuntu-latest
   steps:
-    - uses: actions/checkout@v4
-    - uses: actions/setup-node@v4
+    - uses: actions/checkout@v6
+    - uses: actions/setup-node@v6
       with:
         node-version: '22'
         cache: 'npm'
     - run: npm ci
     - run: npm run test:ci
-    - uses: codecov/codecov-action@v4
+    - uses: codecov/codecov-action@v6
 ```
 
 ### Standard Level (+)
@@ -351,8 +351,8 @@ unit-tests:
 e2e-tests:
   runs-on: ubuntu-latest
   steps:
-    - uses: actions/checkout@v4
-    - uses: actions/setup-node@v4
+    - uses: actions/checkout@v6
+    - uses: actions/setup-node@v6
     - run: npm ci
     - run: npx playwright install --with-deps chromium
     - run: npm run build
@@ -369,8 +369,8 @@ regression-tests:
   runs-on: ubuntu-latest
   if: github.base_ref == 'main' || github.base_ref == 'production'
   steps:
-    - uses: actions/checkout@v4
-    - uses: actions/setup-node@v4
+    - uses: actions/checkout@v6
+    - uses: actions/setup-node@v6
     - run: npm ci
     - run: npx playwright install --with-deps chromium
     - run: npm run build
@@ -386,13 +386,13 @@ regression-tests:
 visual-tests:
   runs-on: ubuntu-latest
   steps:
-    - uses: actions/checkout@v4
-    - uses: actions/setup-node@v4
+    - uses: actions/checkout@v6
+    - uses: actions/setup-node@v6
     - run: npm ci
     - run: npx playwright install --with-deps
     - run: npm run build
     - run: npm run test:visual
-    - uses: actions/upload-artifact@v4
+    - uses: actions/upload-artifact@v7
       if: failure()
       with:
         name: visual-diff
@@ -401,8 +401,8 @@ visual-tests:
 a11y-tests:
   runs-on: ubuntu-latest
   steps:
-    - uses: actions/checkout@v4
-    - uses: actions/setup-node@v4
+    - uses: actions/checkout@v6
+    - uses: actions/setup-node@v6
     - run: npm ci
     - run: npx playwright install --with-deps chromium
     - run: npm run build

--- a/.github/actions/coverage-comment/action.yml
+++ b/.github/actions/coverage-comment/action.yml
@@ -15,7 +15,7 @@ runs:
   using: 'composite'
   steps:
     - name: Post Coverage Comment
-      uses: actions/github-script@v7
+      uses: actions/github-script@v9
       with:
         github-token: ${{ inputs.github-token }}
         script: |

--- a/.github/actions/coverage-comment/example-integration.yml
+++ b/.github/actions/coverage-comment/example-integration.yml
@@ -10,7 +10,7 @@ test:
   needs: changes
   if: needs.changes.outputs.code == 'true' || needs.changes.outputs.dependencies == 'true'
   steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v6
 
     - uses: actions/setup-node@v6
       with:
@@ -39,7 +39,7 @@ test:
     # ===== ここまで追加 =====
 
     - name: Upload test results
-      uses: actions/upload-artifact@v6
+      uses: actions/upload-artifact@v7
       if: always()
       with:
         name: test-results

--- a/.github/actions/setup-node-ci/action.yml
+++ b/.github/actions/setup-node-ci/action.yml
@@ -16,6 +16,6 @@ runs:
         cache: 'npm'
 
     - name: Install dependencies
-      if: ${{ inputs.install == 'true' }}
+      if: inputs.install == 'true'
       run: npm ci
       shell: bash

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -124,7 +124,7 @@ jobs:
           JEST_JUNIT_OUTPUT_NAME: junit.xml
 
       - name: Upload test results
-        uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         if: always()
         with:
           name: test-results
@@ -142,7 +142,7 @@ jobs:
           fail-on-error: false
 
       - name: Upload coverage reports
-        uses: codecov/codecov-action@1af58845a975a7985b0beb0cbe6fbbb71a41dbad # v5.5.3
+        uses: codecov/codecov-action@57e3a136b779b570ffcdbf80b3bdc90e7fab3de2 # v6
         if: always()
         with:
           files: ./coverage/lcov.info
@@ -172,7 +172,7 @@ jobs:
           bats test/integration/*.bats --formatter tap > reports/bats-results.tap
 
       - name: Upload integration test results
-        uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         if: always()
         with:
           name: integration-test-results
@@ -189,7 +189,7 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
       - name: Run actionlint
-        uses: reviewdog/action-actionlint@0d952c597ef8459f634d7145b0b044a9699e5e43 # v1.71.0
+        uses: reviewdog/action-actionlint@6fb7acc99f4a1008869fa8a0f09cfca740837d9d # v1.72.0
         with:
           reporter: github-pr-review
           fail_on_error: true
@@ -202,7 +202,7 @@ jobs:
     continue-on-error: true
     steps:
       - name: Check PR Size
-        uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9
         continue-on-error: true
         with:
           script: |

--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -140,7 +140,7 @@ jobs:
       - name: Run Claude Code Review
         id: claude-review
         continue-on-error: true
-        uses: anthropics/claude-code-action@6062f3709600659be5e47fcddf2cf76993c235c2 # v1
+        uses: anthropics/claude-code-action@b47fd721da662d48c5680e154ad16a73ed74d2e0 # v1
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           prompt: |

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -58,7 +58,7 @@ jobs:
 
       - name: Run Claude Code
         id: claude
-        uses: anthropics/claude-code-action@d59651bd82c48d81756854675ce4fa4d69722200 # v1
+        uses: anthropics/claude-code-action@b47fd721da662d48c5680e154ad16a73ed74d2e0 # v1
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
 

--- a/.github/workflows/container-security.yml
+++ b/.github/workflows/container-security.yml
@@ -52,7 +52,7 @@ jobs:
         uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd # v4
 
       - name: Build image for scanning
-        uses: docker/build-push-action@d08e5c354a6adb9ed34480a06d141179aa583294 # v7
+        uses: docker/build-push-action@bcafcacb16a39f128d818304e6c9c0c18556b85f # v7.1.0
         with:
           context: .
           file: .devcontainer/Dockerfile
@@ -126,7 +126,7 @@ jobs:
         uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd # v4
 
       - name: Build image for SBOM
-        uses: docker/build-push-action@d08e5c354a6adb9ed34480a06d141179aa583294 # v7
+        uses: docker/build-push-action@bcafcacb16a39f128d818304e6c9c0c18556b85f # v7.1.0
         with:
           context: .
           file: .devcontainer/Dockerfile
@@ -143,7 +143,7 @@ jobs:
           output-file: sbom.spdx.json
 
       - name: Upload SBOM artifact
-        uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: sbom
           path: sbom.spdx.json

--- a/.github/workflows/coverage-report.yml
+++ b/.github/workflows/coverage-report.yml
@@ -98,7 +98,7 @@ jobs:
           path: coverage-download
 
       - name: Post coverage comment
-        uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9
         env:
           REPORT_PATH: ${{ inputs.report-path }}
           COMMENT_TITLE: ${{ inputs.title }}
@@ -190,7 +190,7 @@ jobs:
           thresholds: '${{ inputs.min-coverage-overall }} ${{ inputs.min-coverage-changed-files }}'
 
       - name: Post coverage comment
-        uses: marocchino/sticky-pull-request-comment@70d2764d1a7d5d9560b100cbea0077fc8f633987 # v3.0.2
+        uses: marocchino/sticky-pull-request-comment@0ea0beb66eb9baf113663a64ec522f60e49231c0 # v3.0.4
         with:
           header: ${{ inputs.title }}
           message: |

--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -37,7 +37,7 @@ jobs:
       - name: Fetch Dependabot metadata
         if: github.actor == 'dependabot[bot]'
         id: metadata
-        uses: dependabot/fetch-metadata@21025c705c08248db411dc16f3619e6b5f9ea21a # v2
+        uses: dependabot/fetch-metadata@ffa630c65fa7e0ecfa0625b5ceda64399aea1b36 # v3
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
 

--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -158,7 +158,7 @@ jobs:
         with:
           driver-opts: image=moby/buildkit:latest
 
-      - uses: docker/login-action@b45d80f862d83dbcd57f89517bcf500b2ab88fb2 # v4
+      - uses: docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121 # v4.1.0
         if: steps.release.outputs.skip_release != 'true'
         with:
           registry: ghcr.io
@@ -167,7 +167,7 @@ jobs:
 
       - name: Build and push image with cache
         if: steps.release.outputs.skip_release != 'true'
-        uses: docker/build-push-action@d08e5c354a6adb9ed34480a06d141179aa583294 # v7
+        uses: docker/build-push-action@bcafcacb16a39f128d818304e6c9c0c18556b85f # v7.1.0
         with:
           context: .
           file: .devcontainer/Dockerfile
@@ -189,7 +189,7 @@ jobs:
         run: |
           docker run --rm -v "$PWD":/workspace -w /workspace ghcr.io/${{ github.repository_owner }}/config-base:latest bash -lc '{ brew --version; terraform --version; jq --version; } > devcontainer-info.txt'
 
-      - uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0
+      - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         if: steps.release.outputs.skip_release != 'true'
         with:
           name: devcontainer-info

--- a/.github/workflows/manual-release.yml
+++ b/.github/workflows/manual-release.yml
@@ -89,14 +89,14 @@ jobs:
         with:
           driver-opts: image=moby/buildkit:latest
 
-      - uses: docker/login-action@b45d80f862d83dbcd57f89517bcf500b2ab88fb2 # v4
+      - uses: docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121 # v4.1.0
         with:
           registry: ghcr.io
           username: ${{ github.repository_owner }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Build and push image
-        uses: docker/build-push-action@d08e5c354a6adb9ed34480a06d141179aa583294 # v7
+        uses: docker/build-push-action@bcafcacb16a39f128d818304e6c9c0c18556b85f # v7.1.0
         with:
           context: .
           file: .devcontainer/Dockerfile

--- a/.github/workflows/quality-gate-fallback.yml
+++ b/.github/workflows/quality-gate-fallback.yml
@@ -25,7 +25,7 @@ jobs:
     steps:
       - name: Check if CI workflow ran
         id: check
-        uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9
         with:
           script: |
             const { data: runs } = await github.rest.actions.listWorkflowRunsForRepo({

--- a/.github/workflows/rebuild-docker-cache.yml
+++ b/.github/workflows/rebuild-docker-cache.yml
@@ -56,7 +56,7 @@ jobs:
         with:
           driver-opts: image=moby/buildkit:latest
 
-      - uses: docker/login-action@b45d80f862d83dbcd57f89517bcf500b2ab88fb2 # v4
+      - uses: docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121 # v4.1.0
         with:
           registry: ghcr.io
           username: ${{ github.repository_owner }}
@@ -71,7 +71,7 @@ jobs:
           echo "Latest version: $LATEST_VERSION"
 
       - name: Build and push with no-cache
-        uses: docker/build-push-action@d08e5c354a6adb9ed34480a06d141179aa583294 # v7
+        uses: docker/build-push-action@bcafcacb16a39f128d818304e6c9c0c18556b85f # v7.1.0
         with:
           context: .
           file: .devcontainer/Dockerfile

--- a/.github/workflows/scheduled-maintenance.yml
+++ b/.github/workflows/scheduled-maintenance.yml
@@ -39,7 +39,7 @@ jobs:
 
       - name: Run scheduled maintenance
         id: maintenance
-        uses: anthropics/claude-code-action@d59651bd82c48d81756854675ce4fa4d69722200 # v1
+        uses: anthropics/claude-code-action@b47fd721da662d48c5680e154ad16a73ed74d2e0 # v1
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           prompt: |

--- a/.github/workflows/templates/README.md
+++ b/.github/workflows/templates/README.md
@@ -72,7 +72,7 @@ A reusable workflow that posts coverage summary as PR comments. Supports multipl
 | format      | Tools                      | Parser                                |
 | ----------- | -------------------------- | ------------------------------------- |
 | `jacoco`    | JaCoCo (Android/JVM)       | `madrapps/jacoco-report@v1.7.2`       |
-| `jest`      | Jest, Vitest, c8 (JS/TS)   | `actions/github-script@v8`            |
+| `jest`      | Jest, Vitest, c8 (JS/TS)   | `actions/github-script@v9`            |
 | `cobertura` | Cobertura (.NET/Python/Go) | `irongut/CodeCoverageSummary@v1.3.0`  |
 | `lcov`      | Istanbul, nyc, c8 (LCOV)   | `romeovs/lcov-reporter-action@v0.4.0` |
 
@@ -85,7 +85,7 @@ jobs:
     steps:
       - uses: actions/checkout@v6.0.2
       - run: npm ci && npm test -- --coverage
-      - uses: actions/upload-artifact@v6.0.0
+      - uses: actions/upload-artifact@v7.0.1
         if: github.event_name == 'pull_request'
         with:
           name: coverage-report
@@ -117,7 +117,7 @@ jobs:
           distribution: zulu
           java-version: 17
       - run: ./gradlew testDebugUnitTest createDebugUnitTestCoverageReport
-      - uses: actions/upload-artifact@v6.0.0
+      - uses: actions/upload-artifact@v7.0.1
         if: github.event_name == 'pull_request'
         with:
           name: jacoco-report
@@ -148,7 +148,7 @@ jobs:
         with:
           dotnet-version: '8.0'
       - run: dotnet test --collect:"XPlat Code Coverage"
-      - uses: actions/upload-artifact@v6.0.0
+      - uses: actions/upload-artifact@v7.0.1
         if: github.event_name == 'pull_request'
         with:
           name: cobertura-report
@@ -176,7 +176,7 @@ jobs:
     steps:
       - uses: actions/checkout@v6.0.2
       - run: npm ci && npm test -- --coverage --coverageReporters=lcov
-      - uses: actions/upload-artifact@v6.0.0
+      - uses: actions/upload-artifact@v7.0.1
         if: github.event_name == 'pull_request'
         with:
           name: lcov-report

--- a/.github/workflows/templates/tls-evidence.yml
+++ b/.github/workflows/templates/tls-evidence.yml
@@ -133,7 +133,7 @@ jobs:
             | tee -a cert_expiry.txt || true
 
       - name: Upload TLS Evidence
-        uses: actions/upload-artifact@v7.0.0
+        uses: actions/upload-artifact@v7.0.1
         with:
           name: tls-evidence-${{ github.run_number }}
           path: |

--- a/.github/workflows/templates/unified-ci.yml
+++ b/.github/workflows/templates/unified-ci.yml
@@ -103,7 +103,7 @@ jobs:
 
       - name: Upload coverage artifact
         if: github.event_name == 'pull_request' && hashFiles('coverage/coverage-summary.json') != ''
-        uses: actions/upload-artifact@v7.0.0
+        uses: actions/upload-artifact@v7.0.1
         with:
           name: coverage-report
           path: coverage/coverage-summary.json
@@ -133,7 +133,7 @@ jobs:
           fetch-depth: 0
 
       - name: Calculate PR size and add label
-        uses: actions/github-script@v8
+        uses: actions/github-script@v9
         with:
           script: |
             // Get PR details

--- a/.github/workflows/templates/update-db-types.yml
+++ b/.github/workflows/templates/update-db-types.yml
@@ -69,7 +69,7 @@ jobs:
 
       - name: Create Pull Request
         if: steps.changes.outputs.changed == 'true'
-        uses: peter-evans/create-pull-request@v7
+        uses: peter-evans/create-pull-request@v8
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           commit-message: 'chore: update database types'

--- a/.github/workflows/templates/zap-baseline.yml
+++ b/.github/workflows/templates/zap-baseline.yml
@@ -104,7 +104,7 @@ jobs:
 
       - name: Upload HTML Report
         if: always()
-        uses: actions/upload-artifact@v7.0.0
+        uses: actions/upload-artifact@v7.0.1
         with:
           name: zap-report-html
           path: report_html.html
@@ -112,7 +112,7 @@ jobs:
 
       - name: Upload JSON Report
         if: always()
-        uses: actions/upload-artifact@v7.0.0
+        uses: actions/upload-artifact@v7.0.1
         with:
           name: zap-report-json
           path: report_json.json

--- a/.github/workflows/update-claude-plugins.yml
+++ b/.github/workflows/update-claude-plugins.yml
@@ -71,7 +71,7 @@ jobs:
 
       - name: Create pull request
         if: steps.check.outputs.has_updates == 'true'
-        uses: peter-evans/create-pull-request@c0f553fe549906ede9cf27b5156039d195d2ece0 # v8.1.0
+        uses: peter-evans/create-pull-request@5f6978faf089d4d20b00c7766989d076bb2fc7f1 # v8.1.1
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           branch: fix/update-claude-plugins

--- a/.github/workflows/update-dev-tools.yml
+++ b/.github/workflows/update-dev-tools.yml
@@ -135,7 +135,7 @@ jobs:
 
       - name: Create pull request
         if: steps.compare.outputs.has_updates == 'true'
-        uses: peter-evans/create-pull-request@c0f553fe549906ede9cf27b5156039d195d2ece0 # v8.1.0
+        uses: peter-evans/create-pull-request@5f6978faf089d4d20b00c7766989d076bb2fc7f1 # v8.1.1
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           branch: fix/update-dev-tools

--- a/.github/workflows/update-libraries.yml
+++ b/.github/workflows/update-libraries.yml
@@ -62,7 +62,7 @@ jobs:
           } >> $GITHUB_OUTPUT
 
       - name: Create pull request
-        uses: peter-evans/create-pull-request@c0f553fe549906ede9cf27b5156039d195d2ece0 # v8.1.0
+        uses: peter-evans/create-pull-request@5f6978faf089d4d20b00c7766989d076bb2fc7f1 # v8.1.1
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           branch: fix/auto-library-update

--- a/docs/setup/README.md
+++ b/docs/setup/README.md
@@ -151,7 +151,7 @@ pr-size-check:
   if: github.event_name == 'pull_request'
   runs-on: ubuntu-latest
   steps:
-    - uses: actions/github-script@v7
+    - uses: actions/github-script@v9
       with:
         script: |
           const { additions, deletions, changed_files } = context.payload.pull_request;
@@ -196,7 +196,7 @@ notify-failure:
 actionlint:
   runs-on: ubuntu-latest
   steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v6
     - uses: reviewdog/action-actionlint@v1
       with:
         reporter: github-pr-review
@@ -372,7 +372,7 @@ jobs:
     steps:
       - uses: actions/checkout@v6
       - run: npm update
-      - uses: peter-evans/create-pull-request@v7
+      - uses: peter-evans/create-pull-request@v8
         with:
           title: 'chore(deps): update dependencies'
           branch: chore/update-dependencies

--- a/docs/setup/web-app-nextjs.md
+++ b/docs/setup/web-app-nextjs.md
@@ -510,7 +510,7 @@ export default withBundleAnalyzer({
   env:
     NEXT_TELEMETRY_DISABLED: 1
 # .next/analyze/ に生成されたレポートをアーティファクトとして保存
-- uses: actions/upload-artifact@v4
+- uses: actions/upload-artifact@v7
   if: always()
   with:
     name: bundle-report

--- a/templates/testing/ci-test-jobs.yml
+++ b/templates/testing/ci-test-jobs.yml
@@ -10,10 +10,10 @@ unit-tests:
   needs: quality-gate
   timeout-minutes: 15
   steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v6
 
     - name: Setup Node.js
-      uses: actions/setup-node@v4
+      uses: actions/setup-node@v6
       with:
         node-version: '22'
         cache: 'npm'
@@ -25,7 +25,7 @@ unit-tests:
       run: npm test -- --coverage --watchAll=false
 
     - name: Upload coverage to Codecov
-      uses: codecov/codecov-action@v4
+      uses: codecov/codecov-action@v6
       with:
         token: ${{ secrets.CODECOV_TOKEN }}
         files: ./coverage/lcov.info
@@ -34,7 +34,7 @@ unit-tests:
 
     - name: Comment PR with coverage report
       if: github.event_name == 'pull_request'
-      uses: actions/github-script@v7
+      uses: actions/github-script@v9
       with:
         script: |
           const fs = require('fs');
@@ -70,10 +70,10 @@ e2e-critical:
   if: github.event_name == 'pull_request'
   timeout-minutes: 20
   steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v6
 
     - name: Setup Node.js
-      uses: actions/setup-node@v4
+      uses: actions/setup-node@v6
       with:
         node-version: '22'
         cache: 'npm'
@@ -100,7 +100,7 @@ e2e-critical:
         PLAYWRIGHT_BASE_URL: 'http://127.0.0.1:3000'
 
     - name: Upload Playwright report
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v7
       if: failure()
       with:
         name: playwright-report-critical
@@ -117,10 +117,10 @@ e2e-full:
   if: github.ref == 'refs/heads/main'
   timeout-minutes: 30
   steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v6
 
     - name: Setup Node.js
-      uses: actions/setup-node@v4
+      uses: actions/setup-node@v6
       with:
         node-version: '22'
         cache: 'npm'
@@ -146,7 +146,7 @@ e2e-full:
         PLAYWRIGHT_BASE_URL: 'http://127.0.0.1:3000'
 
     - name: Upload Playwright report
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v7
       if: always()
       with:
         name: playwright-report-full

--- a/templates/workflows/claude-health-check.yml
+++ b/templates/workflows/claude-health-check.yml
@@ -16,7 +16,7 @@ jobs:
     steps:
       - name: Check Claude Code token validity
         id: check
-        uses: anthropics/claude-code-action@d59651bd82c48d81756854675ce4fa4d69722200 # v1
+        uses: anthropics/claude-code-action@b47fd721da662d48c5680e154ad16a73ed74d2e0 # v1
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           direct_prompt: 'Reply with only: OK'

--- a/templates/workflows/dependabot-auto-merge.yml
+++ b/templates/workflows/dependabot-auto-merge.yml
@@ -37,7 +37,7 @@ jobs:
       - name: Fetch Dependabot metadata
         if: github.actor == 'dependabot[bot]'
         id: metadata
-        uses: dependabot/fetch-metadata@21025c705c08248db411dc16f3619e6b5f9ea21a # v2
+        uses: dependabot/fetch-metadata@ffa630c65fa7e0ecfa0625b5ceda64399aea1b36 # v3
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
 

--- a/templates/workflows/scheduled-maintenance.yml
+++ b/templates/workflows/scheduled-maintenance.yml
@@ -39,7 +39,7 @@ jobs:
 
       - name: Run scheduled maintenance
         id: maintenance
-        uses: anthropics/claude-code-action@d59651bd82c48d81756854675ce4fa4d69722200 # v1
+        uses: anthropics/claude-code-action@b47fd721da662d48c5680e154ad16a73ed74d2e0 # v1
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           prompt: |

--- a/templates/workflows/stale.yml
+++ b/templates/workflows/stale.yml
@@ -29,7 +29,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:
-      - uses: actions/stale@v9
+      - uses: actions/stale@v10
         with:
           # ── Issue 設定 ──
           days-before-issue-stale: 30

--- a/templates/workflows/terraform-drift.yml
+++ b/templates/workflows/terraform-drift.yml
@@ -106,13 +106,13 @@ jobs:
       # リポジトリのチェックアウト
       # -----------------------------------------------------------------
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       # -----------------------------------------------------------------
       # Terraform セットアップ
       # -----------------------------------------------------------------
       - name: Setup Terraform
-        uses: hashicorp/setup-terraform@v3
+        uses: hashicorp/setup-terraform@v4
         with:
           # TODO: プロジェクトで使用する Terraform バージョンを指定する
           terraform_version: '~> 1.9'
@@ -208,7 +208,7 @@ jobs:
       - name: Check existing drift issue
         id: check_issue
         if: steps.plan.outputs.drift_detected == 'true'
-        uses: actions/github-script@v7
+        uses: actions/github-script@v9
         with:
           script: |
             // 既存の未解決ドリフト Issue を検索する
@@ -235,7 +235,7 @@ jobs:
         if: >-
           steps.plan.outputs.drift_detected == 'true' &&
           steps.check_issue.outputs.exists == 'false'
-        uses: actions/github-script@v7
+        uses: actions/github-script@v9
         with:
           script: |
             const issueTitle = `[Drift] ${{ matrix.environment }}: Terraform state drift detected`;
@@ -281,7 +281,7 @@ jobs:
         if: >-
           steps.plan.outputs.drift_detected == 'true' &&
           steps.check_issue.outputs.exists == 'true'
-        uses: actions/github-script@v7
+        uses: actions/github-script@v9
         with:
           script: |
             // 既存 Issue にコメントを追加して最新のドリフト情報を記録する


### PR DESCRIPTION
## Summary
- ワークフロー・テンプレート・ドキュメント全35ファイルの GitHub Actions バージョンを最新に更新
- SHA 固定ワークフロー（14ファイル）とタグ参照テンプレート/ドキュメント（21ファイル）の両方を対象

## Changes

### メジャー更新
| Action | Before | After |
|--------|--------|-------|
| actions/github-script | v8 | **v9** |
| actions/stale | v9 | **v10** |
| codecov/codecov-action | v5.5.3 | **v6** |
| dependabot/fetch-metadata | v2 | **v3** |
| hashicorp/setup-terraform | v3 | **v4** |

### マイナー/パッチ更新
| Action | Before | After |
|--------|--------|-------|
| actions/upload-artifact | v7.0.0 | **v7.0.1** |
| docker/login-action | v4 | **v4.1.0** |
| docker/build-push-action | v7 | **v7.1.0** |
| peter-evans/create-pull-request | v8.1.0 | **v8.1.1** |
| reviewdog/action-actionlint | v1.71.0 | **v1.72.0** |
| marocchino/sticky-pull-request-comment | v3.0.2 | **v3.0.4** |

### SHA 更新
| Action | Note |
|--------|------|
| anthropics/claude-code-action | v1 タグの最新コミットに更新 |

### テンプレート/ドキュメントのタグ更新
- `actions/checkout` v4 → v6
- `actions/setup-node` v4 → v6
- `actions/upload-artifact` v3/v4/v6 → v7
- `codecov/codecov-action` v4 → v6
- `actions/github-script` v7/v8 → v9
- `peter-evans/create-pull-request` v7 → v8

## Test plan
- [x] Quality Gates (lint, format, test) パス済み
- [ ] CI ワークフローが正常に動作すること
- [ ] テンプレートのバージョン参照が整合していること

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Bumped CI/CD workflow action versions across the repository to newer major releases—covering checkout, Node setup, artifact uploads, coverage/reporting, Docker build/publish, scheduled jobs, and dependency automation—to improve reliability, security, and consistency of automated builds and maintenance tasks.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->