### PR TITLE
feat(security): extend secret detection coverage (GitLab/Doppler/Google)

### DIFF
--- a/.claude/hooks/block_inline_secrets.py
+++ b/.claude/hooks/block_inline_secrets.py
@@ -42,6 +42,9 @@ SECRET_PATTERNS = [
     (r"xox[baprs]-[A-Za-z0-9-]{10,}", "Slack token"),
     (r"[sr]k_(live|test)_[A-Za-z0-9]{24,}", "Stripe key"),
     (r"lin_api_[A-Za-z0-9]{43}", "Linear API key"),
+    (r"AIza[0-9A-Za-z_-]{35}", "Google API key"),
+    (r"glpat-[A-Za-z0-9_-]{20}", "GitLab personal access token"),
+    (r"dp\.(pt|st|sa|ct|scim|audit)\.[A-Za-z0-9]{40,}", "Doppler token"),
     (r"-----BEGIN[A-Z ]*PRIVATE KEY-----", "private key"),
 ]
 

--- a/script/security-credential-scan.sh
+++ b/script/security-credential-scan.sh
@@ -106,6 +106,8 @@ PATTERNS["Supabase Key"]="eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9\\.[a-zA-Z0-9_-]+\
 # Note: Vercel Token pattern removed (too broad, causes false positives)
 PATTERNS["Linear API Key"]="lin_api_[a-zA-Z0-9]{43}"
 PATTERNS["Sentry DSN"]="https://[a-f0-9]{32}@[a-z0-9]+\\.ingest\\.sentry\\.io/[0-9]+"
+PATTERNS["GitLab PAT"]="glpat-[a-zA-Z0-9_-]{20}"
+PATTERNS["Doppler Token"]="dp\\.(pt|st|sa|ct|scim|audit)\\.[a-zA-Z0-9]{40,}"
 
 # Generic Patterns
 PATTERNS["Private Key"]="-----BEGIN.*PRIVATE KEY-----"
@@ -222,6 +224,8 @@ record_finding() {
      [[ "$pattern_name" == *"Stripe"* ]] || \
      [[ "$pattern_name" == *"Supabase"* ]] || \
      [[ "$pattern_name" == *"Slack Token"* ]] || \
+     [[ "$pattern_name" == *"GitLab"* ]] || \
+     [[ "$pattern_name" == *"Doppler"* ]] || \
      [[ "$pattern_name" == *"Database URL"* ]]; then
     severity="CRITICAL"
     CRITICAL_COUNT=$((CRITICAL_COUNT + 1))

--- a/test/hooks-command-safety.test.js
+++ b/test/hooks-command-safety.test.js
@@ -135,6 +135,18 @@ describe('Claude Code command-safety hooks', () => {
       expect(content).toContain('sk-ant-');
     });
 
+    test('should detect Google API keys', () => {
+      expect(content).toContain('AIza');
+    });
+
+    test('should detect GitLab personal access tokens', () => {
+      expect(content).toContain('glpat-');
+    });
+
+    test('should detect Doppler tokens', () => {
+      expect(content).toContain('Doppler token');
+    });
+
     test('should detect private key blocks', () => {
       expect(content).toContain('PRIVATE KEY');
     });

--- a/test/integration/security-scripts.bats
+++ b/test/integration/security-scripts.bats
@@ -199,6 +199,30 @@ JS
     assert_output --partial "Azure Service Principal"
 }
 
+@test "security-credential-scan.sh detects GitLab and Doppler tokens" {
+    mkdir -p "$TEST_TEMP_DIR/.claude"
+    # Build tokens at runtime so no literal secret pattern lives in the source
+    # (GitHub push protection blocks pushes that contain valid token shapes).
+    gl="glpat-$(printf 'x%.0s' $(seq 20))"
+    dp="dp.pt.$(printf 'x%.0s' $(seq 40))"
+    cat > "$TEST_TEMP_DIR/.claude/settings.local.json" <<JSON
+{
+  "permissions": {
+    "allow": [
+      "Bash(export GITLAB_TOKEN=\"$gl\")",
+      "Bash(export DOPPLER_TOKEN=\"$dp\")"
+    ]
+  }
+}
+JSON
+
+    run "$REPO_ROOT/script/security-credential-scan.sh" --path "$TEST_TEMP_DIR" --json
+    assert_success
+    echo "$output" | jq -e '.critical_count >= 2' >/dev/null
+    assert_output --partial "GitLab PAT"
+    assert_output --partial "Doppler Token"
+}
+
 @test "security-credential-scan.sh ignores Nix flake.lock rev hashes" {
     mkdir -p "$TEST_TEMP_DIR/nix"
     cat > "$TEST_TEMP_DIR/nix/flake.lock" <<'JSON'


### PR DESCRIPTION
## Why

secret 検出の対象トークン種別に漏れがあった。scanner と inline-secret フックの
両層に、これまで未対応だった GitLab / Doppler / Google のトークンを追加して、
「混入を入口で止め（hook）、混入済みを scan で検出」する多層防御を揃える。

> ⚠️ このPRは #795 の上に積んだスタックです（base = `fix/dangerous-cmd-bound-remaining-patterns`）。#795 が main にマージされると base は自動的に main へ retarget されます。

## What

### scanner (`security-credential-scan.sh`)
- `PATTERNS` に **GitLab PAT** (`glpat-…`) と **Doppler Token** (`dp.<type>.…`) を追加し、両者を CRITICAL に分類

### hook (`block_inline_secrets.py`)
- `SECRET_PATTERNS` に **Google API key** (`AIza…`) / **GitLab PAT** / **Doppler Token** を追加（scanner に既存だった Google を inline 側にも揃える）

### tests
- `security-scripts.bats`: `.claude` 設定内の GitLab/Doppler を検出するケース追加（トークンは push protection 回避のため実行時生成）
- `hooks-command-safety.test.js`: 3 種別のパターン存在アサーション追加
- behavioral: 実トークン3種を block、変数参照 / `doppler run` / 通常 commit は allow

## Risk

低。検出種別の追加のみ。既存の検出・FP 抑制ロジックは無変更。bats 18 / jest green。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
