### PR TITLE
chore: AGENTS.md から存在しない next/ ディレクトリの行を削除

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -60,7 +60,6 @@ Development infrastructure template repository providing DevContainer images, CI
 | `dot/`               | Dotfiles (DevContainer .zshrc, peco)                        |
 | `eslint/`            | ESLint configuration and plugins                            |
 | `git/`               | Git hooks and configuration                                 |
-| `next/`              | next                                                        |
 | `nix/`               | nix-darwin + home-manager (macOS environment)               |
 | `npm/`               | npm global configuration and library management             |
 | `script/`            | Utility shell scripts                                       |


### PR DESCRIPTION
Fixes #810

## 概要

- `AGENTS.md` のプロジェクト構造テーブルから、存在しない `next/` ディレクトリの行を削除
- `script/update-agents-md.sh` で自動再生成して修正
- `CLAUDE.md` は `AGENTS.md` へのシンボリックリンクのため同時修正済

Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated project structure documentation to reflect current directory organization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->