### PR TITLE
fix: detect required workflow trigger gaps

### DIFF
--- a/.claude/commands/repo-maintenance.md
+++ b/.claude/commands/repo-maintenance.md
@@ -1175,7 +1175,7 @@ job-level `if:` で `schedule` / `workflow_dispatch` に限定する。
 **確認ロジック:**
 
 ```bash
-for workflow in .github/workflows/*.yml; do
+for workflow in .github/workflows/*.yml .github/workflows/*.yaml; do
   [ ! -f "$workflow" ] && continue
   BASENAME=$(basename "$workflow")
   CONTENT=$(cat "$workflow")
@@ -1191,14 +1191,21 @@ for workflow in .github/workflows/*.yml; do
 
   [ "$REQUIRED_HINT" = true ] || continue
 
+  ON_BLOCK=$(awk '
+    /^on:/ { in_on=1; print; next }
+    in_on && /^[A-Za-z0-9_-]+:/ { exit }
+    in_on { print }
+  ' "$workflow")
+
   HAS_PUSH_OR_PR=false
-  echo "$CONTENT" | grep -qE '^  (push|pull_request):' && HAS_PUSH_OR_PR=true
+  printf '%s\n' "$ON_BLOCK" | grep -qE '^(on: *(\[.*(push|pull_request).*\]|(push|pull_request))|  (push|pull_request):)' && HAS_PUSH_OR_PR=true
 
   if [ "$HAS_PUSH_OR_PR" = false ]; then
     ISSUES+=("$BASENAME: Required Workflow 候補ですが push / pull_request トリガーがありません。必須チェック化すると jobs=[] で失敗します")
   fi
 
-  if [ "$BASENAME" = "security-summary.yml" ]; then
+  case "$BASENAME" in
+    security-summary.yml|security-summary.yaml)
     GENERATE_SUMMARY_JOB=$(awk '
       /^  generate-summary:/ { in_job=1; print; next }
       in_job && /^  [A-Za-z0-9_-]+:/ { exit }
@@ -1210,7 +1217,8 @@ for workflow in .github/workflows/*.yml; do
     elif ! printf '%s\n' "$GENERATE_SUMMARY_JOB" | grep -qE "^    if: *github.event_name == 'schedule' \\|\\| github.event_name == 'workflow_dispatch'$"; then
       ISSUES+=("$BASENAME: Slack 通知付き generate-summary は job-level if で schedule / workflow_dispatch に限定してください")
     fi
-  fi
+    ;;
+  esac
 done
 ```
 

--- a/.claude/commands/repo-maintenance.md
+++ b/.claude/commands/repo-maintenance.md
@@ -1193,12 +1193,13 @@ for workflow in .github/workflows/*.yml .github/workflows/*.yaml; do
 
   ON_BLOCK=$(awk '
     /^on:/ { in_on=1; print; next }
+    /^"on":/ { in_on=1; print; next }
     in_on && /^[A-Za-z0-9_-]+:/ { exit }
     in_on { print }
   ' "$workflow")
 
   HAS_PUSH_OR_PR=false
-  printf '%s\n' "$ON_BLOCK" | grep -qE '^(on: *(\[.*(push|pull_request).*\]|(push|pull_request))|  (push|pull_request):)' && HAS_PUSH_OR_PR=true
+  printf '%s\n' "$ON_BLOCK" | grep -qE '^(on: *(\[.*(push|pull_request).*\]|(push|pull_request))|"on": *(\[.*(push|pull_request).*\]|(push|pull_request))|  (push|pull_request):|  - (push|pull_request)$)' && HAS_PUSH_OR_PR=true
 
   if [ "$HAS_PUSH_OR_PR" = false ]; then
     ISSUES+=("$BASENAME: Required Workflow 候補ですが push / pull_request トリガーがありません。必須チェック化すると jobs=[] で失敗します")

--- a/.claude/commands/repo-maintenance.md
+++ b/.claude/commands/repo-maintenance.md
@@ -1199,7 +1199,22 @@ for workflow in .github/workflows/*.yml .github/workflows/*.yaml; do
   ' "$workflow")
 
   HAS_PUSH_OR_PR=false
-  printf '%s\n' "$ON_BLOCK" | grep -qE '^(on: *(\[.*(push|pull_request).*\]|(push|pull_request))|"on": *(\[.*(push|pull_request).*\]|(push|pull_request))|  (push|pull_request):|  - (push|pull_request)$)' && HAS_PUSH_OR_PR=true
+  if printf '%s\n' "$ON_BLOCK" | awk '
+    /^  (push|pull_request):/ { found=1 }
+    /^  - (push|pull_request)$/ { found=1 }
+    /^on:/ || /^"on":/ {
+      line=$0
+      sub(/^"?on"?: */, "", line)
+      gsub(/[][",]/, "", line)
+      count=split(line, events, /[, ]+/)
+      for (i=1; i<=count; i++) {
+        if (events[i] == "push" || events[i] == "pull_request") found=1
+      }
+    }
+    END { exit found ? 0 : 1 }
+  '; then
+    HAS_PUSH_OR_PR=true
+  fi
 
   if [ "$HAS_PUSH_OR_PR" = false ]; then
     ISSUES+=("$BASENAME: Required Workflow 候補ですが push / pull_request トリガーがありません。必須チェック化すると jobs=[] で失敗します")

--- a/.claude/commands/repo-maintenance.md
+++ b/.claude/commands/repo-maintenance.md
@@ -1199,7 +1199,15 @@ for workflow in .github/workflows/*.yml; do
   fi
 
   if [ "$BASENAME" = "security-summary.yml" ]; then
-    if ! echo "$CONTENT" | grep -q "github.event_name == 'schedule' || github.event_name == 'workflow_dispatch'"; then
+    GENERATE_SUMMARY_JOB=$(awk '
+      /^  generate-summary:/ { in_job=1; print; next }
+      in_job && /^  [A-Za-z0-9_-]+:/ { exit }
+      in_job { print }
+    ' "$workflow")
+
+    if [ -z "$GENERATE_SUMMARY_JOB" ]; then
+      ISSUES+=("$BASENAME: Slack 通知付き generate-summary job が見つかりません")
+    elif ! printf '%s\n' "$GENERATE_SUMMARY_JOB" | grep -qE "^    if: *github.event_name == 'schedule' \\|\\| github.event_name == 'workflow_dispatch'$"; then
       ISSUES+=("$BASENAME: Slack 通知付き generate-summary は job-level if で schedule / workflow_dispatch に限定してください")
     fi
   fi

--- a/.claude/commands/repo-maintenance.md
+++ b/.claude/commands/repo-maintenance.md
@@ -1179,7 +1179,7 @@ for workflow in .github/workflows/*.yml .github/workflows/*.yaml; do
   [ ! -f "$workflow" ] && continue
   BASENAME=$(basename "$workflow")
   CONTENT=$(cat "$workflow")
-  NAME=$(grep -m1 '^name:' "$workflow" | sed 's/^name: *//' | tr -d "'\"")
+  NAME=$(grep -m1 '^name:' "$workflow" | sed 's/^name: *//' | tr -d "'\"" || true)
 
   REQUIRED_HINT=false
   case "$BASENAME:$NAME" in

--- a/.claude/commands/repo-maintenance.md
+++ b/.claude/commands/repo-maintenance.md
@@ -1161,6 +1161,77 @@ grep -rh 'runs-on:' .github/workflows/*.yml \
 
 不一致ごとに修正を提案し、承認後に自動修正を実行。
 
+### 3.5.2.1 Required Workflow Trigger Compatibility Check
+
+Organization / repository rulesets で Required Workflow に登録される可能性があるワークフローが、
+`schedule` / `workflow_dispatch` のみで定義されていないか確認する。
+
+**背景:**
+Required Workflow は push / PR の必須チェックとして評価される。ワークフロー側に `push` または
+`pull_request` トリガーがない場合、GitHub は required check を作るが実行対象 job がなく、
+`jobs=[]` の失敗として扱われることがある。定期通知などの重い処理は workflow trigger ではなく
+job-level `if:` で `schedule` / `workflow_dispatch` に限定する。
+
+**確認ロジック:**
+
+```bash
+for workflow in .github/workflows/*.yml; do
+  [ ! -f "$workflow" ] && continue
+  BASENAME=$(basename "$workflow")
+  CONTENT=$(cat "$workflow")
+  NAME=$(grep -m1 '^name:' "$workflow" | sed 's/^name: *//' | tr -d "'\"")
+
+  REQUIRED_HINT=false
+  case "$BASENAME:$NAME" in
+    *security-summary*|*Security\ Summary*|*Required\ Workflow*) REQUIRED_HINT=true ;;
+  esac
+  if echo "$CONTENT" | grep -qE "name: Dependency Audit|npm audit --audit-level"; then
+    REQUIRED_HINT=true
+  fi
+
+  [ "$REQUIRED_HINT" = true ] || continue
+
+  HAS_PUSH_OR_PR=false
+  echo "$CONTENT" | grep -qE '^  (push|pull_request):' && HAS_PUSH_OR_PR=true
+
+  if [ "$HAS_PUSH_OR_PR" = false ]; then
+    ISSUES+=("$BASENAME: Required Workflow 候補ですが push / pull_request トリガーがありません。必須チェック化すると jobs=[] で失敗します")
+  fi
+
+  if [ "$BASENAME" = "security-summary.yml" ]; then
+    if ! echo "$CONTENT" | grep -q "github.event_name == 'schedule' || github.event_name == 'workflow_dispatch'"; then
+      ISSUES+=("$BASENAME: Slack 通知付き generate-summary は job-level if で schedule / workflow_dispatch に限定してください")
+    fi
+  fi
+done
+```
+
+**推奨修正（`security-summary.yml` の場合）:**
+
+```yaml
+on:
+  push:
+    branches: [main, develop]
+  pull_request:
+    branches: [main, develop]
+  schedule:
+    - cron: '0 0 * * 1'
+  workflow_dispatch:
+
+jobs:
+  generate-summary:
+    if: github.event_name == 'schedule' || github.event_name == 'workflow_dispatch'
+```
+
+`dependency-audit` のような軽量な必須チェック用 job は push / PR でも実行し、Slack 通知や週次サマリーだけを
+job-level `if:` で止める。
+
+**結果:**
+
+- ✅ Required Workflow 候補のトリガー互換性: 問題なし
+- ⚠️ push / pull_request がない Required Workflow 候補あり
+- ⚠️ `security-summary.yml` の通知 job に event guard がない
+
 ### 3.5.3 CI Template Deployment Check (他リポジトリ展開)
 
 config リポジトリのテンプレートが他リポジトリに展開可能か確認：

--- a/.claude/commands/repo-maintenance.md
+++ b/.claude/commands/repo-maintenance.md
@@ -1194,6 +1194,7 @@ for workflow in .github/workflows/*.yml .github/workflows/*.yaml; do
   ON_BLOCK=$(awk '
     /^on:/ { in_on=1; print; next }
     /^"on":/ { in_on=1; print; next }
+    /^\047on\047:/ { in_on=1; print; next }
     in_on && /^[A-Za-z0-9_-]+:/ { exit }
     in_on { print }
   ' "$workflow")
@@ -1202,9 +1203,11 @@ for workflow in .github/workflows/*.yml .github/workflows/*.yaml; do
   if printf '%s\n' "$ON_BLOCK" | awk '
     /^  (push|pull_request):/ { found=1 }
     /^  - (push|pull_request)$/ { found=1 }
-    /^on:/ || /^"on":/ {
+    /^on:/ || /^"on":/ || /^\047on\047:/ {
       line=$0
-      sub(/^"?on"?: */, "", line)
+      sub(/^on: */, "", line)
+      sub(/^"on": */, "", line)
+      sub(/^\047on\047: */, "", line)
       gsub(/[][",]/, "", line)
       count=split(line, events, /[, ]+/)
       for (i=1; i<=count; i++) {

--- a/test/claude-workflow-contract.test.js
+++ b/test/claude-workflow-contract.test.js
@@ -1,10 +1,51 @@
 const fs = require('fs');
 const path = require('path');
+const { execFileSync } = require('child_process');
 
 const repoPath = path.resolve(__dirname, '..');
 
 function readWorkflow(relativePath) {
   return fs.readFileSync(path.join(repoPath, relativePath), 'utf8');
+}
+
+function extractRequiredWorkflowScript(command) {
+  const sectionStart = command.indexOf('### 3.5.2.1 Required Workflow Trigger Compatibility Check');
+  expect(sectionStart).toBeGreaterThanOrEqual(0);
+
+  const bashStart = command.indexOf('```bash', sectionStart);
+  expect(bashStart).toBeGreaterThanOrEqual(0);
+
+  const codeStart = bashStart + '```bash\n'.length;
+  const codeEnd = command.indexOf('```', codeStart);
+  expect(codeEnd).toBeGreaterThan(codeStart);
+
+  return command.slice(codeStart, codeEnd);
+}
+
+function runRequiredWorkflowScript(workflows) {
+  const contextDir = path.join(repoPath, '.context');
+  fs.mkdirSync(contextDir, { recursive: true });
+  const tempRoot = fs.mkdtempSync(path.join(contextDir, 'required-workflow-test-'));
+
+  try {
+    const workflowsDir = path.join(tempRoot, '.github', 'workflows');
+    fs.mkdirSync(workflowsDir, { recursive: true });
+    for (const [filename, content] of Object.entries(workflows)) {
+      fs.writeFileSync(path.join(workflowsDir, filename), content);
+    }
+
+    const command = readWorkflow('.claude/commands/repo-maintenance.md');
+    const script = `
+set -euo pipefail
+ISSUES=()
+${extractRequiredWorkflowScript(command)}
+printf '%s\\n' "\${ISSUES[@]}"
+`;
+
+    return execFileSync('bash', ['-c', script], { cwd: tempRoot, encoding: 'utf8' });
+  } finally {
+    fs.rmSync(tempRoot, { recursive: true, force: true });
+  }
 }
 
 describe('Claude workflow contracts', () => {
@@ -90,11 +131,84 @@ describe('Claude workflow contracts', () => {
 
     expect(command).toContain('Required Workflow Trigger Compatibility Check');
     expect(command).toContain('security-summary.yml');
+    expect(command).toContain('security-summary.yaml');
+    expect(command).toContain('.github/workflows/*.yaml');
     expect(command).toContain('jobs=[]');
     expect(command).toContain("github.event_name == 'schedule' || github.event_name == 'workflow_dispatch'");
+    expect(command).toContain('ON_BLOCK=$(awk');
+    expect(command).toContain('/^on:/');
     expect(command).toContain('GENERATE_SUMMARY_JOB=$(awk');
     expect(command).toContain('/^  generate-summary:/');
     expect(command).toContain('/^  [A-Za-z0-9_-]+:/');
     expect(command).toContain("^    if: *github.event_name == 'schedule'");
+  });
+
+  test('repo-maintenance flags .yaml required workflows without push or pull_request', () => {
+    const output = runRequiredWorkflowScript({
+      'security-summary.yaml': `
+name: Security Summary
+on:
+  schedule:
+    - cron: '0 0 * * 1'
+  workflow_dispatch:
+
+jobs:
+  generate-summary:
+    runs-on: ubuntu-latest
+    steps:
+      - run: npm audit --audit-level=high
+`,
+    });
+
+    expect(output).toContain('security-summary.yaml: Required Workflow 候補ですが push / pull_request');
+    expect(output).toContain('security-summary.yaml: Slack 通知付き generate-summary は job-level if');
+  });
+
+  test('repo-maintenance only treats push and pull_request under on as triggers', () => {
+    const output = runRequiredWorkflowScript({
+      'required.yml': `
+name: Required Workflow
+on:
+  schedule:
+    - cron: '0 0 * * 1'
+
+jobs:
+  push:
+    runs-on: ubuntu-latest
+    steps:
+      - run: echo ok
+`,
+    });
+
+    expect(output).toContain('required.yml: Required Workflow 候補ですが push / pull_request');
+  });
+
+  test('repo-maintenance accepts guarded security summary required workflow', () => {
+    const output = runRequiredWorkflowScript({
+      'security-summary.yml': `
+name: Security Summary
+on:
+  push:
+    branches: [main, develop]
+  pull_request:
+    branches: [main, develop]
+  schedule:
+    - cron: '0 0 * * 1'
+  workflow_dispatch:
+
+jobs:
+  dependency-audit:
+    runs-on: ubuntu-latest
+    steps:
+      - run: npm audit --audit-level=high
+  generate-summary:
+    if: github.event_name == 'schedule' || github.event_name == 'workflow_dispatch'
+    runs-on: ubuntu-latest
+    steps:
+      - run: echo summary
+`,
+    });
+
+    expect(output.trim()).toBe('');
   });
 });

--- a/test/claude-workflow-contract.test.js
+++ b/test/claude-workflow-contract.test.js
@@ -138,6 +138,7 @@ describe('Claude workflow contracts', () => {
     expect(command).toContain('ON_BLOCK=$(awk');
     expect(command).toContain('/^on:/');
     expect(command).toContain('/^"on":/');
+    expect(command).toContain('events[i] == "pull_request"');
     expect(command).toContain('GENERATE_SUMMARY_JOB=$(awk');
     expect(command).toContain('/^  generate-summary:/');
     expect(command).toContain('/^  [A-Za-z0-9_-]+:/');
@@ -230,5 +231,22 @@ jobs:
     });
 
     expect(output.trim()).toBe('');
+  });
+
+  test('repo-maintenance does not treat pull_request_target as pull_request', () => {
+    const output = runRequiredWorkflowScript({
+      'required.yml': `
+name: Required Workflow
+on: [pull_request_target, pull_request_review]
+
+jobs:
+  check:
+    runs-on: ubuntu-latest
+    steps:
+      - run: echo ok
+`,
+    });
+
+    expect(output).toContain('required.yml: Required Workflow 候補ですが push / pull_request');
   });
 });

--- a/test/claude-workflow-contract.test.js
+++ b/test/claude-workflow-contract.test.js
@@ -137,6 +137,7 @@ describe('Claude workflow contracts', () => {
     expect(command).toContain("github.event_name == 'schedule' || github.event_name == 'workflow_dispatch'");
     expect(command).toContain('ON_BLOCK=$(awk');
     expect(command).toContain('/^on:/');
+    expect(command).toContain('/^"on":/');
     expect(command).toContain('GENERATE_SUMMARY_JOB=$(awk');
     expect(command).toContain('/^  generate-summary:/');
     expect(command).toContain('/^  [A-Za-z0-9_-]+:/');
@@ -206,6 +207,25 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - run: echo summary
+`,
+    });
+
+    expect(output.trim()).toBe('');
+  });
+
+  test('repo-maintenance accepts block sequence event syntax', () => {
+    const output = runRequiredWorkflowScript({
+      'required.yml': `
+name: Required Workflow
+on:
+  - push
+  - pull_request
+
+jobs:
+  check:
+    runs-on: ubuntu-latest
+    steps:
+      - run: echo ok
 `,
     });
 

--- a/test/claude-workflow-contract.test.js
+++ b/test/claude-workflow-contract.test.js
@@ -185,6 +185,35 @@ jobs:
     expect(output).toContain('security-summary.yml: Slack 通知付き generate-summary は job-level if');
   });
 
+  test('repo-maintenance continues after unnamed unrelated workflow files', () => {
+    const output = runRequiredWorkflowScript({
+      'aaa.yml': `
+on:
+  workflow_dispatch:
+
+jobs:
+  check:
+    runs-on: ubuntu-latest
+    steps:
+      - run: echo unrelated
+`,
+      'security-summary.yml': `
+name: Security Summary
+on:
+  workflow_dispatch:
+
+jobs:
+  generate-summary:
+    runs-on: ubuntu-latest
+    steps:
+      - run: echo summary
+`,
+    });
+
+    expect(output).toContain('security-summary.yml: Required Workflow 候補ですが push / pull_request');
+    expect(output).toContain('security-summary.yml: Slack 通知付き generate-summary は job-level if');
+  });
+
   test('repo-maintenance only treats push and pull_request under on as triggers', () => {
     const output = runRequiredWorkflowScript({
       'required.yml': `

--- a/test/claude-workflow-contract.test.js
+++ b/test/claude-workflow-contract.test.js
@@ -138,6 +138,7 @@ describe('Claude workflow contracts', () => {
     expect(command).toContain('ON_BLOCK=$(awk');
     expect(command).toContain('/^on:/');
     expect(command).toContain('/^"on":/');
+    expect(command).toContain('/^\\047on\\047:/');
     expect(command).toContain('events[i] == "pull_request"');
     expect(command).toContain('GENERATE_SUMMARY_JOB=$(awk');
     expect(command).toContain('/^  generate-summary:/');
@@ -248,5 +249,22 @@ jobs:
     });
 
     expect(output).toContain('required.yml: Required Workflow 候補ですが push / pull_request');
+  });
+
+  test('repo-maintenance accepts single-quoted on key', () => {
+    const output = runRequiredWorkflowScript({
+      'required.yml': `
+name: Required Workflow
+'on': [push]
+
+jobs:
+  check:
+    runs-on: ubuntu-latest
+    steps:
+      - run: echo ok
+`,
+    });
+
+    expect(output.trim()).toBe('');
   });
 });

--- a/test/claude-workflow-contract.test.js
+++ b/test/claude-workflow-contract.test.js
@@ -84,4 +84,13 @@ describe('Claude workflow contracts', () => {
     expect(command).toContain('"script/wait-ci-checks.sh"');
     expect(command).toContain('git checkout "$CLAUDE_BRANCH" 2>/dev/null || git checkout -b "$CLAUDE_BRANCH"');
   });
+
+  test('repo-maintenance detects required workflow trigger incompatibility', () => {
+    const command = readWorkflow('.claude/commands/repo-maintenance.md');
+
+    expect(command).toContain('Required Workflow Trigger Compatibility Check');
+    expect(command).toContain('security-summary.yml');
+    expect(command).toContain('jobs=[]');
+    expect(command).toContain("github.event_name == 'schedule' || github.event_name == 'workflow_dispatch'");
+  });
 });

--- a/test/claude-workflow-contract.test.js
+++ b/test/claude-workflow-contract.test.js
@@ -92,5 +92,9 @@ describe('Claude workflow contracts', () => {
     expect(command).toContain('security-summary.yml');
     expect(command).toContain('jobs=[]');
     expect(command).toContain("github.event_name == 'schedule' || github.event_name == 'workflow_dispatch'");
+    expect(command).toContain('GENERATE_SUMMARY_JOB=$(awk');
+    expect(command).toContain('/^  generate-summary:/');
+    expect(command).toContain('/^  [A-Za-z0-9_-]+:/');
+    expect(command).toContain("^    if: *github.event_name == 'schedule'");
   });
 });

--- a/test/claude-workflow-contract.test.js
+++ b/test/claude-workflow-contract.test.js
@@ -167,6 +167,24 @@ jobs:
     expect(output).toContain('security-summary.yaml: Slack 通知付き generate-summary は job-level if');
   });
 
+  test('repo-maintenance detects security summary by filename without name key', () => {
+    const output = runRequiredWorkflowScript({
+      'security-summary.yml': `
+on:
+  workflow_dispatch:
+
+jobs:
+  generate-summary:
+    runs-on: ubuntu-latest
+    steps:
+      - run: echo summary
+`,
+    });
+
+    expect(output).toContain('security-summary.yml: Required Workflow 候補ですが push / pull_request');
+    expect(output).toContain('security-summary.yml: Slack 通知付き generate-summary は job-level if');
+  });
+
   test('repo-maintenance only treats push and pull_request under on as triggers', () => {
     const output = runRequiredWorkflowScript({
       'required.yml': `


### PR DESCRIPTION
## Summary

- Add a repo-maintenance check for Required Workflow candidates that only have `schedule` / `workflow_dispatch` triggers.
- Document the `security-summary.yml` fix pattern: add `push` / `pull_request` triggers and gate notification-heavy jobs with job-level `if`.
- Add a contract test so the repo-maintenance guidance keeps this regression check.

## Validation

- `npm test -- --runTestsByPath test/claude-workflow-contract.test.js`
- `npm run lint`
- `npm run format:check -- .claude/commands/repo-maintenance.md test/claude-workflow-contract.test.js`
- pre-commit: `format:check`, `lint`, full `npm test` passed

## Notes

- Latest `origin/main` was merged before creating this PR.
- Untracked local `.context/worktrees/` and `.gemini/skills/` were left untouched.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added workflow trigger compatibility reference with implementation examples and output patterns to support CI workflow consistency verification.

* **Tests**
  * Introduced contract tests that validate workflow documentation completeness against specified requirements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->