### PR TITLE
chore(permissions): ワークスペース認証情報(.env.*.local)の読み取りを許可

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -173,7 +173,11 @@
       "Bash(supabase db branch delete)",
       "Bash(supabase db branch delete:*)",
       "Read(./.env)",
-      "Read(./.env.*)",
+      "Read(./.env.local)",
+      "Read(./.env.development*)",
+      "Read(./.env.production*)",
+      "Read(./.env.staging*)",
+      "Read(./.env.test*)",
       "Read(**/*.pem)",
       "Read(**/*.key)"
     ],


### PR DESCRIPTION
## Why
n8n の REST 検証など、ワークスペース別の認証情報ファイル（`.env.elu.local` / `.env.oykot.local`）を Claude Code から読めるようにする必要があった。従来は `Read(./.env.*)` の包括 deny によりこれらもブロックされていた（deny は allow より優先のため、deny の絞り込みが必須）。

## What
`permissions.deny` を変更:
- 削除: `Read(./.env.*)`
- 追加: `Read(./.env.local)`, `Read(./.env.development*)`, `Read(./.env.production*)`, `Read(./.env.staging*)`, `Read(./.env.test*)`
- 維持: `Read(./.env)`, `Read(**/*.pem)`, `Read(**/*.key)`

## Risk / 留意
- これはグローバル設定（全プロジェクト共通、`~/.claude/settings.json` が本ファイルへの symlink）。
- 汎用シークレット env（`.env.local` / `.env.development*` / `.env.production*` / `.env.staging*` / `.env.test*`）は引き続き保護。
- `.env.<workspace>.local` 形式（およびその他 `.env.*`）が読み取り可能になる点が緩和。保護を完全に戻す場合は本 PR を revert（`Read(./.env.*)` 1行に戻す）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated environment file access permissions with more explicit configuration rules.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->