### PR TITLE
feat: モダンツール 4 種テンプレートを追加 (closes #724)

### DIFF
--- a/.claude/commands/repo-maintenance.md
+++ b/.claude/commands/repo-maintenance.md
@@ -2278,24 +2278,30 @@ fi
 
 **同期対象ファイルの分類:**
 
-| カテゴリ     | ファイル                                      | 同期ポリシー                 |
-| ------------ | --------------------------------------------- | ---------------------------- |
-| マネージド   | `.github/workflows/claude.yml`                | 常に config の最新版で上書き |
-| マネージド   | `.github/workflows/claude-code-review.yml`    | 常に config の最新版で上書き |
-| マネージド   | `.github/workflows/quality-gate-fallback.yml` | 常に config の最新版で上書き |
-| マネージド   | `.claude/hooks/block_git_no_verify.py`        | 常に config の最新版で上書き |
-| マネージド   | `.claude/hooks/pre_git_quality_gates.py`      | 常に config の最新版で上書き |
-| マネージド   | `.claude/hooks/post_git_push_ci.py`           | 常に config の最新版で上書き |
-| マネージド   | `.claude/hooks/post_commit_adr_reminder.py`   | 常に config の最新版で上書き |
-| マネージド   | `.claude/rules/development-standards.md`      | 常に config の最新版で上書き |
-| マネージド   | `.claude/rules/git-conventions.md`            | 常に config の最新版で上書き |
-| マネージド   | `.claude/rules/release-types.md`              | 常に config の最新版で上書き |
-| テンプレート | `.github/workflows/security.yml`              | 差分表示 → 確認後に上書き    |
-| テンプレート | `.github/workflows/ci.yml`                    | 差分表示 → 確認後に上書き    |
-| テンプレート | `.github/ISSUE_TEMPLATE/*`                    | 欠落ファイルのみ追加         |
-| テンプレート | `.github/pull_request_template.md`            | 欠落時のみ追加               |
+| カテゴリ     | ファイル                                      | 同期ポリシー                   |
+| ------------ | --------------------------------------------- | ------------------------------ |
+| マネージド   | `.github/workflows/claude.yml`                | 常に config の最新版で上書き   |
+| マネージド   | `.github/workflows/claude-code-review.yml`    | 常に config の最新版で上書き   |
+| マネージド   | `.github/workflows/quality-gate-fallback.yml` | 常に config の最新版で上書き   |
+| マネージド   | `.claude/hooks/block_git_no_verify.py`        | 常に config の最新版で上書き   |
+| マネージド   | `.claude/hooks/pre_git_quality_gates.py`      | 常に config の最新版で上書き   |
+| マネージド   | `.claude/hooks/post_git_push_ci.py`           | 常に config の最新版で上書き   |
+| マネージド   | `.claude/hooks/post_commit_adr_reminder.py`   | 常に config の最新版で上書き   |
+| マネージド   | `.claude/rules/development-standards.md`      | 常に config の最新版で上書き   |
+| マネージド   | `.claude/rules/git-conventions.md`            | 常に config の最新版で上書き   |
+| マネージド   | `.claude/rules/release-types.md`              | 常に config の最新版で上書き   |
+| テンプレート | `.github/workflows/security.yml`              | 差分表示 → 確認後に上書き      |
+| テンプレート | `.github/workflows/ci.yml`                    | 差分表示 → 確認後に上書き      |
+| テンプレート | `.github/ISSUE_TEMPLATE/*`                    | 欠落ファイルのみ追加           |
+| テンプレート | `.github/pull_request_template.md`            | 欠落時のみ追加                 |
+| テンプレート | `vitest.config.ts`                            | 欠落時のみ追加 (Vitest 採用時) |
+| テンプレート | `eslint.config.mjs`                           | 欠落時のみ追加 (flat config)   |
+| テンプレート | `biome.json`                                  | 欠落時のみ追加 (Biome 採用時)  |
+| テンプレート | `commitlint.config.js`                        | 欠落時のみ追加                 |
 
 `quality-gate-fallback.yml` は `setup-team-protection.sh` がブランチ保護に登録する `Quality Gate` 必須チェックとセットで配布する。ci.yml が paths フィルタ等でスキップされた場合に PR が `Expected — Waiting for status to be reported` のまま blocked にならないよう、Pass を emit する役割を持つ。
+
+モダンツール 4 種 (`vitest.config.ts` / `eslint.config.mjs` / `biome.json` / `commitlint.config.js`) は `templates/testing/` `templates/eslint/` `templates/` 配下のテンプレートを欠落時のみ配置する。既存設定がある repo はそのまま尊重される。
 
 **マネージドファイル**: config リポジトリが正規のソースであり、プロジェクト側でカスタマイズしない前提のファイル。
 **テンプレートファイル**: プロジェクト固有のカスタマイズが入る可能性があるため、差分確認を挟む。
@@ -2440,6 +2446,44 @@ if [ -f "$PR_TEMPLATE_SRC" ] && [ ! -f "$PR_TEMPLATE_DST" ]; then
   cp "$PR_TEMPLATE_SRC" "$PR_TEMPLATE_DST"
   UPDATED+=(".github/pull_request_template.md (新規追加)")
 fi
+
+# モダンツール 4 種: 採用判定 + 欠落時のみ配置 (path-mapping)
+# vitest: package.json の devDependencies に vitest があれば配置候補
+# eslint flat config: eslint.config.* が無く、かつ ESLint を使っている場合
+# biome: package.json に @biomejs/biome があれば配置候補
+# commitlint: commit-msg フックを使う or commitlint 依存があれば配置候補
+declare -A MODERN_TOOLS=(
+  ["templates/testing/vitest.config.ts"]="vitest.config.ts"
+  ["templates/eslint/eslint.config.mjs"]="eslint.config.mjs"
+  ["templates/biome.json"]="biome.json"
+  ["templates/commitlint.config.js"]="commitlint.config.js"
+)
+for src_rel in "${!MODERN_TOOLS[@]}"; do
+  dst_rel="${MODERN_TOOLS[$src_rel]}"
+  src_file="$CONFIG_REPO/$src_rel"
+  dst_file="./$dst_rel"
+  [ ! -f "$src_file" ] && continue
+  # 既存の同等ファイルが既にある場合はスキップ (拡張子違いを含む)
+  case "$dst_rel" in
+    vitest.config.ts)
+      ls vitest.config.{ts,js,mjs,cjs} >/dev/null 2>&1 && continue
+      jq -e '.devDependencies.vitest // .dependencies.vitest' package.json >/dev/null 2>&1 || continue
+      ;;
+    eslint.config.mjs)
+      ls eslint.config.{mjs,js,cjs,ts} .eslintrc{.js,.json,.cjs,.yml,.yaml} >/dev/null 2>&1 && continue
+      jq -e '.devDependencies.eslint // .dependencies.eslint' package.json >/dev/null 2>&1 || continue
+      ;;
+    biome.json)
+      ls biome.json{,c} >/dev/null 2>&1 && continue
+      jq -e '.devDependencies["@biomejs/biome"] // .dependencies["@biomejs/biome"]' package.json >/dev/null 2>&1 || continue
+      ;;
+    commitlint.config.js)
+      ls commitlint.config.{js,ts,mjs,cjs} .commitlintrc{,.js,.json,.yml,.yaml} >/dev/null 2>&1 && continue
+      ;;
+  esac
+  cp "$src_file" "$dst_file"
+  UPDATED+=("$dst_rel (新規追加, モダンツールテンプレート)")
+done
 ```
 
 **結果パターン:**

--- a/.claude/commands/setup-husky.md
+++ b/.claude/commands/setup-husky.md
@@ -88,7 +88,15 @@ fi
 ]
 }
 
-.commitlintrc.json（リポジトリルート）
+commitlint.config.js（リポジトリルート、推奨）
+
+`templates/commitlint.config.js` をコピーして使用:
+
+```bash
+cp /path/to/config/templates/commitlint.config.js ./commitlint.config.js
+```
+
+最小構成のみ必要な場合は `.commitlintrc.json` でも可:
 
 {
 "extends": ["@commitlint/config-conventional"]

--- a/.claude/commands/setup-tests.md
+++ b/.claude/commands/setup-tests.md
@@ -179,6 +179,25 @@ npm install -D @stryker-mutator/core @stryker-mutator/jest-runner @stryker-mutat
 - `jest.setup.js` - テスト前セットアップ
 - `jest.polyfills.js` - Web API ポリフィル
 
+### 4.1.b Vitest を選択する場合
+
+Jest の代わりに Vitest を使うプロジェクトでは、`templates/testing/vitest.config.ts` をコピー:
+
+```bash
+cp /path/to/config/templates/testing/vitest.config.ts ./vitest.config.ts
+npm install -D vitest @vitest/coverage-v8 jsdom
+npm install -D @vitejs/plugin-react   # React 使用時
+mkdir -p tests && cat > tests/setup.ts <<'EOF'
+import '@testing-library/jest-dom/vitest';
+EOF
+```
+
+Vitest 採用基準:
+
+- Vite ベースのプロジェクト (高速 HMR / ESM ネイティブ)
+- React 19 / Next.js 15+ で Jest の互換性問題に直面した場合
+- TypeScript first / モダンな ESM プロジェクト
+
 ### 4.2 Standard Level 追加
 
 - `playwright.config.ts` - Playwright E2E 設定

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -4,7 +4,7 @@ import eslintConfigPrettier from 'eslint-config-prettier';
 
 export default [
   {
-    ignores: ['node_modules/', 'dist/', 'coverage/', '*.min.js'],
+    ignores: ['node_modules/', 'dist/', 'coverage/', '*.min.js', 'templates/'],
   },
   js.configs.recommended,
   eslintConfigPrettier,

--- a/templates/biome.json
+++ b/templates/biome.json
@@ -1,0 +1,48 @@
+{
+  "$schema": "https://biomejs.dev/schemas/2.4.8/schema.json",
+  "_comment": "Biome 統合フォーマッタ + リンタテンプレート。npm install -D --save-exact @biomejs/biome の後、'npx biome init' で生成される設定を本テンプレートで上書き推奨",
+  "files": {
+    "includes": [
+      "**",
+      "!**/node_modules",
+      "!**/.next",
+      "!**/dist",
+      "!**/build",
+      "!**/coverage",
+      "!**/public",
+      "!**/.vercel",
+      "!**/*.min.js",
+      "!**/*.generated.*",
+      "!**/database.types.ts",
+      "!**/pnpm-lock.yaml",
+      "!**/package-lock.json",
+      "!**/yarn.lock",
+      "!**/tsconfig.tsbuildinfo"
+    ]
+  },
+  "formatter": {
+    "enabled": true,
+    "indentStyle": "space",
+    "indentWidth": 2,
+    "lineWidth": 100,
+    "lineEnding": "lf"
+  },
+  "linter": {
+    "enabled": true,
+    "rules": {
+      "recommended": true
+    }
+  },
+  "javascript": {
+    "formatter": {
+      "quoteStyle": "single",
+      "semicolons": "always",
+      "trailingCommas": "all"
+    }
+  },
+  "json": {
+    "formatter": {
+      "trailingCommas": "none"
+    }
+  }
+}

--- a/templates/commitlint.config.js
+++ b/templates/commitlint.config.js
@@ -1,0 +1,24 @@
+// commitlint テンプレート (Conventional Commits)
+//
+// 使い方:
+//   1. プロジェクトルートに `commitlint.config.js` としてコピー
+//   2. 必要な依存をインストール:
+//      npm install -D @commitlint/cli @commitlint/config-conventional
+//   3. .husky/commit-msg に以下を追加 (setup-husky 実行で自動設定):
+//      npx --no-install commitlint --edit "$1"
+//
+// 許可される type:
+//   feat, fix, docs, style, refactor, perf, test, build, ci, chore, revert
+//
+// scope は project 固有。CLAUDE.md / AGENTS.md の git-conventions を参照。
+module.exports = {
+  extends: ['@commitlint/config-conventional'],
+  rules: {
+    // Subject 末尾のピリオド禁止 (デフォルト: error)
+    'subject-full-stop': [2, 'never', '.'],
+    // 本文の最大行長 (日本語コミットの場合は緩和推奨)
+    'body-max-line-length': [1, 'always', 100],
+    // フッターの最大行長
+    'footer-max-line-length': [1, 'always', 100],
+  },
+};

--- a/templates/eslint/eslint.config.mjs
+++ b/templates/eslint/eslint.config.mjs
@@ -1,0 +1,55 @@
+/**
+ * ESLint flat config テンプレート (TypeScript / Next.js プロジェクト向け)
+ *
+ * 使い方:
+ *   1. プロジェクトルートに `eslint.config.mjs` としてコピー
+ *   2. 必要な依存をインストール:
+ *      npm install -D eslint typescript-eslint
+ *   3. (オプション) Next.js プロジェクトの場合:
+ *      npm install -D eslint-config-next
+ *      → 下記 Next.js セクションのコメントを外す
+ *   4. (オプション) 複雑度ルールを有効化:
+ *      → complexityRules import のコメントを外す
+ *
+ * 参考: keito4/config の eslint/complexity-rules.mjs を ./eslint/ に
+ *      コピーして import すると複雑度ガードが有効になる
+ */
+import tseslint from 'typescript-eslint';
+// import { complexityRules } from './eslint/complexity-rules.mjs';
+// import nextCoreWebVitals from 'eslint-config-next/core-web-vitals';
+// import nextTypescript from 'eslint-config-next/typescript';
+
+export default [
+  {
+    ignores: [
+      'node_modules/**',
+      '.next/**',
+      'dist/**',
+      'build/**',
+      'coverage/**',
+      'public/**',
+      '.vercel/**',
+      '**/*.generated.*',
+      '**/database.types.ts',
+    ],
+  },
+  ...tseslint.configs.recommended,
+  // ...nextCoreWebVitals,
+  // ...nextTypescript,
+  {
+    files: ['**/*.{ts,tsx}'],
+    rules: {
+      // 警告は許容、未使用変数は _ 接頭辞で許可
+      '@typescript-eslint/no-unused-vars': [
+        'warn',
+        {
+          argsIgnorePattern: '^_',
+          varsIgnorePattern: '^_',
+          caughtErrorsIgnorePattern: '^_',
+        },
+      ],
+      // 複雑度ルールを取り込む場合:
+      // ...complexityRules,
+    },
+  },
+];

--- a/templates/testing/vitest.config.ts
+++ b/templates/testing/vitest.config.ts
@@ -1,0 +1,57 @@
+// Vitest config テンプレート
+//
+// 使い方:
+//   1. プロジェクトルートに `vitest.config.ts` としてコピー
+//   2. 必要な依存をインストール:
+//      npm install -D vitest @vitest/coverage-v8 jsdom
+//      npm install -D @vitejs/plugin-react   # React 使用時
+//   3. tests/setup.ts を作成 (testing-library/jest-dom 等)
+//   4. package.json scripts に追加:
+//      "test": "vitest run"
+//      "test:watch": "vitest"
+//      "test:coverage": "vitest run --coverage"
+//
+// プロジェクト固有のカスタマイズが必要な箇所はコメントで明記している。
+import { defineConfig } from 'vitest/config';
+import path from 'node:path';
+
+// React プロジェクトの場合は以下を有効化:
+// import react from '@vitejs/plugin-react';
+
+export default defineConfig({
+  // plugins: [react()],
+  test: {
+    // jsdom: ブラウザ DOM シミュレーション (React/UI テストで使用)
+    // node: API/サーバサイドのみのプロジェクトでは 'node' に変更
+    environment: 'jsdom',
+    globals: true,
+    setupFiles: ['./tests/setup.ts'],
+    include: ['{src,tests,lib}/**/*.{test,spec}.{ts,tsx,js,jsx}'],
+    exclude: ['node_modules/**', '.next/**', 'dist/**', 'tests/e2e/**', 'tests/regression/**'],
+    coverage: {
+      provider: 'v8',
+      reporter: ['text', 'json', 'html', 'lcov'],
+      include: ['src/**/*.{ts,tsx}', 'lib/**/*.ts'],
+      exclude: [
+        '**/*.d.ts',
+        '**/*.test.{ts,tsx}',
+        '**/*.spec.{ts,tsx}',
+        '**/types.ts',
+        '**/types/**',
+        '**/__tests__/**',
+        '**/__mocks__/**',
+      ],
+      thresholds: {
+        lines: 70,
+        functions: 70,
+        branches: 70,
+        statements: 70,
+      },
+    },
+  },
+  resolve: {
+    alias: {
+      '@': path.resolve(__dirname, './src'),
+    },
+  },
+});


### PR DESCRIPTION
## Why

`config-contribution-discover` の網羅的スキャン (Issue #724) で発見した、複数 repo に共通するモダンツール設定を keito4/config に取り込む。

新規 repo セットアップ時の手書きコスト削減と、ツール選択の標準化が目的。Vitest / Biome / ESLint flat config は今後の標準なので早期テンプレート化が有用。

## What

新規テンプレート 4 ファイル + 配布ロジック + ドキュメント更新。

### 新規ファイル

| ファイル | 内容 | 検出元 |
|---------|------|--------|
| `templates/testing/vitest.config.ts` | jsdom + v8 coverage + 70% threshold + 標準 alias | 8 repos が vitest 採用 |
| `templates/eslint/eslint.config.mjs` | TypeScript ESLint flat config の base + Next.js セクション (optional) + 複雑度ルール (optional) | 13 repos が flat config 採用 |
| `templates/biome.json` | Biome v2 統合フォーマッタ + リンタ (lineWidth 100, single quote) | 3 repos が Biome 採用 |
| `templates/commitlint.config.js` | Conventional Commits + 日本語向け緩和 (body 100 文字許容) | 9 repos が commitlint 使用 |

### repo-maintenance.md section 3.22 への配布登録

- 同期テーブルに 4 種を「テンプレート (欠落時のみ追加)」として追記
- `MODERN_TOOLS` 連想配列で path-mapping (templates/X → ./Y) を実装
- 採用判定:
  - vitest: `package.json devDependencies.vitest` が存在
  - eslint flat: `devDependencies.eslint` あり、かつ既存 `.eslintrc*` / `eslint.config.*` 不在
  - biome: `devDependencies.@biomejs/biome` が存在
  - commitlint: 既存 `commitlint.config.*` / `.commitlintrc*` 不在 (setup-husky とセット運用)

### ドキュメント更新

- `setup-tests.md`: Step 4.1.b として Vitest 採用基準 + 導入手順を追加
- `setup-husky.md`: `commitlint.config.js` テンプレート参照を追加

### keito4/config 自身の eslint.config.mjs 修正

- `ignores` に `templates/` を追加。本 repo の ESLint v10 が `templates/eslint/eslint.config.mjs` を auto-discovery して typescript-eslint 未インストールエラーを起こすのを防ぐ

## How

`/repo-maintenance --mode full` 実行時、新規 4 ブロックが順次評価される:

```bash
declare -A MODERN_TOOLS=(
  ["templates/testing/vitest.config.ts"]="vitest.config.ts"
  ["templates/eslint/eslint.config.mjs"]="eslint.config.mjs"
  ["templates/biome.json"]="biome.json"
  ["templates/commitlint.config.js"]="commitlint.config.js"
)
for src_rel in "${!MODERN_TOOLS[@]}"; do
  # 採用判定 (package.json 依存 + 既存設定不在) → コピー
done
```

## Risk

- 低: 新規テンプレート追加と配布ロジック追加のみ
- 既存設定がある repo は判定で skip されるため上書き不可
- vitest/biome/eslint flat 採用判定は package.json 依存をチェックするため、未採用 repo には何も配布されない (no-op)

## Test plan

- [x] `prettier --check` パス
- [x] pre-commit hooks (test 95 件) パス
- [x] 本 repo 自身の ESLint 実行が成功 (templates/ 除外確認)
- [ ] 別 repo (vitest 採用済み, 例: Elu-co-jp/calendar_management) で `/repo-maintenance --mode full` を実行し、既存 vitest.config.ts が上書きされないことを確認
- [ ] 別 repo (vitest 未採用 + ESLint flat config 未配置) で実行し、配布判定が機能することを確認

## Discovered but NOT included (rationale)

| 候補 | 不採用理由 |
|------|-----------|
| `release.yml` (8 repos) | publish 先 (npm/GHCR/Vercel) が project ごとに異なる |
| `terraform-*.yml` (3 repos) | Terraform backend / state 構成が repo ごとに異なる |
| `verify-ui.md` / `setup-project.md` (4 repos) | Next.js + Supabase 専用 |
| Tailwind / Next.js config | project 固有 |

詳細は issue #724 を参照。

## Follow-up (別 PR で対応)

- `.github/policies/` テンプレート → PR #725 (Issue #723)
- complexity-check.yml ワークフローの sonarjs ベース化 (検討中)

Closes #724

🤖 Generated with [Claude Code](https://claude.com/claude-code)