### PR TITLE
feat: add Sentry Claude plugin

### DIFF
--- a/.claude/plugins/plugins.txt
+++ b/.claude/plugins/plugins.txt
@@ -15,6 +15,9 @@ typescript-lsp@claude-plugins-official
 # Code Review
 code-review@claude-plugins-official
 
+# Monitoring
+sentry@claude-plugins-official
+
 # === Workflow Plugins (claude-code-workflows) ===
 code-refactoring@claude-code-workflows
 kubernetes-operations@claude-code-workflows

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -294,6 +294,46 @@
     "hookify@claude-code-plugins": true,
     "security-guidance@claude-code-plugins": true,
     "nextjs-vercel-pro@claude-code-templates": true,
-    "supabase-toolkit@claude-code-templates": true
+    "supabase-toolkit@claude-code-templates": true,
+    "commit-commands@claude-plugins-official": true,
+    "hookify@claude-plugins-official": true,
+    "plugin-dev@claude-plugins-official": true,
+    "code-review@claude-plugins-official": true,
+    "sentry@claude-plugins-official": true,
+    "postgres-best-practices@supabase-agent-skills": true,
+    "agent-browser@agent-browser": true,
+    "context7@intellectronica-skills": true
+  },
+  "extraKnownMarketplaces": {
+    "claude-plugins-official": {
+      "source": {
+        "source": "git",
+        "url": "https://github.com/anthropics/claude-plugins-official.git"
+      }
+    },
+    "agent-browser": {
+      "source": {
+        "source": "git",
+        "url": "https://github.com/vercel-labs/agent-browser.git"
+      }
+    },
+    "claude-code-workflows": {
+      "source": {
+        "source": "git",
+        "url": "https://github.com/wshobson/agents.git"
+      }
+    },
+    "intellectronica-skills": {
+      "source": {
+        "source": "git",
+        "url": "https://github.com/intellectronica/agent-skills.git"
+      }
+    },
+    "supabase-agent-skills": {
+      "source": {
+        "source": "git",
+        "url": "https://github.com/supabase/agent-skills.git"
+      }
+    }
   }
 }

--- a/README.md
+++ b/README.md
@@ -1078,7 +1078,7 @@ The repository includes a complete DevContainer setup (`.devcontainer/`) that pr
 
 **Pre-installed Plugins** (defined in `.claude/plugins/plugins.txt`):
 
-- Official plugins: `commit-commands`, `hookify`, `plugin-dev`, `typescript-lsp`, `code-review`
+- Official plugins: `commit-commands`, `hookify`, `plugin-dev`, `typescript-lsp`, `code-review`, `sentry`
 - Workflow plugins: `code-refactoring`, `kubernetes-operations`, `javascript-typescript`, `backend-development`, `full-stack-orchestration`, `database-design`, `database-migrations`
 - Supabase plugins: `postgres-best-practices`
 - Vercel plugins: `agent-browser`

--- a/docs/using-config-base-image.md
+++ b/docs/using-config-base-image.md
@@ -63,6 +63,7 @@ claude --help
 - `plugin-dev` - プラグイン開発ツール
 - `typescript-lsp` - TypeScript 言語サーバー
 - `code-review` - コードレビュー支援
+- `sentry` - Sentry 連携・エラー監視
 
 **ワークフロープラグイン (`claude-code-workflows`)**:
 


### PR DESCRIPTION
## Summary

- Add `sentry@claude-plugins-official` to the Claude plugin manifest
- Persist the Claude CLI-installed plugin enablement and marketplace declarations in shared settings
- Update documentation to list Sentry alongside the pre-installed official plugins

## Verification

- `make claude-setup`
- `jq empty .claude/settings.json .claude/plugins/known_marketplaces.json.template`
- `git diff --check`
- `npx prettier --check README.md docs/using-config-base-image.md .claude/settings.json`
- `npm test` via pre-commit: 25 suites / 564 tests passed

Note: TypeScript LSP was already present as `typescript-lsp@claude-plugins-official` and remains enabled.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added Sentry monitoring integration for error tracking and observability
  * Expanded available development plugins and tools, including code review, database utilities, and browser automation
  * Configured additional plugin marketplaces for extended functionality

* **Documentation**
  * Updated documentation to reflect newly available plugins and monitoring capabilities

<!-- end of auto-generated comment: release notes by coderabbit.ai -->