### PR TITLE
fix: protect existing environment branches

### DIFF
--- a/.claude/commands/repo-maintenance.md
+++ b/.claude/commands/repo-maintenance.md
@@ -374,11 +374,11 @@ GitHub リポジトリの保護ルールを確認・設定：
 - 必須ステータスチェックの設定（`Quality Gate` ジョブ）
 - レビュー要件の設定
 - Dependabot、脆弱性アラートの有効化
-- Next.js プロジェクトの場合、`pre-production` / `production` ブランチの保護確認
+- Next.js プロジェクト、または既存の `pre-production` / `production` ブランチの保護確認
 
 これは `/setup-team-protection` コマンドと同等の処理を実行します。
 
-**フレームワーク検出による保護ブランチの自動判定:**
+**フレームワーク/既存ブランチ検出による保護ブランチの自動判定:**
 
 ```bash
 # Next.js プロジェクトかどうかを検出
@@ -389,13 +389,23 @@ if [ -f "package.json" ]; then
   fi
 fi
 
-# Next.js の場合は pre-production / production も保護対象
+PROTECT_BRANCHES="main"
+PROTECTION_LEVEL="standard"
+
+# 既存の環境ブランチは、Next.js 以外でも保護対象に含める
+EXISTING_ENV_BRANCHES=""
+for branch in pre-production production; do
+  if gh api "repos/$REPO/branches/$branch" &>/dev/null; then
+    EXISTING_ENV_BRANCHES="${EXISTING_ENV_BRANCHES:+$EXISTING_ENV_BRANCHES,}$branch"
+  fi
+done
+
+# Next.js の場合は pre-production / production を作成・保護対象に含める
 if [ "$IS_NEXTJS" = true ]; then
   PROTECT_BRANCHES="main,pre-production,production"
   PROTECTION_LEVEL="strict"
-else
-  PROTECT_BRANCHES="main"
-  PROTECTION_LEVEL="standard"
+elif [ -n "$EXISTING_ENV_BRANCHES" ]; then
+  PROTECT_BRANCHES="main,$EXISTING_ENV_BRANCHES"
 fi
 ```
 
@@ -403,7 +413,7 @@ fi
 
 - ✅ 保護ルール設定済み
 - ⚠️ 未設定の保護ルールあり（詳細をリスト）
-- ⚠️ Next.js プロジェクト: `pre-production` / `production` ブランチ未保護 → strict レベルで保護を提案
+- ⚠️ `pre-production` / `production` ブランチ未保護 → 保護を提案
 - 🔧 設定を適用
 
 ### 3.2 Husky Setup Check

--- a/.claude/commands/setup-team-protection.md
+++ b/.claude/commands/setup-team-protection.md
@@ -48,6 +48,8 @@
 bash script/setup-team-protection.sh
 ```
 
+`pre-production` / `production` ブランチが既に存在する場合は、デフォルトで `main` と一緒に保護対象へ含めます。
+
 **別のリポジトリに対して実行**
 
 ```bash
@@ -89,6 +91,13 @@ main ブランチ:
 ```bash
 # enforce_admins=false, reviewers=0, code_owner_reviews=false
 bash script/setup-team-protection.sh --branches main
+```
+
+既存の pre-production / production ブランチを含むデフォルト:
+
+```bash
+# main + 存在する pre-production / production を保護
+bash script/setup-team-protection.sh
 ```
 
 pre-production / production ブランチ:

--- a/script/setup-team-protection.sh
+++ b/script/setup-team-protection.sh
@@ -14,7 +14,8 @@
 #   --dry-run             Show what would be done without making changes
 #   --reviewers N         Number of required reviewers (default: 1)
 #   --enforce-admins      Apply protection rules to administrators
-#   --branches B1,B2      Comma-separated list of branches to protect (default: main)
+#   --branches B1,B2      Comma-separated list of branches to protect
+#                         (default: main plus existing pre-production/production)
 #   --skip-status-checks  Skip required status checks configuration
 #   --create-branches     Create branches if they don't exist
 #   --merge-method METHOD Merge method: squash, merge, rebase, all, none (default: squash)
@@ -41,6 +42,7 @@ source "$SCRIPT_DIR/lib/output.sh"
 REVIEWERS=1
 ENFORCE_ADMINS=false
 BRANCHES="main"
+BRANCHES_EXPLICIT=false
 INTERACTIVE=false
 DRY_RUN=false
 SKIP_STATUS_CHECKS=false
@@ -71,6 +73,7 @@ while [[ $# -gt 0 ]]; do
       ;;
     --branches)
       BRANCHES="$2"
+      BRANCHES_EXPLICIT=true
       shift 2
       ;;
     --skip-status-checks)
@@ -150,6 +153,29 @@ if [[ "$PERMISSIONS" != "true" ]]; then
   echo "Branch protection requires repository admin permissions."
   exit 1
 fi
+
+# Include existing environment branches by default. Explicit --branches keeps
+# exact caller intent and skips this auto-detection.
+include_existing_environment_branches() {
+  if [[ "$BRANCHES_EXPLICIT" == "true" ]]; then
+    return 0
+  fi
+
+  local branch
+  for branch in pre-production production; do
+    if gh api "repos/$REPO/branches/$branch" &>/dev/null; then
+      case ",$BRANCHES," in
+        *",$branch,"*) ;;
+        *)
+          BRANCHES="$BRANCHES,$branch"
+          info "Detected existing environment branch: $branch (will protect)"
+          ;;
+      esac
+    fi
+  done
+}
+
+include_existing_environment_branches
 
 # Validate protection level
 case "$PROTECTION_LEVEL" in

--- a/test/integration/core-scripts.bats
+++ b/test/integration/core-scripts.bats
@@ -61,6 +61,18 @@ load ../test_helper/test_helper
     [ -x "$REPO_ROOT/script/setup-team-protection.sh" ]
 }
 
+@test "setup-team-protection.sh defines include_existing_environment_branches function" {
+    grep -q "include_existing_environment_branches()" "$REPO_ROOT/script/setup-team-protection.sh"
+}
+
+@test "setup-team-protection.sh initializes BRANCHES_EXPLICIT to false" {
+    grep -q "BRANCHES_EXPLICIT=false" "$REPO_ROOT/script/setup-team-protection.sh"
+}
+
+@test "setup-team-protection.sh sets BRANCHES_EXPLICIT=true when --branches is given" {
+    grep -q "BRANCHES_EXPLICIT=true" "$REPO_ROOT/script/setup-team-protection.sh"
+}
+
 @test "check-file-length.sh exists and is executable" {
     assert_file_exists "$REPO_ROOT/script/check-file-length.sh"
     [ -x "$REPO_ROOT/script/check-file-length.sh" ]


### PR DESCRIPTION
## Summary

- include existing pre-production and production branches in setup-team-protection defaults
- document repo-maintenance branch protection detection for existing environment branches
- keep explicit --branches behavior unchanged

## Tests

- bash -n script/setup-team-protection.sh
- npx prettier --check .claude/commands/repo-maintenance.md .claude/commands/setup-team-protection.md
- npm test -- --runTestsByPath test/config-validation.test.js
- git diff --check
- pre-commit: npm run format:check, npm run lint, npm test

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Branch protection now auto-detects and includes existing pre-production/production branches alongside main; explicit branch overrides remain supported.

* **Documentation**
  * Setup guides clarified to describe the auto-detection behavior and example commands for protecting main plus existing environment branches.

* **Tests**
  * Integration tests added to verify the auto-detect behavior and explicit-override flag.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/keito4/config/pull/764?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->