### PR TITLE
fix(deps): 依存パッケージとグローバルCLIを最新化

### DIFF
--- a/docs/tool-catalog.md
+++ b/docs/tool-catalog.md
@@ -59,29 +59,29 @@ Layer 1: ベースイメージ (ghcr.io/keito4/config-base)
 
 ### 2.3 ユーティリティ
 
-| ツール          | バージョン            | 用途                                        |
-| --------------- | --------------------- | ------------------------------------------- |
-| shellcheck      | apt 管理              | シェルスクリプト検証                        |
-| GitHub CLI (gh) | 2.89.0                | GitHub 操作                                 |
-| Doppler CLI     | 3.75.3                | シークレット管理                            |
-| similarity-ts   | オンデマンド          | コード類似度分析（初回実行時に自動インストール） |
-| eslint          | npm global            | JavaScript リンター                         |
-| Supabase CLI    | pnpm global           | Supabase 操作                               |
-| Vercel CLI      | 50.35.0 (global.json) | Vercel デプロイ                             |
-| n8n             | 2.12.3 (global.json)  | ワークフロー自動化                          |
-| pm2             | 6.0.14 (global.json)  | プロセスマネージャ                          |
-| difit           | 3.1.17 (global.json)  | AI diff レビューツール                      |
-| `@antfu/ni`     | 29.0.0 (global.json)  | パッケージマネージャ抽象化 CLI              |
+| ツール          | バージョン           | 用途                                             |
+| --------------- | -------------------- | ------------------------------------------------ |
+| shellcheck      | apt 管理             | シェルスクリプト検証                             |
+| GitHub CLI (gh) | 2.89.0               | GitHub 操作                                      |
+| Doppler CLI     | 3.75.3               | シークレット管理                                 |
+| similarity-ts   | オンデマンド         | コード類似度分析（初回実行時に自動インストール） |
+| eslint          | npm global           | JavaScript リンター                              |
+| Supabase CLI    | pnpm global          | Supabase 操作                                    |
+| Vercel CLI      | 52.0.0 (global.json) | Vercel デプロイ                                  |
+| n8n             | 2.17.7 (global.json) | ワークフロー自動化                               |
+| pm2             | 6.0.14 (global.json) | プロセスマネージャ                               |
+| difit           | 4.0.4 (global.json)  | AI diff レビューツール                           |
+| `@antfu/ni`     | 30.1.0 (global.json) | パッケージマネージャ抽象化 CLI                   |
 
 ### 2.4 Language Servers（global.json）
 
 | パッケージ                   | バージョン | 対象言語              |
 | ---------------------------- | ---------- | --------------------- |
-| typescript                   | 5.9.3      | TypeScript コンパイラ |
+| typescript                   | 6.0.3      | TypeScript コンパイラ |
 | typescript-language-server   | 5.1.3      | TypeScript LSP        |
 | bash-language-server         | 5.6.0      | Bash LSP              |
 | vscode-langservers-extracted | 4.10.0     | HTML/CSS/JSON LSP     |
-| yaml-language-server         | 1.21.0     | YAML LSP              |
+| yaml-language-server         | 1.22.0     | YAML LSP              |
 
 ### 2.5 MCP / Automation
 
@@ -95,7 +95,7 @@ Layer 1: ベースイメージ (ghcr.io/keito4/config-base)
 | パッケージ                        | バージョン | 用途                   |
 | --------------------------------- | ---------- | ---------------------- |
 | husky                             | 9.1.7      | Git hooks              |
-| `@commitlint/cli`                 | 20.5.0     | コミットメッセージ検証 |
+| `@commitlint/cli`                 | 20.5.2     | コミットメッセージ検証 |
 | `@commitlint/config-conventional` | 20.5.0     | Conventional Commits   |
 
 ## 3. DevContainer Features（config ベースで提供）

--- a/npm/global.json
+++ b/npm/global.json
@@ -2,7 +2,7 @@
   "name": "lib",
   "dependencies": {
     "@commitlint/cli": {
-      "version": "20.5.0",
+      "version": "20.5.2",
       "overridden": false
     },
     "@commitlint/config-conventional": {
@@ -14,15 +14,15 @@
       "overridden": false
     },
     "@openai/codex": {
-      "version": "0.116.0",
+      "version": "0.125.0",
       "overridden": false
     },
     "@google/gemini-cli": {
-      "version": "0.34.0",
+      "version": "0.39.1",
       "overridden": false
     },
     "happy-coder": {
-      "version": "0.13.0",
+      "version": "0.13.1",
       "overridden": false
     },
     "bash-language-server": {
@@ -30,7 +30,7 @@
       "overridden": false
     },
     "typescript": {
-      "version": "5.9.3",
+      "version": "6.0.3",
       "overridden": false
     },
     "typescript-language-server": {
@@ -42,19 +42,19 @@
       "overridden": false
     },
     "yaml-language-server": {
-      "version": "1.21.0",
+      "version": "1.22.0",
       "overridden": false
     },
     "corepack": {
-      "version": "0.34.6",
+      "version": "0.34.7",
       "overridden": false
     },
     "@antfu/ni": {
-      "version": "29.0.0",
+      "version": "30.1.0",
       "overridden": false
     },
     "difit": {
-      "version": "3.1.17",
+      "version": "4.0.4",
       "overridden": false
     },
     "mcp-remote": {
@@ -62,11 +62,11 @@
       "overridden": false
     },
     "n8n": {
-      "version": "2.12.3",
+      "version": "2.17.7",
       "overridden": false
     },
     "npm": {
-      "version": "11.12.0",
+      "version": "11.13.0",
       "overridden": false
     },
     "pm2": {
@@ -74,7 +74,7 @@
       "overridden": false
     },
     "vercel": {
-      "version": "50.35.0",
+      "version": "52.0.0",
       "overridden": false
     }
   }

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,7 +8,7 @@
       "name": "config",
       "version": "1.0.0",
       "devDependencies": {
-        "@commitlint/cli": "^20.5.0",
+        "@commitlint/cli": "^20.5.2",
         "@commitlint/config-conventional": "^20.5.0",
         "@eslint/js": "^10.0.1",
         "@semantic-release/commit-analyzer": "13.0.1",
@@ -22,7 +22,7 @@
         "globals": "17.5.0",
         "husky": "9.1.7",
         "jest": "30.3.0",
-        "jest-junit": "^16.0.0",
+        "jest-junit": "^17.0.0",
         "prettier": "3.8.3",
         "semantic-release": "25.0.3"
       },
@@ -597,15 +597,15 @@
       }
     },
     "node_modules/@commitlint/cli": {
-      "version": "20.5.0",
-      "resolved": "https://registry.npmjs.org/@commitlint/cli/-/cli-20.5.0.tgz",
-      "integrity": "sha512-yNkyN/tuKTJS3wdVfsZ2tXDM4G4Gi7z+jW54Cki8N8tZqwKBltbIvUUrSbT4hz1bhW/h0CdR+5sCSpXD+wMKaQ==",
+      "version": "20.5.2",
+      "resolved": "https://registry.npmjs.org/@commitlint/cli/-/cli-20.5.2.tgz",
+      "integrity": "sha512-IXr5xd3IX8SEG936P8gcpozRplkDeDSwJlt8UvoY1winwIy2udTbQ/cOCgbaaxcjdDqVoS29VUcz/wkwnSozbA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@commitlint/format": "^20.5.0",
         "@commitlint/lint": "^20.5.0",
-        "@commitlint/load": "^20.5.0",
+        "@commitlint/load": "^20.5.2",
         "@commitlint/read": "^20.5.0",
         "@commitlint/types": "^20.5.0",
         "tinyexec": "^1.0.0",
@@ -719,15 +719,15 @@
       }
     },
     "node_modules/@commitlint/load": {
-      "version": "20.5.0",
-      "resolved": "https://registry.npmjs.org/@commitlint/load/-/load-20.5.0.tgz",
-      "integrity": "sha512-sLhhYTL/KxeOTZjjabKDhwidGZan84XKK1+XFkwDYL/4883kIajcz/dZFAhBJmZPtL8+nBx6bnkzA95YxPeDPw==",
+      "version": "20.5.2",
+      "resolved": "https://registry.npmjs.org/@commitlint/load/-/load-20.5.2.tgz",
+      "integrity": "sha512-zmr0RGDz7vThxW1I8ohb9yBjnGuH9mqwJpn21hInjGla+IlLOkS9ey0+dD5HlkzFlY0lX2NYdA2lDW6/0rO7Gw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@commitlint/config-validator": "^20.5.0",
         "@commitlint/execute-rule": "^20.0.0",
-        "@commitlint/resolve-extends": "^20.5.0",
+        "@commitlint/resolve-extends": "^20.5.2",
         "@commitlint/types": "^20.5.0",
         "cosmiconfig": "^9.0.1",
         "cosmiconfig-typescript-loader": "^6.1.0",
@@ -782,15 +782,15 @@
       }
     },
     "node_modules/@commitlint/resolve-extends": {
-      "version": "20.5.0",
-      "resolved": "https://registry.npmjs.org/@commitlint/resolve-extends/-/resolve-extends-20.5.0.tgz",
-      "integrity": "sha512-3SHPWUW2v0tyspCTcfSsYml0gses92l6TlogwzvM2cbxDgmhSRc+fldDjvGkCXJrjSM87BBaWYTPWwwyASZRrg==",
+      "version": "20.5.2",
+      "resolved": "https://registry.npmjs.org/@commitlint/resolve-extends/-/resolve-extends-20.5.2.tgz",
+      "integrity": "sha512-8EhSCU9eNos/5cI1yg64GW79UH1c64O69AfStCsj4zqy6An/qIphVEXj4/+2M6056T8coz00f+UXFn4WUUP1HQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@commitlint/config-validator": "^20.5.0",
         "@commitlint/types": "^20.5.0",
-        "global-directory": "^4.0.1",
+        "global-directory": "^5.0.0",
         "import-meta-resolve": "^4.0.0",
         "lodash.mergewith": "^4.6.2",
         "resolve-from": "^5.0.0"
@@ -2767,9 +2767,9 @@
       }
     },
     "node_modules/ajv": {
-      "version": "8.18.0",
-      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.18.0.tgz",
-      "integrity": "sha512-PlXPeEWMXMZ7sPYOHqmDyCJzcfNrUr3fGNKtezX14ykXOEIvyK81d+qydx89KY5O71FKMPaQ2vBfBFI5NHR63A==",
+      "version": "8.20.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.20.0.tgz",
+      "integrity": "sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -3661,13 +3661,13 @@
       }
     },
     "node_modules/cosmiconfig-typescript-loader": {
-      "version": "6.2.0",
-      "resolved": "https://registry.npmjs.org/cosmiconfig-typescript-loader/-/cosmiconfig-typescript-loader-6.2.0.tgz",
-      "integrity": "sha512-GEN39v7TgdxgIoNcdkRE3uiAzQt3UXLyHbRHD6YoL048XAeOomyxaP+Hh/+2C6C2wYjxJ2onhJcsQp+L4YEkVQ==",
+      "version": "6.3.0",
+      "resolved": "https://registry.npmjs.org/cosmiconfig-typescript-loader/-/cosmiconfig-typescript-loader-6.3.0.tgz",
+      "integrity": "sha512-Akr82WH1Wfqatyiqpj8HDkO2o2KmJRu1FhKfSNJP3K4IdXwHfEyL7MOb62i1AGQVLtIQM+iCE9CGOtrfhR+mmA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "jiti": "^2.6.1"
+        "jiti": "2.6.1"
       },
       "engines": {
         "node": ">=v18"
@@ -4732,9 +4732,9 @@
       "license": "MIT"
     },
     "node_modules/glob/node_modules/brace-expansion": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.2.tgz",
-      "integrity": "sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.0.tgz",
+      "integrity": "sha512-TN1kCZAgdgweJhWWpgKYrQaMNHcDULHkWwQIspdtjV4Y5aurRdZpjAqn6yX3FPqTA9ngHCc4hJxMAMgGfve85w==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -4758,16 +4758,16 @@
       }
     },
     "node_modules/global-directory": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/global-directory/-/global-directory-4.0.1.tgz",
-      "integrity": "sha512-wHTUcDUoZ1H5/0iVqEudYW4/kAlN5cZ3j/bXn0Dpbizl9iaUVeWSHqiOjsgk6OW2bkLclbBjzewBz6weQ1zA2Q==",
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/global-directory/-/global-directory-5.0.0.tgz",
+      "integrity": "sha512-1pgFdhK3J2LeM+dVf2Pd424yHx2ou338lC0ErNP2hPx4j8eW1Sp0XqSjNxtk6Tc4Kr5wlWtSvz8cn2yb7/SG/w==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "ini": "4.1.1"
+        "ini": "6.0.0"
       },
       "engines": {
-        "node": ">=18"
+        "node": ">=20"
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
@@ -5064,13 +5064,13 @@
       "license": "ISC"
     },
     "node_modules/ini": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/ini/-/ini-4.1.1.tgz",
-      "integrity": "sha512-QQnnxNyfvmHFIsj7gkPcYymR8Jdw/o7mp5ZFihxn6h8Ci6fh3Dx4E1gPjpQEpIuPo9XVNY/ZUwh4BPMjGyL01g==",
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/ini/-/ini-6.0.0.tgz",
+      "integrity": "sha512-IBTdIkzZNOpqm7q3dRqJvMaldXjDHWkEDfrwGEQTs5eaQMWV+djAhR+wahyNNMAa+qpbDUhBMVt4ZKNwpPm7xQ==",
       "dev": true,
       "license": "ISC",
       "engines": {
-        "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
+        "node": "^20.17.0 || >=22.9.0"
       }
     },
     "node_modules/into-stream": {
@@ -5711,9 +5711,9 @@
       }
     },
     "node_modules/jest-haste-map/node_modules/picomatch": {
-      "version": "4.0.3",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz",
-      "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
+      "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -5724,19 +5724,19 @@
       }
     },
     "node_modules/jest-junit": {
-      "version": "16.0.0",
-      "resolved": "https://registry.npmjs.org/jest-junit/-/jest-junit-16.0.0.tgz",
-      "integrity": "sha512-A94mmw6NfJab4Fg/BlvVOUXzXgF0XIH6EmTgJ5NDPp4xoKq0Kr7sErb+4Xs9nZvu58pJojz5RFGpqnZYJTrRfQ==",
+      "version": "17.0.0",
+      "resolved": "https://registry.npmjs.org/jest-junit/-/jest-junit-17.0.0.tgz",
+      "integrity": "sha512-RYWCkq4j59gUXj5DsgbIE7xFBZzu1gtibPhyjSjMmGaOTLnqlXhg7x9zuGCwgbCuMAyoyvk0Mi8wSrRR5uOeLA==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "mkdirp": "^1.0.4",
         "strip-ansi": "^6.0.1",
-        "uuid": "^8.3.2",
+        "uuid": "^14.0.0",
         "xml": "^1.0.1"
       },
       "engines": {
-        "node": ">=10.12.0"
+        "node": ">=20.0.0"
       }
     },
     "node_modules/jest-junit/node_modules/ansi-regex": {
@@ -5814,9 +5814,9 @@
       }
     },
     "node_modules/jest-message-util/node_modules/picomatch": {
-      "version": "4.0.3",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz",
-      "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
+      "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -6023,9 +6023,9 @@
       }
     },
     "node_modules/jest-util/node_modules/picomatch": {
-      "version": "4.0.3",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz",
-      "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
+      "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -9147,9 +9147,9 @@
       "license": "ISC"
     },
     "node_modules/picomatch": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
-      "integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==",
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.2.tgz",
+      "integrity": "sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -10657,9 +10657,9 @@
       "license": "MIT"
     },
     "node_modules/test-exclude/node_modules/brace-expansion": {
-      "version": "1.1.12",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
-      "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
+      "version": "1.1.14",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.14.tgz",
+      "integrity": "sha512-MWPGfDxnyzKU7rNOW9SP/c50vi3xrmrua/+6hfPbCS2ABNWfx24vPidzvC7krjU/RTo235sV776ymlsMtGKj8g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -10798,9 +10798,9 @@
       }
     },
     "node_modules/tinyglobby/node_modules/picomatch": {
-      "version": "4.0.3",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz",
-      "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
+      "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -11093,13 +11093,17 @@
       "license": "MIT"
     },
     "node_modules/uuid": {
-      "version": "8.3.2",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
-      "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
+      "version": "14.0.0",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-14.0.0.tgz",
+      "integrity": "sha512-Qo+uWgilfSmAhXCMav1uYFynlQO7fMFiMVZsQqZRMIXp0O7rR7qjkj+cPvBHLgBqi960QCoo/PH2/6ZtVqKvrg==",
       "dev": true,
+      "funding": [
+        "https://github.com/sponsors/broofa",
+        "https://github.com/sponsors/ctavan"
+      ],
       "license": "MIT",
       "bin": {
-        "uuid": "dist/bin/uuid"
+        "uuid": "dist-node/bin/uuid"
       }
     },
     "node_modules/v8-to-istanbul": {

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "prepare": "husky"
   },
   "devDependencies": {
-    "@commitlint/cli": "^20.5.0",
+    "@commitlint/cli": "^20.5.2",
     "@commitlint/config-conventional": "^20.5.0",
     "@eslint/js": "^10.0.1",
     "@semantic-release/commit-analyzer": "13.0.1",
@@ -42,7 +42,7 @@
     "globals": "17.5.0",
     "husky": "9.1.7",
     "jest": "30.3.0",
-    "jest-junit": "^16.0.0",
+    "jest-junit": "^17.0.0",
     "prettier": "3.8.3",
     "semantic-release": "25.0.3"
   },


### PR DESCRIPTION
## Summary

- `npm run update:libs` で依存パッケージとグローバルCLIマニフェストを一括更新
- `npm audit fix` で直接依存ツリーの brace-expansion / picomatch 脆弱性を解消
- `docs/tool-catalog.md` を新バージョンに同期

## 主な更新内容

### `package.json`

- `@commitlint/cli` `^20.5.0 → ^20.5.2`
- `jest-junit` `^16.0.0 → ^17.0.0` (major)

### `npm/global.json`（DevContainer グローバルCLI）

| パッケージ            | before  | after   |
| --------------------- | ------- | ------- |
| typescript            | 5.9.3   | 6.0.3 (major) |
| vercel                | 50.35.0 | 52.0.0 (major) |
| @antfu/ni             | 29.0.0  | 30.1.0 (major) |
| difit                 | 3.1.17  | 4.0.4 (major) |
| n8n                   | 2.12.3  | 2.17.7  |
| @google/gemini-cli    | 0.34.0  | 0.39.1  |
| @openai/codex         | 0.116.0 | 0.125.0 |
| @commitlint/cli       | 20.5.0  | 20.5.2  |
| corepack              | 0.34.6  | 0.34.7  |
| happy-coder           | 0.13.0  | 0.13.1  |
| npm                   | 11.12.0 | 11.13.0 |
| yaml-language-server  | 1.21.0  | 1.22.0  |

`semantic-release`系は `update-libraries.sh` の `UPDATE_LIBS_REJECT` で意図的に固定中。

## セキュリティ

`npm audit` は2件 (moderate 1 / high 1) 残るが、いずれも `@semantic-release/npm` がバンドルする `npm@11.11.1` の内部 transitive (`brace-expansion@5.0.4`, `picomatch@4.0.3`)。`overrides` で潰すと npm 自体を破壊しうるため上流対応待ち。

## Test plan

- [x] `npm run lint` 緑
- [x] `npm test` 95 tests pass
- [x] `npm run format:check` 緑
- [x] pre-commit hook 全パス

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated pinned tooling, CLIs, utilities and language-server versions (npm, corepack, Vercel CLI, n8n, dift, package managers, LSPs, and AI/assistant CLIs) for improved compatibility and stability.
* **Documentation**
  * Revised the tool catalog/config docs to reflect the refreshed version matrix and adjusted table layout for clearer readability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->