### PR TITLE
fix: harden repo maintenance workflows

### DIFF
--- a/.github/labels.yml
+++ b/.github/labels.yml
@@ -86,6 +86,10 @@
   color: 'b60205'
   description: '破壊的変更あり'
 
+- name: 'dependabot-minor'
+  color: '0366d6'
+  description: 'Minor dependency update'
+
 - name: 'auto-discovered'
   color: 'bfdadc'
   description: '自動検出された機能・改善'

--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -83,11 +83,32 @@ jobs:
         with:
           fetch-depth: 1
 
+      - name: Check Claude authentication
+        id: claude-auth
+        env:
+          CLAUDE_CODE_OAUTH_TOKEN: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+          ANTHROPIC_FEDERATION_RULE_ID: ${{ secrets.ANTHROPIC_FEDERATION_RULE_ID }}
+          ANTHROPIC_ORGANIZATION_ID: ${{ secrets.ANTHROPIC_ORGANIZATION_ID }}
+        run: |
+          if [ -n "$CLAUDE_CODE_OAUTH_TOKEN" ] ||
+             [ -n "$ANTHROPIC_API_KEY" ] ||
+             { [ -n "$ANTHROPIC_FEDERATION_RULE_ID" ] && [ -n "$ANTHROPIC_ORGANIZATION_ID" ]; }; then
+            echo "available=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "available=false" >> "$GITHUB_OUTPUT"
+            echo "::notice::Skipping Claude Code Review because no Claude authentication secret is configured."
+          fi
+
       - name: Run Claude Code Review
         id: claude-review
+        if: steps.claude-auth.outputs.available == 'true'
         uses: anthropics/claude-code-action@d5726de019ec4498aa667642bc3a80fca83aa102 # v1
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
+          anthropic_federation_rule_id: ${{ secrets.ANTHROPIC_FEDERATION_RULE_ID }}
+          anthropic_organization_id: ${{ secrets.ANTHROPIC_ORGANIZATION_ID }}
 
           # 進捗トラッキングを有効化
           track_progress: true

--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -29,6 +29,7 @@ jobs:
     timeout-minutes: 10
     permissions:
       contents: write
+      issues: write
       pull-requests: write
     steps:
       # 更新種別を取得（patch / minor / major）
@@ -64,9 +65,21 @@ jobs:
           PR_URL: ${{ github.event.pull_request.html_url }}
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
-      # minor: 自動承認（マージは手動で判断）
+      # minor: ラベル付与（手動マージ）+ 自動承認試行
+      # GITHUB_TOKEN は既定で PR 承認不可のため continue-on-error: true で失敗しても CI をブロックしない
+      # リポジトリ設定「Allow GitHub Actions to create and approve pull requests」を有効にすると承認も動作する
+      - name: Label minor updates
+        if: github.actor == 'dependabot[bot]' && steps.metadata.outputs.update-type == 'version-update:semver-minor'
+        run: |
+          gh label create "dependabot-minor" --color "0366d6" --description "Minor dependency update" --force
+          gh pr edit "$PR_URL" --add-label "dependabot-minor"
+        env:
+          PR_URL: ${{ github.event.pull_request.html_url }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
       - name: Auto-approve minor updates
         if: github.actor == 'dependabot[bot]' && steps.metadata.outputs.update-type == 'version-update:semver-minor'
+        continue-on-error: true
         run: |
           gh pr review "$PR_URL" --approve --body "Auto-approved: minor version update"
         env:
@@ -77,6 +90,8 @@ jobs:
       - name: Label major updates for review
         if: github.actor == 'dependabot[bot]' && steps.metadata.outputs.update-type == 'version-update:semver-major'
         run: |
+          gh label create "needs-review" --color "fbca04" --description "レビュー待ち" --force
+          gh label create "breaking-change" --color "b60205" --description "破壊的変更あり" --force
           gh pr edit "$PR_URL" --add-label "needs-review,breaking-change"
         env:
           PR_URL: ${{ github.event.pull_request.html_url }}

--- a/.github/workflows/label-sync.yml
+++ b/.github/workflows/label-sync.yml
@@ -17,6 +17,7 @@ on:
   workflow_dispatch:
 
 permissions:
+  contents: read
   issues: write
   pull-requests: write
 

--- a/templates/github/labels.yml
+++ b/templates/github/labels.yml
@@ -86,6 +86,10 @@
   color: 'b60205'
   description: '破壊的変更あり'
 
+- name: 'dependabot-minor'
+  color: '0366d6'
+  description: 'Minor dependency update'
+
 - name: 'auto-discovered'
   color: 'bfdadc'
   description: '自動検出された機能・改善'

--- a/templates/workflows/dependabot-auto-merge.yml
+++ b/templates/workflows/dependabot-auto-merge.yml
@@ -29,6 +29,7 @@ jobs:
     timeout-minutes: 10
     permissions:
       contents: write
+      issues: write
       pull-requests: write
     steps:
       # 更新種別を取得（patch / minor / major）
@@ -70,6 +71,7 @@ jobs:
       - name: Label minor updates
         if: steps.metadata.outputs.update-type == 'version-update:semver-minor'
         run: |
+          gh label create "dependabot-minor" --color "0366d6" --description "Minor dependency update" --force
           gh pr edit "$PR_URL" --add-label "dependabot-minor"
         env:
           PR_URL: ${{ github.event.pull_request.html_url }}
@@ -88,6 +90,8 @@ jobs:
       - name: Label major updates for review
         if: steps.metadata.outputs.update-type == 'version-update:semver-major'
         run: |
+          gh label create "needs-review" --color "fbca04" --description "レビュー待ち" --force
+          gh label create "breaking-change" --color "b60205" --description "破壊的変更あり" --force
           gh pr edit "$PR_URL" --add-label "needs-review,breaking-change"
         env:
           PR_URL: ${{ github.event.pull_request.html_url }}

--- a/templates/workflows/label-sync.yml
+++ b/templates/workflows/label-sync.yml
@@ -17,6 +17,7 @@ on:
   workflow_dispatch:
 
 permissions:
+  contents: read
   issues: write
   pull-requests: write
 

--- a/test/claude-workflow-contract.test.js
+++ b/test/claude-workflow-contract.test.js
@@ -117,6 +117,21 @@ describe('Claude workflow contracts', () => {
     expect(workflow).toContain("needs.check-ci-status.outputs.review_gate_changed != 'true'");
   });
 
+  test('Claude Code Review skips Anthropic action when authentication is not configured', () => {
+    const workflow = readWorkflow('.github/workflows/claude-code-review.yml');
+
+    expect(workflow).toContain('name: Check Claude authentication');
+    expect(workflow).toContain('CLAUDE_CODE_OAUTH_TOKEN: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}');
+    expect(workflow).toContain('ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}');
+    expect(workflow).toContain('ANTHROPIC_FEDERATION_RULE_ID: ${{ secrets.ANTHROPIC_FEDERATION_RULE_ID }}');
+    expect(workflow).toContain('ANTHROPIC_ORGANIZATION_ID: ${{ secrets.ANTHROPIC_ORGANIZATION_ID }}');
+    expect(workflow).toContain('available=false');
+    expect(workflow).toContain("if: steps.claude-auth.outputs.available == 'true'");
+    expect(workflow).toContain('anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}');
+    expect(workflow).toContain('anthropic_federation_rule_id: ${{ secrets.ANTHROPIC_FEDERATION_RULE_ID }}');
+    expect(workflow).toContain('anthropic_organization_id: ${{ secrets.ANTHROPIC_ORGANIZATION_ID }}');
+  });
+
   test('repo-maintenance reports downstream sync when managed files change', () => {
     const command = readWorkflow('.claude/commands/repo-maintenance.md');
 

--- a/test/template-workflows.test.js
+++ b/test/template-workflows.test.js
@@ -159,6 +159,7 @@ describe('Template workflow contracts', () => {
     test('should have required permissions for merging PRs', () => {
       expect(workflow).toContain('permissions:');
       expect(workflow).toContain('contents: write');
+      expect(workflow).toContain('issues: write');
       expect(workflow).toContain('pull-requests: write');
     });
 
@@ -190,6 +191,7 @@ describe('Template workflow contracts', () => {
       expect(workflow).toContain('contents: read');
       // Job-level: elevated only after actor is verified
       expect(workflow).toContain('contents: write');
+      expect(workflow).toContain('issues: write');
       expect(workflow).toContain('pull-requests: write');
     });
 
@@ -203,6 +205,13 @@ describe('Template workflow contracts', () => {
     test.each(workflowPaths)('%s: should not auto-merge major updates', (wfPath) => {
       const workflow = readWorkflow(wfPath);
       expect(workflow).not.toMatch(/semver-major[\s\S]{0,300}gh pr merge/);
+    });
+
+    test.each(workflowPaths)('%s: should create labels before assigning them', (wfPath) => {
+      const workflow = readWorkflow(wfPath);
+      expect(workflow).toContain('gh label create "dependabot-minor"');
+      expect(workflow).toContain('gh label create "needs-review"');
+      expect(workflow).toContain('gh label create "breaking-change"');
     });
   });
 
@@ -276,8 +285,9 @@ describe('Template workflow contracts', () => {
       expect(workflow).toContain('EndBug/label-sync');
     });
 
-    test.each(workflowPaths)('%s: should have issues and pull-requests write permissions', (wfPath) => {
+    test.each(workflowPaths)('%s: should have checkout read and label write permissions', (wfPath) => {
       const workflow = readWorkflow(wfPath);
+      expect(workflow).toContain('contents: read');
       expect(workflow).toContain('issues: write');
       expect(workflow).toContain('pull-requests: write');
     });


### PR DESCRIPTION
## Summary
- add missing label-sync checkout permission and self-create Dependabot labels before applying them
- skip Claude Code Review when no OAuth, API key, or OIDC federation auth is configured
- add workflow contract tests so these cases stay covered

## Verification
- actionlint .github/workflows/dependabot-auto-merge.yml .github/workflows/label-sync.yml .github/workflows/claude-code-review.yml templates/workflows/dependabot-auto-merge.yml templates/workflows/label-sync.yml
- npm run format:check
- npm run lint
- npm test -- --runTestsByPath test/template-workflows.test.js test/claude-workflow-contract.test.js

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `dependabot-minor` label to better categorize minor dependency updates separately.
  * Enhanced Claude code review workflow with authentication validation before running reviews.

* **Chores**
  * Improved workflow permission configurations for better security and clarity.
  * Updated dependency update workflow to handle minor and major updates with improved label management.

* **Tests**
  * Added comprehensive test coverage for Claude authentication workflow checks.
  * Strengthened workflow permission and label-handling contract tests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->