### PR TITLE
fix: post_pr_ci_watch.py から未使用変数を削除

### DIFF
--- a/.claude/hooks/post_pr_ci_watch.py
+++ b/.claude/hooks/post_pr_ci_watch.py
@@ -72,8 +72,6 @@ def get_pr_checks(pr_number: str, timeout_seconds: int = 600):
                 return "no_checks", []
 
             # チェック状態を集計
-            pending = [c for c in checks if c.get("state") == "PENDING"]
-            in_progress = [c for c in checks if c.get("state") == "IN_PROGRESS"]
             completed = [c for c in checks if c.get("state") == "SUCCESS" or c.get("state") == "FAILURE" or c.get("state") == "SKIPPED"]
             failed = [c for c in checks if c.get("conclusion") == "FAILURE" or c.get("state") == "FAILURE"]
 


### PR DESCRIPTION
closes #776

## 変更内容

`.claude/hooks/post_pr_ci_watch.py` の `get_pr_checks()` 内に存在した未使用変数 `pending` と `in_progress` を削除。

Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Optimized internal CI monitoring processes for improved efficiency.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/keito4/config/pull/777?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->