### PR TITLE
fix(hooks): bound force-push patterns to avoid chained-command false positives

### DIFF
--- a/.claude/hooks/block_dangerous_commands.py
+++ b/.claude/hooks/block_dangerous_commands.py
@@ -21,9 +21,12 @@ normalized = " ".join(cmd.split()).lower()
 # ── Dangerous patterns (regex) ──────────────────────────────────
 DANGEROUS_PATTERNS = [
     # === Git destructive operations ===
-    (r"git\s+push\s+.*--force", "git push --force (force push)"),
-    (r"git\s+push\s+.*-f\b", "git push -f (force push)"),
-    (r"git\s+push\s+.*--force-with-lease", "git push --force-with-lease"),
+    # Bound the wildcard to the push invocation's own args: [^|&;<>]* stops at a
+    # pipe/redirect/separator so a later `-f` in a chained command or a flattened
+    # heredoc body (newlines collapse to spaces) cannot trigger a false positive.
+    (r"git\s+push\s+[^|&;<>]*--force", "git push --force (force push)"),
+    (r"git\s+push\s+[^|&;<>]*-f\b", "git push -f (force push)"),
+    (r"git\s+push\s+[^|&;<>]*--force-with-lease", "git push --force-with-lease"),
     (r"git\s+push\s+\S+\s+\+", "git push origin +branch (force push)"),
     (r"git\s+clean\s+.*-f", "git clean -f (delete untracked files)"),
     (r"git\s+reflog\s+expire", "git reflog expire (destroy recovery data)"),

--- a/test/hooks-integrity.test.js
+++ b/test/hooks-integrity.test.js
@@ -106,11 +106,17 @@ describe('Claude Code Hooks integrity', () => {
     });
 
     test('should block git force push (--force)', () => {
-      expect(content).toContain('git\\s+push\\s+.*--force');
+      expect(content).toContain('git\\s+push\\s+[^|&;<>]*--force');
     });
 
     test('should block git force push (-f)', () => {
-      expect(content).toContain('git\\s+push\\s+.*-f\\b');
+      expect(content).toContain('git\\s+push\\s+[^|&;<>]*-f\\b');
+    });
+
+    test('should bound force-push wildcard to avoid chained-command false positives', () => {
+      // [^|&;<>]* stops at a pipe/redirect/separator so a later -f in a chained
+      // command or flattened heredoc body does not trigger a false positive.
+      expect(content).not.toContain('git\\s+push\\s+.*-f\\b');
     });
 
     test('should block git reset --hard', () => {


### PR DESCRIPTION
## Why

`block_dangerous_commands.py` は normalize 時に `" ".join(cmd.split())` で改行を空白へ潰す。その状態で force-push 検出の `git\s+push\s+.*-f\b` 系が `.*` 貪欲マッチするため、**push の引数を越えて後続コマンドや flatten された heredoc 本文中の `-f`** にまでマッチし、安全なコマンドを誤ブロックしていた。

実例（このセッションで遭遇）:

```
git push -u origin my-branch 2>&1 | tail -4   # -4 や後続テキストの -f で誤検知
git push -u origin b && cat <<EOF ... use -f ... EOF
```

## What

force-push 3 パターンの `.*` を `[^|&;<>]*` に変更し、**pipe / redirect / separator をまたがない（push 自身の引数内のみ）**よう限定。

```diff
- (r"git\s+push\s+.*--force", ...)
- (r"git\s+push\s+.*-f\b", ...)
- (r"git\s+push\s+.*--force-with-lease", ...)
+ (r"git\s+push\s+[^|&;<>]*--force", ...)
+ (r"git\s+push\s+[^|&;<>]*-f\b", ...)
+ (r"git\s+push\s+[^|&;<>]*--force-with-lease", ...)
```

## 検証

behavioral テスト 8 ケースで確認:

- **block 継続**: `--force` / 短縮形 / `--force-with-lease` / `origin +branch`
- **誤検知解消**: pipe 連結 / heredoc 本文に `-f` / `echo … -f && git status` / 通常の `push -u`

`hooks-integrity.test.js` のパターン文字列アサーション更新 + 退行防止テスト追加。jest 111 / 全 jest green。

## Risk

低。検出を緩めるのではなく「push 引数内に限定」する変更で、実 force push の検出は維持。

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved dangerous command detection accuracy by refining pattern matching for git push force operations, reducing false positives while maintaining robust security protections.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->