### PR TITLE
fix: harden reusable CI workflows

### DIFF
--- a/.claude/commands/setup-ci.md
+++ b/.claude/commands/setup-ci.md
@@ -334,7 +334,7 @@ jobs:
 
             if [ -z "$QUALITY_GATE" ]; then
               if [ $ELAPSED_TIME -ge 120 ]; then
-                echo "ci_passed=true" >> $GITHUB_OUTPUT
+                echo "ci_passed=true" >> "$GITHUB_OUTPUT"
                 echo "✅ CI workflow skipped by path filters"
                 exit 0
               fi
@@ -355,17 +355,17 @@ jobs:
             fi
 
             if [ "$QUALITY_GATE_CONCLUSION" != "success" ]; then
-              echo "ci_passed=false" >> $GITHUB_OUTPUT
+              echo "ci_passed=false" >> "$GITHUB_OUTPUT"
               echo "❌ Quality Gate failed with conclusion: $QUALITY_GATE_CONCLUSION"
               exit 0
             fi
 
-            echo "ci_passed=true" >> $GITHUB_OUTPUT
+            echo "ci_passed=true" >> "$GITHUB_OUTPUT"
             echo "✅ All CI checks passed"
             exit 0
           done
 
-          echo "ci_passed=false" >> $GITHUB_OUTPUT
+          echo "ci_passed=false" >> "$GITHUB_OUTPUT"
           echo "⏱️ Timeout: CI did not complete within ${MAX_WAIT_TIME}s"
           exit 0
 

--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -59,7 +59,7 @@ jobs:
               if [ $ELAPSED_TIME -ge 120 ]; then
                 DETECT_CHANGES=$(echo "$CHECK_RUNS" | jq -r 'select(.name == "Detect Changes")')
                 if [ -z "$DETECT_CHANGES" ]; then
-                  echo "ci_passed=true" >> $GITHUB_OUTPUT
+                  echo "ci_passed=true" >> "$GITHUB_OUTPUT"
                   echo "✅ CI workflow skipped by path filters (no code changes detected)"
                   echo "Claude Code Review will proceed without waiting for CI."
                   exit 0
@@ -83,7 +83,7 @@ jobs:
 
             # Quality Gate完了 - 結果を確認
             if [ "$QUALITY_GATE_CONCLUSION" != "success" ]; then
-              echo "ci_passed=false" >> $GITHUB_OUTPUT
+              echo "ci_passed=false" >> "$GITHUB_OUTPUT"
               echo "❌ Quality Gate failed with conclusion: $QUALITY_GATE_CONCLUSION"
               echo "Claude Code Review will be skipped."
               exit 0
@@ -93,7 +93,7 @@ jobs:
             FAILED_CHECKS=$(echo "$CHECK_RUNS" | jq -r 'select(.status == "completed" and .conclusion != "success" and .conclusion != "skipped" and .conclusion != "neutral")')
 
             if [ -n "$FAILED_CHECKS" ]; then
-              echo "ci_passed=false" >> $GITHUB_OUTPUT
+              echo "ci_passed=false" >> "$GITHUB_OUTPUT"
               echo "❌ Some CI checks failed:"
               echo "$FAILED_CHECKS" | jq -r '"\(.name): \(.conclusion)"'
               echo "Claude Code Review will be skipped."
@@ -101,13 +101,13 @@ jobs:
             fi
 
             # すべてのチェックが成功
-            echo "ci_passed=true" >> $GITHUB_OUTPUT
+            echo "ci_passed=true" >> "$GITHUB_OUTPUT"
             echo "✅ All CI checks passed"
             exit 0
           done
 
           # タイムアウト
-          echo "ci_passed=false" >> $GITHUB_OUTPUT
+          echo "ci_passed=false" >> "$GITHUB_OUTPUT"
           echo "⏱️ Timeout: CI did not complete within ${MAX_WAIT_TIME}s"
           echo "Claude Code Review will be skipped."
           exit 0

--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -42,10 +42,27 @@ jobs:
           github-token: ${{ secrets.GITHUB_TOKEN }}
 
       # patch: 自動マージ（CI パス後）
+      # Repo Settings > Pull Requests > Allow auto-merge が無効な環境では
+      # gh pr merge --auto が enablePullRequestAutoMerge エラーで落ちるため、
+      # 既知エラーだけ自動承認へフォールバックしてワークフロー自体は green を維持する。
       - name: Auto-merge patch updates
         if: github.actor == 'dependabot[bot]' && steps.metadata.outputs.update-type == 'version-update:semver-patch'
         run: |
-          gh pr merge "$PR_URL" --auto --merge
+          set +e
+          MERGE_OUTPUT=$(gh pr merge "$PR_URL" --auto --merge 2>&1)
+          MERGE_EXIT=$?
+          set -e
+
+          if [ "$MERGE_EXIT" -ne 0 ]; then
+            if echo "$MERGE_OUTPUT" | grep -q "enablePullRequestAutoMerge"; then
+              echo "::warning::Repo auto-merge is disabled. Falling back to auto-approve. Enable it at Settings > Pull Requests."
+              gh pr review "$PR_URL" --approve --body "Auto-approved: patch version update (auto-merge unavailable; merge manually)" \
+                || echo "::warning::Auto-approve fallback failed. Merge manually after CI passes."
+            else
+              echo "$MERGE_OUTPUT" >&2
+              exit "$MERGE_EXIT"
+            fi
+          fi
         env:
           PR_URL: ${{ github.event.pull_request.html_url }}
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/templates/update-db-types.yml
+++ b/.github/workflows/templates/update-db-types.yml
@@ -8,6 +8,7 @@
 #   - SUPABASE_PROJECT_REF: Supabase project reference ID
 #
 # Customization:
+#   - Supabase CLI is installed via supabase/setup-cli@v2 using its default version resolution
 #   - Modify `types:gen` command in your package.json
 #   - Adjust output file path as needed
 #   - Configure branch naming convention
@@ -49,6 +50,9 @@ jobs:
       - name: Install dependencies
         run: npm ci
 
+      - name: Setup Supabase CLI
+        uses: supabase/setup-cli@v2
+
       - name: Generate database types
         env:
           SUPABASE_ACCESS_TOKEN: ${{ secrets.SUPABASE_ACCESS_TOKEN }}
@@ -56,7 +60,7 @@ jobs:
         run: |
           # Use the types generation script from package.json
           # Customize the command name as needed (e.g., types:gen, types:gen:staging)
-          npm run types:gen || npm run supabase:types || npx supabase gen types typescript --project-id "${SUPABASE_PROJECT_REF}" > src/types/database.types.ts
+          npm run types:gen || npm run supabase:types || supabase gen types typescript --project-id "${SUPABASE_PROJECT_REF}" > src/types/database.types.ts
 
       - name: Check for changes
         id: changes

--- a/templates/workflows/dependabot-auto-merge.yml
+++ b/templates/workflows/dependabot-auto-merge.yml
@@ -41,12 +41,28 @@ jobs:
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
 
-      # patch: 自動承認 + 自動マージ（CI パス後）
+      # patch: 自動マージ（CI パス後）
+      # Repo Settings > Pull Requests > Allow auto-merge が無効な環境では
+      # gh pr merge --auto が enablePullRequestAutoMerge エラーで落ちるため、
+      # 既知エラーだけ自動承認へフォールバックしてワークフロー自体は green を維持する。
       - name: Auto-merge patch updates
         if: github.actor == 'dependabot[bot]' && steps.metadata.outputs.update-type == 'version-update:semver-patch'
         run: |
-          gh pr review "$PR_URL" --approve --body "Auto-approved: patch version update"
-          gh pr merge "$PR_URL" --auto --merge || echo "::notice::Auto-merge is not enabled in repository settings. Please enable it in Settings > General to allow automatic merging after CI passes."
+          set +e
+          MERGE_OUTPUT=$(gh pr merge "$PR_URL" --auto --merge 2>&1)
+          MERGE_EXIT=$?
+          set -e
+
+          if [ "$MERGE_EXIT" -ne 0 ]; then
+            if echo "$MERGE_OUTPUT" | grep -q "enablePullRequestAutoMerge"; then
+              echo "::warning::Repo auto-merge is disabled. Falling back to auto-approve. Enable it at Settings > Pull Requests."
+              gh pr review "$PR_URL" --approve --body "Auto-approved: patch version update (auto-merge unavailable; merge manually)" \
+                || echo "::warning::Auto-approve fallback failed. Merge manually after CI passes."
+            else
+              echo "$MERGE_OUTPUT" >&2
+              exit "$MERGE_EXIT"
+            fi
+          fi
         env:
           PR_URL: ${{ github.event.pull_request.html_url }}
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Summary

- Install Supabase CLI in the database-types workflow via `supabase/setup-cli@v2`
- Let `supabase/setup-cli` use its default version resolution instead of pinning `version: latest`
- Add an auto-merge-disabled fallback to Dependabot patch auto-merge workflows
- Quote `GITHUB_OUTPUT` writes in Claude CI status checks and the setup-ci template

## Background

This ports reusable CI hardening from recent merged PRs in other repositories:

- `Elu-co-jp/job-post-generator#86`: replace brittle direct Supabase CLI archive downloads with `supabase/setup-cli`
- `Elu-co-jp/prog-insight#215`: quote `GITHUB_OUTPUT` writes in GitHub Actions shell snippets

App-specific changes from those PRs were intentionally not ported.

## Validation

- `npm run format:check`
- `npm run lint`
- `npm test`
- YAML parse for changed workflow files
- `git diff --check`

Note: `actionlint` is not installed locally, so workflow lint was not run locally.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed CI status output redirection in code review workflow.
  * Improved Dependabot auto-merge to gracefully fall back when repository auto-merge settings are disabled, preventing workflow failures.

* **Chores**
  * Updated database type generation workflow to use Supabase CLI directly.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/keito4/config/pull/756?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->