### PR TITLE
fix(ci): quality-gate-fallback workflow 名を区別可能に

### DIFF
--- a/.github/workflows/quality-gate-fallback.yml
+++ b/.github/workflows/quality-gate-fallback.yml
@@ -4,7 +4,7 @@
 # Required Status Check "Quality Gate" を Pass で報告する。
 # CI が実行された場合は ci.yml 側の Quality Gate が優先される。
 #
-name: CI
+name: CI Fallback
 
 on:
   pull_request:


### PR DESCRIPTION
## Summary

`ci.yml` と `quality-gate-fallback.yml` が両方 `name: CI` で Actions UI 上区別できなかった。fallback 側を `CI Fallback` に変更。

Required status check は job 名 `Quality Gate` 単独で参照される（branch protection の `contexts: ["Quality Gate"]`）ため、workflow 名変更の影響はない。

## Test plan

- [x] `npm run lint` 緑
- [x] `npm test` 95 件パス
- [x] `npm run format:check` 緑
- [x] pre-commit hook すべて通過
- [ ] PR 作成後 fallback workflow が "CI Fallback" として認識されること（マージ後 main で確認）

🤖 Generated with [Claude Code](https://claude.com/claude-code)