### PR TITLE
fix: load Codex MCP credentials from devcontainer env

### DIFF
--- a/.codex/config.toml
+++ b/.codex/config.toml
@@ -2,6 +2,7 @@ sandbox_mode = "workspace-write"
 model = "gpt-5.5"
 model_reasoning_effort = "xhigh"
 web_search = "live"
+suppress_unstable_features_warning = true
 [sandbox_workspace_write]
 network_access = true
 [features]
@@ -17,6 +18,7 @@ url = "https://knowledge-mcp.global.api.aws"
 [mcp_servers.chrome-devtools]
 command = "npx"
 args = ["chrome-devtools-mcp@latest"]
+startup_timeout_sec = 90
 
 [mcp_servers.next-devtools]
 command = "npx"
@@ -46,13 +48,17 @@ bearer_token_env_var = "VERCEL_TOKEN"
 [mcp_servers.context7]
 command = "npx"
 args = ["-y", "@upstash/context7-mcp"]
+startup_timeout_sec = 90
 
 [mcp_servers.linear]
 url = "https://mcp.linear.app/mcp"
+bearer_token_env_var = "LINEAR_API_KEY"
 
 [mcp_servers.doppler]
 command = "npx"
 args = ["-y", "@dopplerhq/mcp-server", "--read-only"]
+startup_timeout_sec = 90
+env_vars = ["DOPPLER_TOKEN"]
 
 [mcp_servers.doppler.env]
 npm_config_cache = "/private/tmp/codex-npm-cache"

--- a/.zsh/configs/pre/devcontainer-env.zsh
+++ b/.zsh/configs/pre/devcontainer-env.zsh
@@ -1,7 +1,11 @@
 # Expose selected shared local secrets to CLI tools such as Codex MCP servers.
+# NOTE: This list is duplicated in nix/home/zsh.nix (home.file). Keep both in sync.
 if [[ -r "$HOME/.devcontainer.env" ]]; then
   while IFS='=' read -r _codex_env_key _codex_env_value || [[ -n $_codex_env_key ]]; do
+    # Strip trailing CR so Windows-style CRLF files work correctly.
+    _codex_env_value="${_codex_env_value%$'\r'}"
     case "$_codex_env_key" in
+      # Allowed keys: SUPABASE_ACCESS_TOKEN | VERCEL_TOKEN | LINEAR_API_KEY | DOPPLER_TOKEN
       SUPABASE_ACCESS_TOKEN|VERCEL_TOKEN|LINEAR_API_KEY|DOPPLER_TOKEN)
         export "$_codex_env_key=$_codex_env_value"
         ;;

--- a/.zsh/configs/pre/devcontainer-env.zsh
+++ b/.zsh/configs/pre/devcontainer-env.zsh
@@ -1,6 +1,6 @@
 # Expose selected shared local secrets to CLI tools such as Codex MCP servers.
 if [[ -r "$HOME/.devcontainer.env" ]]; then
-  while IFS='=' read -r _codex_env_key _codex_env_value; do
+  while IFS='=' read -r _codex_env_key _codex_env_value || [[ -n $_codex_env_key ]]; do
     case "$_codex_env_key" in
       SUPABASE_ACCESS_TOKEN|VERCEL_TOKEN|LINEAR_API_KEY|DOPPLER_TOKEN)
         export "$_codex_env_key=$_codex_env_value"

--- a/.zsh/configs/pre/devcontainer-env.zsh
+++ b/.zsh/configs/pre/devcontainer-env.zsh
@@ -1,5 +1,7 @@
 # Expose selected shared local secrets to CLI tools such as Codex MCP servers.
 # NOTE: This list is duplicated in nix/home/zsh.nix (home.file). Keep both in sync.
+# Clear previously exported tokens so removed entries in ~/.devcontainer.env don't linger.
+unset SUPABASE_ACCESS_TOKEN VERCEL_TOKEN LINEAR_API_KEY DOPPLER_TOKEN
 if [[ -r "$HOME/.devcontainer.env" ]]; then
   while IFS='=' read -r _codex_env_key _codex_env_value || [[ -n $_codex_env_key ]]; do
     # Strip trailing CR so Windows-style CRLF files work correctly.

--- a/.zsh/configs/pre/devcontainer-env.zsh
+++ b/.zsh/configs/pre/devcontainer-env.zsh
@@ -1,0 +1,11 @@
+# Expose selected shared local secrets to CLI tools such as Codex MCP servers.
+if [[ -r "$HOME/.devcontainer.env" ]]; then
+  while IFS='=' read -r _codex_env_key _codex_env_value; do
+    case "$_codex_env_key" in
+      SUPABASE_ACCESS_TOKEN|VERCEL_TOKEN|LINEAR_API_KEY|DOPPLER_TOKEN)
+        export "$_codex_env_key=$_codex_env_value"
+        ;;
+    esac
+  done < "$HOME/.devcontainer.env"
+  unset _codex_env_key _codex_env_value
+fi

--- a/nix/home/zsh.nix
+++ b/nix/home/zsh.nix
@@ -113,7 +113,7 @@
       text = ''
         # Expose selected shared local secrets to CLI tools such as Codex MCP servers.
         if [[ -r "$HOME/.devcontainer.env" ]]; then
-          while IFS='=' read -r _codex_env_key _codex_env_value; do
+          while IFS='=' read -r _codex_env_key _codex_env_value || [[ -n $_codex_env_key ]]; do
             case "$_codex_env_key" in
               SUPABASE_ACCESS_TOKEN|VERCEL_TOKEN|LINEAR_API_KEY|DOPPLER_TOKEN)
                 export "$_codex_env_key=$_codex_env_value"

--- a/nix/home/zsh.nix
+++ b/nix/home/zsh.nix
@@ -112,9 +112,13 @@
     ".zsh/configs/pre/devcontainer-env.zsh" = {
       text = ''
         # Expose selected shared local secrets to CLI tools such as Codex MCP servers.
+        # NOTE: This list is duplicated in .zsh/configs/pre/devcontainer-env.zsh. Keep both in sync.
         if [[ -r "$HOME/.devcontainer.env" ]]; then
           while IFS='=' read -r _codex_env_key _codex_env_value || [[ -n $_codex_env_key ]]; do
+            # Strip trailing CR so Windows-style CRLF files work correctly.
+            _codex_env_value="''${_codex_env_value%$'\r'}"
             case "$_codex_env_key" in
+              # Allowed keys: SUPABASE_ACCESS_TOKEN | VERCEL_TOKEN | LINEAR_API_KEY | DOPPLER_TOKEN
               SUPABASE_ACCESS_TOKEN|VERCEL_TOKEN|LINEAR_API_KEY|DOPPLER_TOKEN)
                 export "$_codex_env_key=$_codex_env_value"
                 ;;

--- a/nix/home/zsh.nix
+++ b/nix/home/zsh.nix
@@ -113,6 +113,8 @@
       text = ''
         # Expose selected shared local secrets to CLI tools such as Codex MCP servers.
         # NOTE: This list is duplicated in .zsh/configs/pre/devcontainer-env.zsh. Keep both in sync.
+        # Clear previously exported tokens so removed entries in ~/.devcontainer.env don't linger.
+        unset SUPABASE_ACCESS_TOKEN VERCEL_TOKEN LINEAR_API_KEY DOPPLER_TOKEN
         if [[ -r "$HOME/.devcontainer.env" ]]; then
           while IFS='=' read -r _codex_env_key _codex_env_value || [[ -n $_codex_env_key ]]; do
             # Strip trailing CR so Windows-style CRLF files work correctly.

--- a/nix/home/zsh.nix
+++ b/nix/home/zsh.nix
@@ -16,6 +16,12 @@
       SUPABASE_UPDATE_CHECK = "false";
     };
 
+    loginExtra = ''
+      if [[ -r "$HOME/.zsh/configs/pre/devcontainer-env.zsh" ]]; then
+        source "$HOME/.zsh/configs/pre/devcontainer-env.zsh"
+      fi
+    '';
+
     initContent = ''
       # pnpm
       case ":$PATH:" in
@@ -100,6 +106,22 @@
         else
           compinit -C -d $HOME/.zcompdump;
         fi;
+      '';
+    };
+
+    ".zsh/configs/pre/devcontainer-env.zsh" = {
+      text = ''
+        # Expose selected shared local secrets to CLI tools such as Codex MCP servers.
+        if [[ -r "$HOME/.devcontainer.env" ]]; then
+          while IFS='=' read -r _codex_env_key _codex_env_value; do
+            case "$_codex_env_key" in
+              SUPABASE_ACCESS_TOKEN|VERCEL_TOKEN|LINEAR_API_KEY|DOPPLER_TOKEN)
+                export "$_codex_env_key=$_codex_env_value"
+                ;;
+            esac
+          done < "$HOME/.devcontainer.env"
+          unset _codex_env_key _codex_env_value
+        fi
       '';
     };
 


### PR DESCRIPTION
## Summary

- Load selected Codex MCP credentials from `~/.devcontainer.env` for login shell startup.
- Switch Linear MCP auth to `LINEAR_API_KEY` bearer token env var.
- Extend startup timeout for slower `npx`-based MCP servers and pass `DOPPLER_TOKEN` to Doppler MCP.

## Verification

- `git grep --cached -n -E 'sbp_|vcp_|lin_api_|dp\.pt\.|gho_|SUPABASE_ACCESS_TOKEN=|VERCEL_TOKEN=|LINEAR_API_KEY=|DOPPLER_TOKEN=|Bearer [A-Za-z0-9_-]+' -- .codex/config.toml nix/home/zsh.nix .zsh/configs/pre/devcontainer-env.zsh` returned no matches.
- `zsh -n .zsh/configs/pre/devcontainer-env.zsh`
- `nix-instantiate --parse nix/home/zsh.nix >/dev/null`
- `git diff --cached --check`
- `zsh -lc 'codex exec --ephemeral --sandbox read-only "Respond exactly: CLI_OK"'`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Extended development server startup timeouts to improve reliability.
  * Implemented selective environment-variable loading that clears stale token exports, reads local env files safely, normalizes line endings, and exports only allowlisted service tokens.
  * Added a global configuration flag to control display of unstable feature warnings.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/keito4/config/pull/758?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->