### PR TITLE
feat: harden secret prevention for .claude local settings

### DIFF
--- a/.claude/hooks/block_inline_secrets.py
+++ b/.claude/hooks/block_inline_secrets.py
@@ -1,0 +1,63 @@
+#!/usr/bin/env python3
+"""Defense-in-depth hook: block commands that embed literal credentials.
+
+Claude Code persists approved commands as permission rules in
+``.claude/settings.local.json``. When a command embeds a real secret inline
+(e.g. ``export AWS_SECRET_ACCESS_KEY="..."``), that secret leaks into the
+settings file — and, if the file is tracked, into git history. This is exactly
+how long-lived credentials end up committed.
+
+This hook inspects the full command string and blocks execution when it
+contains a high-confidence credential pattern, so secrets never get approved,
+run, or written to disk. Pass secrets via the environment or a secret manager
+(1Password / Doppler / GitHub Secrets) instead.
+
+Only high-confidence patterns are blocked to keep false positives near zero;
+variable references like ``export TOKEN="$GH_TOKEN"`` are never matched.
+"""
+import sys
+import re
+from common import load_hook_input, get_command
+
+data = load_hook_input()
+cmd = get_command(data)
+
+if not cmd.strip():
+    sys.exit(0)
+
+# Public Supabase local-dev JWT (issuer "supabase-demo", base64 marker below).
+# Shipped in every `supabase start` stack — public by design, not a real secret.
+SUPABASE_DEMO_MARKER = "eyJpc3MiOiJzdXBhYmFzZS1kZW1v"
+
+# High-confidence credential patterns (real secrets, low false-positive rate).
+SECRET_PATTERNS = [
+    (r"(AKIA|ASIA)[0-9A-Z]{16}", "AWS access key id"),
+    (r"aws_secret_access_key\s*[=:]\s*['\"]?[A-Za-z0-9/+]{40}", "AWS secret access key"),
+    (r"ghp_[A-Za-z0-9]{36}", "GitHub personal access token"),
+    (r"gho_[A-Za-z0-9]{36}", "GitHub OAuth token"),
+    (r"github_pat_[A-Za-z0-9]{22}_[A-Za-z0-9]{59}", "GitHub fine-grained PAT"),
+    (r"sk-ant-[A-Za-z0-9_-]{95,}", "Anthropic API key"),
+    (r"sk-proj-[A-Za-z0-9_-]{20,}", "OpenAI project key"),
+    (r"\bsk-[A-Za-z0-9]{48}\b", "OpenAI legacy key"),
+    (r"xox[baprs]-[A-Za-z0-9-]{10,}", "Slack token"),
+    (r"[sr]k_(live|test)_[A-Za-z0-9]{24,}", "Stripe key"),
+    (r"lin_api_[A-Za-z0-9]{43}", "Linear API key"),
+    (r"-----BEGIN[A-Z ]*PRIVATE KEY-----", "private key"),
+]
+
+# Strip the public demo JWT so it never trips detection.
+scan = cmd.replace(SUPABASE_DEMO_MARKER, "")
+
+for pattern, label in SECRET_PATTERNS:
+    if re.search(pattern, scan, re.IGNORECASE):
+        sys.stderr.write(
+            f"🚫 コマンドに認証情報が埋め込まれています: {label}\n"
+            f"   inline の秘密は settings.local.json に許可ルールとして永続化され、"
+            f"git 履歴への漏洩原因になります。\n"
+            f"   環境変数 もしくは シークレットマネージャ"
+            f"（1Password / Doppler / GitHub Secrets）経由で渡してください。\n"
+        )
+        sys.stderr.flush()
+        sys.exit(2)
+
+sys.exit(0)

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -211,6 +211,15 @@
         "hooks": [
           {
             "type": "command",
+            "command": "bash -c 'cd \"$(git rev-parse --show-toplevel 2>/dev/null || echo .)\" && { [ -f .claude/hooks/block_inline_secrets.py ] && python3 .claude/hooks/block_inline_secrets.py || echo \"[hooks] .claude/hooks/block_inline_secrets.py not found. Run /repo-maintenance to set up quality hooks.\"; }'"
+          }
+        ]
+      },
+      {
+        "matcher": "Bash",
+        "hooks": [
+          {
+            "type": "command",
             "command": "bash -c 'cd \"$(git rev-parse --show-toplevel 2>/dev/null || echo .)\" && { [ -f .claude/hooks/block_git_no_verify.py ] && python3 .claude/hooks/block_git_no_verify.py || echo \"[hooks] .claude/hooks/block_git_no_verify.py not found. Run /repo-maintenance to set up quality hooks.\"; }'"
           }
         ]

--- a/.devcontainer/claude-settings.json
+++ b/.devcontainer/claude-settings.json
@@ -283,6 +283,15 @@
         "hooks": [
           {
             "type": "command",
+            "command": "python3 /home/vscode/.claude/hooks/block_inline_secrets.py"
+          }
+        ]
+      },
+      {
+        "matcher": "Bash",
+        "hooks": [
+          {
+            "type": "command",
             "command": "python3 /home/vscode/.claude/hooks/block_git_no_verify.py"
           }
         ]

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -60,6 +60,7 @@ Development infrastructure template repository providing DevContainer images, CI
 | `dot/`               | Dotfiles (DevContainer .zshrc, peco)                        |
 | `eslint/`            | ESLint configuration and plugins                            |
 | `git/`               | Git hooks and configuration                                 |
+| `next/`              | next                                                        |
 | `nix/`               | nix-darwin + home-manager (macOS environment)               |
 | `npm/`               | npm global configuration and library management             |
 | `script/`            | Utility shell scripts                                       |
@@ -164,6 +165,7 @@ Additional test commands: `test:integration` (BATS), `test:coverage` (Jest + cov
 | `block_config_edit.py`        | Pre edit            | Protect configuration files                      |
 | `block_dangerous_commands.py` | Pre Bash            | Block destructive commands                       |
 | `block_git_no_verify.py`      | Pre git commit/push | Block `--no-verify` and `HUSKY=0`                |
+| `block_inline_secrets.py`     | Pre Bash            | Block commands embedding literal credentials     |
 | `common.py`                   | —                   | Shared utility library (imported by other hooks) |
 | `post_commit_adr_reminder.py` | Post git commit     | Remind ADR for architectural changes             |
 | `post_edit_auto_lint.py`      | Post edit           | Auto-format and lint                             |

--- a/script/lib/agents-md-data.sh
+++ b/script/lib/agents-md-data.sh
@@ -62,6 +62,7 @@ HOOK_TABLE=(
   "pre_git_quality_gates.py|Pre git commit/push|Auto-detect and run quality gates"
   "block_config_edit.py|Pre edit|Protect configuration files"
   "block_dangerous_commands.py|Pre Bash|Block destructive commands"
+  "block_inline_secrets.py|Pre Bash|Block commands embedding literal credentials"
   "common.py|—|Shared utility library (imported by other hooks)"
   "post_edit_auto_lint.py|Post edit|Auto-format and lint"
   "post_git_push_ci.py|Post git push|Monitor CI status"

--- a/script/security-credential-scan.sh
+++ b/script/security-credential-scan.sh
@@ -77,7 +77,8 @@ fi
 # Patterns to detect
 declare -A PATTERNS
 # Cloud Provider Keys
-PATTERNS["AWS Access Key"]="AKIA[0-9A-Z]{16}"
+# AKIA = long-lived access key, ASIA = STS temporary credentials (both worth flagging)
+PATTERNS["AWS Access Key"]="(AKIA|ASIA)[0-9A-Z]{16}"
 PATTERNS["AWS Secret"]="['\"][A-Za-z0-9/+=]{40}['\"]"
 PATTERNS["Google API Key"]="AIza[0-9A-Za-z\\-_]{35}"
 PATTERNS["Azure Service Principal"]="['\"][a-f0-9]{8}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{12}['\"]"
@@ -176,7 +177,42 @@ is_known_false_positive() {
       ;;
   esac
 
+  # Public Supabase local-dev JWT (issuer "supabase-demo", base64 marker below).
+  # Shipped in every `supabase start` stack — public by design, not a real secret.
+  if [[ "$line_content" == *"eyJpc3MiOiJzdXBhYmFzZS1kZW1v"* ]]; then
+    return 0
+  fi
+
   return 1
+}
+
+# Record a finding: assign severity, mask secret material, append to FINDINGS.
+# Mutates the global CRITICAL_COUNT / WARNING_COUNT / FINDINGS.
+record_finding() {
+  local pattern_name="$1" file="$2" line_num="$3" line_content="$4"
+  local severity="WARNING"
+
+  if [[ "$pattern_name" == *"AWS"* ]] || \
+     [[ "$pattern_name" == *"GitHub Token"* ]] || \
+     [[ "$pattern_name" == *"Private Key"* ]] || \
+     [[ "$pattern_name" == *"OpenAI"* ]] || \
+     [[ "$pattern_name" == *"Anthropic"* ]] || \
+     [[ "$pattern_name" == *"Stripe"* ]] || \
+     [[ "$pattern_name" == *"Supabase"* ]] || \
+     [[ "$pattern_name" == *"Slack Token"* ]] || \
+     [[ "$pattern_name" == *"Database URL"* ]]; then
+    severity="CRITICAL"
+    CRITICAL_COUNT=$((CRITICAL_COUNT + 1))
+  else
+    WARNING_COUNT=$((WARNING_COUNT + 1))
+  fi
+
+  # Mask sensitive part
+  local masked
+  # shellcheck disable=SC2001
+  masked=$(echo "$line_content" | sed 's/[A-Za-z0-9]\{10,\}/************/g')
+
+  FINDINGS+=("$severity|$pattern_name|$file:$line_num|$masked")
 }
 
 # Scan for patterns
@@ -200,30 +236,34 @@ for pattern_name in "${!PATTERNS[@]}"; do
       continue
     fi
 
-    # Determine severity
-    SEVERITY="WARNING"
-    # Critical patterns: cloud credentials, API keys that provide full access
-    if [[ "$pattern_name" == *"AWS"* ]] || \
-       [[ "$pattern_name" == *"GitHub Token"* ]] || \
-       [[ "$pattern_name" == *"Private Key"* ]] || \
-       [[ "$pattern_name" == *"OpenAI"* ]] || \
-       [[ "$pattern_name" == *"Anthropic"* ]] || \
-       [[ "$pattern_name" == *"Stripe"* ]] || \
-       [[ "$pattern_name" == *"Supabase"* ]] || \
-       [[ "$pattern_name" == *"Slack Token"* ]] || \
-       [[ "$pattern_name" == *"Database URL"* ]]; then
-      SEVERITY="CRITICAL"
-      CRITICAL_COUNT=$((CRITICAL_COUNT + 1))
-    else
-      WARNING_COUNT=$((WARNING_COUNT + 1))
-    fi
-
-    # Mask sensitive part
-    # shellcheck disable=SC2001
-    MASKED=$(echo "$line_content" | sed 's/[A-Za-z0-9]\{10,\}/************/g')
-
-    FINDINGS+=("$SEVERITY|$pattern_name|$file:$line_num|$MASKED")
+    record_finding "$pattern_name" "$file" "$line_num" "$line_content"
   done < <(grep -rn -E $GREP_EXCLUDE "$pattern" "$SCAN_PATH" 2>/dev/null || true)
+done
+
+# Focused scan: .claude/settings*.json are excluded from the broad scan above
+# (EXCLUDE_DIRS contains ".claude"), but they are exactly where approved
+# `export SECRET=...` permission rules accumulate real credentials. Scan them
+# explicitly — even when gitignored, since the secret still sits on disk and
+# tracked variants (e.g. a committed settings.local.json) leak into history.
+for claude_settings in \
+  "$SCAN_PATH/.claude/settings.json" \
+  "$SCAN_PATH/.claude/settings.local.json"; do
+  [ -f "$claude_settings" ] || continue
+
+  if [ -n "$IGNORE_PATTERN" ] && [[ "$claude_settings" =~ $IGNORE_PATTERN ]]; then
+    continue
+  fi
+
+  for pattern_name in "${!PATTERNS[@]}"; do
+    pattern="${PATTERNS[$pattern_name]}"
+    while IFS=: read -r line_num line_content; do
+      [ -z "$line_num" ] && continue
+      if is_known_false_positive "$pattern_name" "$claude_settings" "$line_content"; then
+        continue
+      fi
+      record_finding "$pattern_name" "$claude_settings" "$line_num" "$line_content"
+    done < <(grep -n -E "$pattern" "$claude_settings" 2>/dev/null || true)
+  done
 done
 
 # Count files scanned
@@ -251,12 +291,16 @@ EOF
       echo ","
     fi
     first=false
+    # Escape backslashes and double-quotes so masked content stays valid JSON
+    # (settings.json findings are quote-heavy).
+    content_json=${content//\\/\\\\}
+    content_json=${content_json//\"/\\\"}
     cat <<EOF
     {
       "severity": "$severity",
       "type": "$type",
       "location": "$location",
-      "masked_content": "$content"
+      "masked_content": "$content_json"
     }
 EOF
   done

--- a/test/hooks-integrity.test.js
+++ b/test/hooks-integrity.test.js
@@ -10,6 +10,7 @@ describe('Claude Code Hooks integrity', () => {
     'common.py',
     'block_config_edit.py',
     'block_dangerous_commands.py',
+    'block_inline_secrets.py',
     'block_git_no_verify.py',
     'post_commit_adr_reminder.py',
     'post_edit_auto_lint.py',
@@ -175,6 +176,55 @@ describe('Claude Code Hooks integrity', () => {
 
     test('should normalize command for matching (lowercase)', () => {
       expect(content).toContain('.lower()');
+    });
+  });
+
+  describe('block_inline_secrets.py — inline credential protection', () => {
+    let content;
+
+    beforeAll(() => {
+      content = fs.readFileSync(path.join(hooksDir, 'block_inline_secrets.py'), 'utf8');
+    });
+
+    test('should have shebang line', () => {
+      expect(content.startsWith('#!/usr/bin/env python3')).toBe(true);
+    });
+
+    test('should define SECRET_PATTERNS list', () => {
+      expect(content).toContain('SECRET_PATTERNS');
+    });
+
+    test('should detect AWS access key ids (AKIA/ASIA)', () => {
+      expect(content).toContain('(AKIA|ASIA)[0-9A-Z]{16}');
+    });
+
+    test('should detect GitHub personal access tokens', () => {
+      expect(content).toContain('ghp_');
+    });
+
+    test('should detect Anthropic API keys', () => {
+      expect(content).toContain('sk-ant-');
+    });
+
+    test('should detect private key blocks', () => {
+      expect(content).toContain('PRIVATE KEY');
+    });
+
+    test('should whitelist the public Supabase demo JWT', () => {
+      expect(content).toContain('SUPABASE_DEMO_MARKER');
+    });
+
+    test('should exit 2 when an inline secret is detected', () => {
+      expect(content).toContain('sys.exit(2)');
+    });
+
+    test('should exit 0 for commands without inline secrets', () => {
+      expect(content).toContain('sys.exit(0)');
+    });
+
+    test('should reuse get_command from common', () => {
+      expect(content).toContain('from common import');
+      expect(content).toContain('get_command');
     });
   });
 

--- a/test/integration/security-scripts.bats
+++ b/test/integration/security-scripts.bats
@@ -81,6 +81,70 @@ load ../test_helper/test_helper
     assert_failure
 }
 
+@test "security-credential-scan.sh detects AWS temporary (ASIA) keys" {
+    temp_dir=$(mktemp -d)
+    trap "rm -rf $temp_dir" EXIT
+
+    # STS temporary credentials use the ASIA prefix
+    echo 'const key = "ASIAIOSFODNN7EXAMPLE";' > "$temp_dir/test.js"
+
+    run "$REPO_ROOT/script/security-credential-scan.sh" --path "$temp_dir"
+    assert_success
+    assert_output --partial "AWS Access Key"
+}
+
+@test "security-credential-scan.sh scans .claude/settings.local.json for inline secrets" {
+    mkdir -p "$TEST_TEMP_DIR/.claude"
+    cat > "$TEST_TEMP_DIR/.claude/settings.local.json" <<'JSON'
+{
+  "permissions": {
+    "allow": [
+      "Bash(export AWS_ACCESS_KEY_ID=\"ASIAIOSFODNN7EXAMPLE\")"
+    ]
+  }
+}
+JSON
+
+    run "$REPO_ROOT/script/security-credential-scan.sh" --path "$TEST_TEMP_DIR" --strict
+    assert_failure
+    assert_output --partial "AWS Access Key"
+}
+
+@test "security-credential-scan.sh emits valid JSON for quote-heavy .claude settings" {
+    mkdir -p "$TEST_TEMP_DIR/.claude"
+    cat > "$TEST_TEMP_DIR/.claude/settings.local.json" <<'JSON'
+{
+  "permissions": {
+    "allow": [
+      "Bash(export AWS_ACCESS_KEY_ID=\"ASIAIOSFODNN7EXAMPLE\")"
+    ]
+  }
+}
+JSON
+
+    run "$REPO_ROOT/script/security-credential-scan.sh" --path "$TEST_TEMP_DIR" --json
+    assert_success
+    # Output must parse as JSON despite escaped quotes in the finding
+    echo "$output" | jq -e '.critical_count >= 1' >/dev/null
+}
+
+@test "security-credential-scan.sh ignores public Supabase local-dev demo key" {
+    mkdir -p "$TEST_TEMP_DIR/.claude"
+    cat > "$TEST_TEMP_DIR/.claude/settings.local.json" <<'JSON'
+{
+  "permissions": {
+    "allow": [
+      "Bash(SUPABASE_SERVICE_ROLE_KEY=\"eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZS1kZW1vIiwicm9sZSI6InNlcnZpY2Vfcm9sZSJ9.demo\" supabase status)"
+    ]
+  }
+}
+JSON
+
+    run "$REPO_ROOT/script/security-credential-scan.sh" --path "$TEST_TEMP_DIR" --strict
+    assert_success
+    assert_output --partial "No credentials found"
+}
+
 @test "security-credential-scan.sh ignores Nix flake.lock rev hashes" {
     mkdir -p "$TEST_TEMP_DIR/nix"
     cat > "$TEST_TEMP_DIR/nix/flake.lock" <<'JSON'


### PR DESCRIPTION
## Why

直近の active リポ走査中に **`.claude/settings.local.json` に AWS 認証情報が平文でコミットされ `origin/main` に push 済み**（commit `8c17a17`）であることを検出した。原因は Claude Code が「秘密を含むコマンドを丸ごと許可ルール化」して local settings に永続化する挙動。

config の既存ガードはこのクラスを多層で取りこぼしていた：

- `security-credential-scan.sh` は `.claude` を `EXCLUDE_DIRS` で**丸ごと除外**しており、`settings*.json` 内の `export SECRET=...` を一切スキャンしていなかった
- AWS キーパターンが `AKIA`（長期キー）のみで、`ASIA`（STS 一時キー）を検出できなかった
- そもそも秘密がコマンドに埋め込まれる瞬間を止める手段が無かった

本PRはこれらを塞ぐ（platform-infra 自体の除去・鍵ローテーションは別作業）。

## What

### 1. scanner 強化 (`script/security-credential-scan.sh`)

- AWS Access Key を `(AKIA|ASIA)[0-9A-Z]{16}` に拡張（一時キーも検出）
- `.claude/settings.json` / `.claude/settings.local.json` への**専用スキャン**を追加（broad scan の `.claude` 除外をバイパス、gitignore でも走査）
- 公開 Supabase local-dev demo JWT（issuer `supabase-demo`）をホワイトリスト化
- JSON 出力で `masked_content` の引用符/バックスラッシュ未エスケープにより引用符の多い行で JSON が壊れる**潜在バグを修正**

### 2. 新フック (`.claude/hooks/block_inline_secrets.py`)

- `PreToolUse(Bash)` で、コマンドに埋め込まれた literal な認証情報を検知して `exit 2` でブロック
- 対象: `AKIA/ASIA`, AWS secret, GitHub `ghp_/gho_/PAT`, `sk-ant`, `sk-proj`, Slack, Stripe, Linear, private key
- 変数参照（`export TOKEN="$GH_TOKEN"`）や demo JWT は誤検知しない
- `.claude/settings.json` と `.devcontainer/claude-settings.json` の両方に配線（ローカル/コンテナ両環境で有効）

### 3. tests / docs

- `hooks-integrity.test.js`: `block_inline_secrets` を `EXPECTED_HOOKS` + describe（10 ケース）に追加
- `security-scripts.bats`: ASIA 検出 / `.claude` 設定スキャン / JSON 妥当性 / demo 鍵ホワイトリストの 4 ケース追加
- `AGENTS.md`（生成元 `agents-md-data.sh`）のフック表に追記

## How

多層防御。フックが「秘密の混入」を入口で止め、スキャナが「既に混入したもの」を CI/quality-gate で検出する。いずれも既存の `block_dangerous_commands.py` / 既存スキャナのパターンを踏襲し、repo 横断で再利用可能。

## Risk

低。
- フックは high-confidence パターンのみブロック（false-positive をほぼ排除、変数参照は通す）。
- スキャナ変更は検出強化＋潜在バグ修正のみ。既存テスト含め 575 テスト green、shellcheck / prettier 通過。

## Follow-up（別作業）

- 認証情報の追跡解除・`.gitignore` 追加・履歴 scrub、および**該当 AWS キーがまだ有効ならローテーション**（ASIA 一時キーのため失効済みの可能性大だが要確認）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a command execution blocker that detects and prevents embedded credentials from running
  * Enhanced credential scanning to detect additional types of AWS access credentials
  
* **Bug Fixes**
  * Improved credential scanning accuracy by excluding known safe credential patterns (Supabase local-dev JWTs)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->