### PR TITLE
ci: Claude Code テンプレートの timeout を 30 分に延長

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -48,7 +48,7 @@ jobs:
         (github.event_name == 'issues' && (contains(github.event.issue.body || '', '@claude') || contains(github.event.issue.title || '', '@claude')))
       )
     runs-on: ubuntu-latest
-    timeout-minutes: 20
+    timeout-minutes: 30
     permissions:
       contents: write
       pull-requests: write

--- a/templates/workflows/claude.yml
+++ b/templates/workflows/claude.yml
@@ -10,7 +10,7 @@
 #   リポジトリ Secret に CLAUDE_CODE_OAUTH_TOKEN を設定
 #
 # カスタマイズ:
-#   - timeout-minutes: タイムアウト（デフォルト: 20分）
+#   - timeout-minutes: タイムアウト（デフォルト: 30分）
 #   - allowed_tools: Claude に許可するツール
 #   - claude_args: 追加の system prompt 等
 #
@@ -63,7 +63,7 @@ jobs:
         (github.event_name == 'issues' && (contains(github.event.issue.body || '', '@claude') || contains(github.event.issue.title || '', '@claude')))
       )
     runs-on: ubuntu-latest
-    timeout-minutes: 20
+    timeout-minutes: 30
     permissions:
       contents: write
       pull-requests: write


### PR DESCRIPTION
## Why
配布先リポジトリ(Elu-co-jp/job_description #754)で `@claude` 実行が 20 分上限に達し、調査完了後の実装〜PR作成途中でキャンセルされた。提案テンプレート側のデフォルトも引き上げ、配布先で同じ詰まりが起きにくくする。

## What
- `templates/workflows/claude.yml`: `timeout-minutes: 20` → `30`、カスタマイズ説明コメントの `デフォルト: 20分` → `30分`
- `.github/workflows/claude.yml`(config 自身): `timeout-minutes: 20` → `30`

## How
ランナウェイ防止の上限は維持しつつ、コスト増を抑えた穏当な 30 分に設定。`test/template-workflows.test.js` は `timeout-minutes:` の存在のみ検証するため値変更による破綻なし。

## Risk
低。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Extended automated workflow execution timeout from 20 to 30 minutes, allowing background processing tasks additional time to complete before timing out.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->