### PR TITLE
fix: allow Claude workflows to create pull requests

### DIFF
--- a/.claude/commands/repo-maintenance.md
+++ b/.claude/commands/repo-maintenance.md
@@ -938,6 +938,19 @@ TEMPLATE_RAW_URL="https://raw.githubusercontent.com/keito4/config/main/templates
 
 if [ -f "$SCHED_MAINT" ]; then
   echo "scheduled-maintenance.yml: 存在"
+
+  SCHED_CONTENT=$(cat "$SCHED_MAINT")
+  if echo "$SCHED_CONTENT" | grep -q -- "--create-pr"; then
+    if ! echo "$SCHED_CONTENT" | grep -q -- "--allowedTools"; then
+      echo "scheduled-maintenance.yml: claude_args --allowedTools 未設定（PR作成コマンドが許可されない可能性）"
+    fi
+    if ! echo "$SCHED_CONTENT" | grep -q "Bash(gh pr create:\*)"; then
+      echo "scheduled-maintenance.yml: Bash(gh pr create:*) 未許可（--create-pr が PR を作成できない）"
+    fi
+    if ! echo "$SCHED_CONTENT" | grep -q 'GH_TOKEN: ${{ github.token }}'; then
+      echo "scheduled-maintenance.yml: GH_TOKEN 未設定（gh CLI が認証できない可能性）"
+    fi
+  fi
 else
   echo "scheduled-maintenance.yml: 未配置"
 fi
@@ -945,11 +958,12 @@ fi
 
 **結果パターン:**
 
-| 状態                                  | 対応                                    |
-| ------------------------------------- | --------------------------------------- |
-| ワークフロー存在 + テンプレートと一致 | ✅ スキップ                             |
-| ワークフロー存在 + テンプレートと乖離 | ⚠️ テンプレートとの差分を表示           |
-| ワークフロー未配置                    | ⚠️ → full mode でテンプレートからコピー |
+| 状態                                  | 対応                                                 |
+| ------------------------------------- | ---------------------------------------------------- |
+| ワークフロー存在 + テンプレートと一致 | ✅ スキップ                                          |
+| ワークフロー存在 + テンプレートと乖離 | ⚠️ テンプレートとの差分を表示                        |
+| PR作成許可またはGH_TOKEN不足          | ⚠️ `claude_args --allowedTools` と `GH_TOKEN` を更新 |
+| ワークフロー未配置                    | ⚠️ → full mode でテンプレートからコピー              |
 
 **MODE が `full` かつ未配置の場合:**
 
@@ -1192,14 +1206,17 @@ done
 
 **チェック項目:**
 
-| #   | チェック                                       | 推奨値                                   | コスト影響                     |
-| --- | ---------------------------------------------- | ---------------------------------------- | ------------------------------ |
-| 1   | `claude.yml` の `cancel-in-progress`           | `true`                                   | 重複実行防止（**最大の効果**） |
-| 2   | `claude.yml` の issues トリガー                | `[opened]` のみ                          | `assigned` での不要起動防止    |
-| 3   | `claude.yml` の bot 除外                       | `github-actions[bot]`, `dependabot[bot]` | bot連鎖防止                    |
-| 4   | `claude.yml` の timeout                        | `20` 分以下                              | 長時間実行抑制                 |
-| 5   | `claude-code-review.yml` の `synchronize` 除外 | `[opened, ready_for_review, reopened]`   | push毎のレビュー実行防止       |
-| 6   | Copilot code review との重複                   | どちらか1つに統一                        | AIレビュー重複防止             |
+| #   | チェック                                       | 推奨値                                                                    | コスト影響                     |
+| --- | ---------------------------------------------- | ------------------------------------------------------------------------- | ------------------------------ |
+| 1   | `claude.yml` の `cancel-in-progress`           | `true`                                                                    | 重複実行防止（**最大の効果**） |
+| 2   | `claude.yml` の issues トリガー                | `[opened]` のみ                                                           | `assigned` での不要起動防止    |
+| 3   | `claude.yml` の bot 除外                       | `github-actions[bot]`, `dependabot[bot]`                                  | bot連鎖防止                    |
+| 4   | `claude.yml` の timeout                        | `20` 分以下                                                               | 長時間実行抑制                 |
+| 5   | `claude-code-review.yml` の `synchronize` 除外 | `[opened, ready_for_review, reopened]`                                    | push毎のレビュー実行防止       |
+| 6   | Copilot code review との重複                   | どちらか1つに統一                                                         | AIレビュー重複防止             |
+| 7   | Issue対応用 `gh pr create` の許可              | `claude_args --allowedTools` に `Bash(gh pr create:*)`                    | Issue対応後のPR自動作成        |
+| 8   | `gh` CLI 認証用 token                          | Claude action step の `env.GH_TOKEN: ${{ github.token }}`                 | `gh pr create` の認証失敗防止  |
+| 9   | 旧形式の tool 設定                             | `settings.permissions.allowedTools` ではなく `claude_args --allowedTools` | Claude SDK への反映漏れ防止    |
 
 ```bash
 # claude.yml のチェック
@@ -1225,6 +1242,23 @@ if [ -f ".github/workflows/claude.yml" ]; then
   TIMEOUT=$(echo "$CLAUDE_YML" | grep "timeout-minutes:" | head -1 | grep -o '[0-9]*')
   if [ -n "$TIMEOUT" ] && [ "$TIMEOUT" -gt 20 ]; then
     ISSUES+=("claude.yml: timeout が ${TIMEOUT}分（推奨: 20分以下）")
+  fi
+
+  if echo "$CLAUDE_YML" | grep -q "gh pr create"; then
+    if ! echo "$CLAUDE_YML" | grep -q -- "--allowedTools"; then
+      ISSUES+=("claude.yml: claude_args --allowedTools 未設定（gh pr create が Claude SDK の allowedTools に入らない可能性）")
+    fi
+    if ! echo "$CLAUDE_YML" | grep -q "Bash(gh pr create:\*)"; then
+      ISSUES+=("claude.yml: Bash(gh pr create:*) 未許可（Issue対応後にPRを自動作成できない）")
+    fi
+    if ! echo "$CLAUDE_YML" | grep -q 'GH_TOKEN: ${{ github.token }}'; then
+      ISSUES+=("claude.yml: Claude action step に GH_TOKEN が未設定（gh CLI が認証できない可能性）")
+    fi
+  fi
+
+  if echo "$CLAUDE_YML" | grep -q "settings:" && \
+     echo "$CLAUDE_YML" | grep -q '"allowedTools"'; then
+    ISSUES+=("claude.yml: settings.permissions.allowedTools を使用中（claude_args --allowedTools へ移行推奨）")
   fi
 fi
 

--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -71,20 +71,19 @@ jobs:
               continue
             fi
 
-            QUALITY_GATE_STATUS=$(echo "$QUALITY_GATE" | jq -r '.status')
-            QUALITY_GATE_CONCLUSION=$(echo "$QUALITY_GATE" | jq -r '.conclusion')
-
-            if [ "$QUALITY_GATE_STATUS" != "completed" ]; then
-              echo "⏳ Quality Gate is still running: $QUALITY_GATE_STATUS, waiting..."
+            if echo "$QUALITY_GATE" | jq -e 'select(.status != "completed")' >/dev/null; then
+              echo "⏳ Quality Gate is still running, waiting..."
+              echo "$QUALITY_GATE" | jq -r '"\(.name): \(.status) - \(.conclusion)"'
               sleep $POLL_INTERVAL
               ELAPSED_TIME=$((ELAPSED_TIME + POLL_INTERVAL))
               continue
             fi
 
             # Quality Gate完了 - 結果を確認
-            if [ "$QUALITY_GATE_CONCLUSION" != "success" ]; then
+            if echo "$QUALITY_GATE" | jq -e 'select(.conclusion != "success")' >/dev/null; then
               echo "ci_passed=false" >> "$GITHUB_OUTPUT"
-              echo "❌ Quality Gate failed with conclusion: $QUALITY_GATE_CONCLUSION"
+              echo "❌ Quality Gate failed:"
+              echo "$QUALITY_GATE" | jq -r 'select(.conclusion != "success") | "\(.name): \(.conclusion)"'
               echo "Claude Code Review will be skipped."
               exit 0
             fi

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -67,19 +67,9 @@ jobs:
             actions: read
             checks: read
 
-          # Settings for allowed tools and permissions
-          settings: |
-            {
-              "permissions": {
-                "allowedTools": [
-                  "Bash(gh:*)",
-                  "Bash(npm:*)",
-                  "Bash(pnpm:*)",
-                  "Bash(npx:*)"
-                ]
-              }
-            }
-
           # System prompt to automatically create PRs when working on Issues
           claude_args: |
+            --allowedTools "Bash(gh pr create:*),Bash(gh pr view:*),Bash(gh pr list:*),Bash(gh pr status:*),Bash(npm:*),Bash(pnpm:*),Bash(npx:*)"
             --system-prompt "When working on GitHub Issues (not PRs), after completing all code changes and pushing to a branch, you MUST create a Pull Request by running 'gh pr create' command. Do not just provide a link - actually execute the gh pr create command to create the PR automatically."
+        env:
+          GH_TOKEN: ${{ github.token }}

--- a/.github/workflows/scheduled-maintenance.yml
+++ b/.github/workflows/scheduled-maintenance.yml
@@ -51,21 +51,10 @@ jobs:
             - What needs manual attention
 
             If no updates are needed, do NOT create an issue.
-          settings: |
-            {
-              "permissions": {
-                "allowedTools": [
-                  "Bash(gh:*)",
-                  "Bash(npm:*)",
-                  "Bash(pnpm:*)",
-                  "Bash(npx:*)",
-                  "Bash(node:*)",
-                  "Bash(git:*)",
-                  "Bash(curl:*)",
-                  "Bash(jq:*)"
-                ]
-              }
-            }
+          claude_args: |
+            --allowedTools "Bash(gh api:*),Bash(gh issue create:*),Bash(gh issue list:*),Bash(gh pr create:*),Bash(gh pr view:*),Bash(npm:*),Bash(pnpm:*),Bash(npx:*),Bash(node:*),Bash(git:*),Bash(curl:*),Bash(jq:*)"
+        env:
+          GH_TOKEN: ${{ github.token }}
 
       - name: Post failure issue
         if: failure()

--- a/templates/workflows/claude.yml
+++ b/templates/workflows/claude.yml
@@ -87,18 +87,8 @@ jobs:
             actions: read
             checks: read
 
-          settings: |
-            {
-              "permissions": {
-                "allowedTools": [
-                  "Bash(gh:*)",
-                  "Bash(git:*)",
-                  "Bash(npm:*)",
-                  "Bash(pnpm:*)",
-                  "Bash(npx:*)"
-                ]
-              }
-            }
-
           claude_args: |
+            --allowedTools "Bash(gh pr create:*),Bash(gh pr view:*),Bash(gh pr list:*),Bash(gh pr status:*),Bash(git:*),Bash(npm:*),Bash(pnpm:*),Bash(npx:*)"
             --system-prompt "When working on GitHub Issues (not PRs), after completing all code changes and pushing to a branch, you MUST create a Pull Request by running 'gh pr create' command. Do not just provide a link - actually execute the gh pr create command to create the PR automatically."
+        env:
+          GH_TOKEN: ${{ github.token }}

--- a/templates/workflows/scheduled-maintenance.yml
+++ b/templates/workflows/scheduled-maintenance.yml
@@ -51,21 +51,10 @@ jobs:
             - What needs manual attention
 
             If no updates are needed, do NOT create an issue.
-          settings: |
-            {
-              "permissions": {
-                "allowedTools": [
-                  "Bash(gh:*)",
-                  "Bash(npm:*)",
-                  "Bash(pnpm:*)",
-                  "Bash(npx:*)",
-                  "Bash(node:*)",
-                  "Bash(git:*)",
-                  "Bash(curl:*)",
-                  "Bash(jq:*)"
-                ]
-              }
-            }
+          claude_args: |
+            --allowedTools "Bash(gh api:*),Bash(gh issue create:*),Bash(gh issue list:*),Bash(gh pr create:*),Bash(gh pr view:*),Bash(npm:*),Bash(pnpm:*),Bash(npx:*),Bash(node:*),Bash(git:*),Bash(curl:*),Bash(jq:*)"
+        env:
+          GH_TOKEN: ${{ github.token }}
 
       - name: Post failure issue
         if: failure()


### PR DESCRIPTION
## Summary

- Move Claude workflow tool permissions from `settings.permissions.allowedTools` to `claude_args --allowedTools` so they are reflected in the Claude SDK allowed tools.
- Allow `gh pr create` and related read commands for issue-handling Claude workflows.
- Pass `GH_TOKEN: ${{ github.token }}` to Claude action steps so `gh` can authenticate without committing credentials.
- Add repo-maintenance checks that recommend the PR creation allowlist and token wiring.
- Handle duplicate `Quality Gate` check-runs in Claude Code Review so CI fallback + CI do not keep the review gate waiting until timeout.

## Verification

- `actionlint .github/workflows/claude.yml .github/workflows/scheduled-maintenance.yml .github/workflows/claude-code-review.yml templates/workflows/claude.yml templates/workflows/scheduled-maintenance.yml`
- `npx prettier --check .github/workflows/claude.yml .github/workflows/scheduled-maintenance.yml .github/workflows/claude-code-review.yml templates/workflows/claude.yml templates/workflows/scheduled-maintenance.yml .claude/commands/repo-maintenance.md`
- `git diff --check`
- Live check-run parsing smoke test for duplicate `Quality Gate`: `quality-gates-ok`
- Staged diff credential pattern scan: no findings
- `bash script/security-credential-scan.sh --strict` was run; it reports pre-existing false positives in `nix/flake.lock` rev hashes, unrelated to this PR.