### PR TITLE
fix: align Gemini MCP settings schema

### DIFF
--- a/.gemini/settings.json
+++ b/.gemini/settings.json
@@ -18,21 +18,18 @@
     },
     "supabase": {
       "url": "https://mcp.supabase.com/mcp",
-      "transport": "sse",
       "headers": {
         "Authorization": "Bearer ${SUPABASE_MCP_TOKEN}"
       }
     },
     "vercel": {
       "url": "https://mcp.vercel.com",
-      "transport": "sse",
       "headers": {
         "Authorization": "Bearer ${VERCEL_MCP_TOKEN}"
       }
     },
     "github": {
       "url": "https://api.githubcopilot.com/mcp/",
-      "transport": "sse",
       "headers": {
         "Authorization": "Bearer ${GITHUB_COPILOT_MCP_TOKEN}"
       }

--- a/test/gemini-settings.test.js
+++ b/test/gemini-settings.test.js
@@ -1,0 +1,58 @@
+const fs = require('fs');
+const path = require('path');
+
+const repoPath = path.resolve(__dirname, '..');
+
+function readJson(relativePath) {
+  return JSON.parse(fs.readFileSync(path.join(repoPath, relativePath), 'utf8'));
+}
+
+function hasOwn(object, key) {
+  return Object.prototype.hasOwnProperty.call(object, key);
+}
+
+describe('Gemini CLI settings', () => {
+  const settings = readJson('.gemini/settings.json');
+
+  test('should define MCP servers', () => {
+    expect(settings).toHaveProperty('mcpServers');
+    expect(Object.keys(settings.mcpServers).length).toBeGreaterThan(0);
+  });
+
+  test('remote MCP servers should use Gemini CLI supported keys', () => {
+    for (const server of Object.values(settings.mcpServers)) {
+      if (!hasOwn(server, 'url')) {
+        continue;
+      }
+
+      expect(server).not.toHaveProperty('transport');
+      expect(typeof server.url).toBe('string');
+      expect(server.url).toMatch(/^https:\/\//);
+
+      if (hasOwn(server, 'headers')) {
+        expect(server.headers).not.toBeNull();
+        expect(Array.isArray(server.headers)).toBe(false);
+        expect(typeof server.headers).toBe('object');
+      }
+
+      for (const key of Object.keys(server)) {
+        expect(['url', 'headers', 'timeout', 'trust'].includes(key)).toBe(true);
+      }
+    }
+  });
+
+  test('local MCP servers should define command and args', () => {
+    for (const server of Object.values(settings.mcpServers)) {
+      if (hasOwn(server, 'url')) {
+        continue;
+      }
+
+      expect(typeof server.command).toBe('string');
+      expect(Array.isArray(server.args)).toBe(true);
+
+      for (const key of Object.keys(server)) {
+        expect(['command', 'args', 'env', 'cwd', 'timeout', 'trust'].includes(key)).toBe(true);
+      }
+    }
+  });
+});


### PR DESCRIPTION
## Summary

- remove unsupported `transport` keys from remote Gemini MCP server settings
- add a Gemini settings contract test for local and remote MCP server shapes
- verify the tracked settings no longer emit Gemini CLI invalid configuration warnings

## Tests

- `gemini --help`
- `npm run format:check`
- `npm run lint`
- `npm test`
- `npm run shellcheck`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated MCP server configuration for Supabase, Vercel, and GitHub by removing explicit transport settings and consolidating authentication headers
* **Tests**
  * Added validation test suite for MCP server configuration to verify proper field structure, URL formats, and allowed configuration parameters

<!-- end of auto-generated comment: release notes by coderabbit.ai -->