### PR TITLE
fix: セキュリティ修正 トークンをコマンドライン引数からenv変数経由に変更

### DIFF
--- a/script/install-claude-plugins.sh
+++ b/script/install-claude-plugins.sh
@@ -57,18 +57,21 @@ if [[ ! -f "$PLUGINS_FILE" ]]; then
 fi
 
 # トークン文字列を credentials JSON に書き出すヘルパー関数
-# セキュリティ: コマンドライン引数にトークンを渡すと ps aux に露出するため
-#              環境変数経由で渡し、プロセスリストへの漏洩を防ぐ
+# セキュリティ: コマンドライン引数・環境変数経由はプロセスリスト/environ から
+#              露出するため、stdin 経由でトークンを渡す。
+#              また os.open で O_CREAT 時に 0600 を指定し umask に依存しない。
 _write_credentials_json() {
     local token="$1"
     local dest="$2"
-    _CREDS_TOKEN="$token" _CREDS_PATH="$dest" python3 -c "
-import json, os
-token = os.environ['_CREDS_TOKEN']
-creds = {'claudeAiOauth': {'accessToken': token, 'expiresAt': 9999999999999}}
-with open(os.environ['_CREDS_PATH'], 'w') as f:
+    printf '%s' "$token" | python3 -c '
+import json, os, sys
+token = sys.stdin.read()
+dest = sys.argv[1]
+creds = {"claudeAiOauth": {"accessToken": token, "expiresAt": 9999999999999}}
+fd = os.open(dest, os.O_WRONLY | os.O_CREAT | os.O_TRUNC, 0o600)
+with os.fdopen(fd, "w") as f:
     json.dump(creds, f, indent=2)
-"
+' "$dest"
 }
 
 # --- 認証情報の設定 ---

--- a/script/install-claude-plugins.sh
+++ b/script/install-claude-plugins.sh
@@ -56,6 +56,21 @@ if [[ ! -f "$PLUGINS_FILE" ]]; then
     exit 0
 fi
 
+# トークン文字列を credentials JSON に書き出すヘルパー関数
+# セキュリティ: コマンドライン引数にトークンを渡すと ps aux に露出するため
+#              環境変数経由で渡し、プロセスリストへの漏洩を防ぐ
+_write_credentials_json() {
+    local token="$1"
+    local dest="$2"
+    _CREDS_TOKEN="$token" _CREDS_PATH="$dest" python3 -c "
+import json, os
+token = os.environ['_CREDS_TOKEN']
+creds = {'claudeAiOauth': {'accessToken': token, 'expiresAt': 9999999999999}}
+with open(os.environ['_CREDS_PATH'], 'w') as f:
+    json.dump(creds, f, indent=2)
+"
+}
+
 # --- 認証情報の設定 ---
 mkdir -p "$CLAUDE_DIR"
 
@@ -68,33 +83,15 @@ if [[ -n "$CREDENTIALS_SECRET" ]]; then
     else
         # プレーンテキスト（トークン文字列）: JSON に変換
         log_info "トークン文字列を credentials JSON に変換中..."
-        python3 -c "
-import json, sys
-token = sys.argv[1]
-creds = {'claudeAiOauth': {'accessToken': token, 'expiresAt': 9999999999999}}
-with open(sys.argv[2], 'w') as f:
-    json.dump(creds, f, indent=2)
-" "$SECRET_CONTENT" "${CLAUDE_DIR}/.credentials.json"
+        _write_credentials_json "$SECRET_CONTENT" "${CLAUDE_DIR}/.credentials.json"
     fi
     chmod 600 "${CLAUDE_DIR}/.credentials.json"
 elif [[ -n "${CLAUDE_CODE_OAUTH_TOKEN:-}" ]]; then
     log_info "CLAUDE_CODE_OAUTH_TOKEN から認証情報を作成中..."
-    python3 -c "
-import json, sys
-token = sys.argv[1]
-creds = {'claudeAiOauth': {'accessToken': token, 'expiresAt': 9999999999999}}
-with open(sys.argv[2], 'w') as f:
-    json.dump(creds, f, indent=2)
-" "$CLAUDE_CODE_OAUTH_TOKEN" "${CLAUDE_DIR}/.credentials.json"
+    _write_credentials_json "$CLAUDE_CODE_OAUTH_TOKEN" "${CLAUDE_DIR}/.credentials.json"
 elif [[ -n "${ANTHROPIC_API_KEY:-}" ]]; then
     log_info "ANTHROPIC_API_KEY から認証情報を作成中..."
-    python3 -c "
-import json, sys
-token = sys.argv[1]
-creds = {'claudeAiOauth': {'accessToken': token, 'expiresAt': 9999999999999}}
-with open(sys.argv[2], 'w') as f:
-    json.dump(creds, f, indent=2)
-" "$ANTHROPIC_API_KEY" "${CLAUDE_DIR}/.credentials.json"
+    _write_credentials_json "$ANTHROPIC_API_KEY" "${CLAUDE_DIR}/.credentials.json"
 else
     log_warn "認証情報が見つかりません"
     echo "  - BuildKit secret: $CREDENTIALS_SECRET"


### PR DESCRIPTION
Closes #804

## Summary
- `script/install-claude-plugins.sh` でトークンを `python3 -c` のコマンドライン引数として渡していたため、ps aux でトークン値が露出する可能性を修正
- `_write_credentials_json` ヘルパー関数を追加し、環境変数経由でトークンをPythonに渡すように変更

Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Streamlined the plugin installation script's credential setup by consolidating repeated credential-to-JSON conversion steps into a single centralized helper. This reduces duplication and simplifies maintenance while preserving existing behavior, directory/permission handling, and installation outcomes; there is no user-facing change.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->