### PR TITLE
fix: wire workflow template validation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -204,9 +204,9 @@ jobs:
           reporter: github-pr-review
           fail_on_error: true
           actionlint_flags: >-
-            .github/workflows/*.yml
-            .github/workflows/templates/*.yml
-            templates/workflows/*.yml
+            .github/workflows/*.y*ml
+            .github/workflows/templates/*.y*ml
+            templates/workflows/*.y*ml
 
   pr-size-check:
     name: PR Size Check

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -82,6 +82,9 @@ jobs:
             workflows:
               - '.github/workflows/**'
               - '.github/actionlint.yaml'
+              - '.github/labels.yml'
+              - 'templates/workflows/**'
+              - 'templates/github/labels.yml'
             dependencies:
               - 'package.json'
               - 'package-lock.json'
@@ -91,7 +94,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 10
     needs: changes
-    if: needs.changes.outputs.code == 'true' || needs.changes.outputs.scripts == 'true' || needs.changes.outputs.dependencies == 'true'
+    if: needs.changes.outputs.code == 'true' || needs.changes.outputs.scripts == 'true' || needs.changes.outputs.dependencies == 'true' || needs.changes.outputs.workflows == 'true'
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
 
@@ -114,7 +117,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 15
     needs: changes
-    if: needs.changes.outputs.code == 'true' || needs.changes.outputs.dependencies == 'true'
+    if: needs.changes.outputs.code == 'true' || needs.changes.outputs.dependencies == 'true' || needs.changes.outputs.workflows == 'true'
     permissions:
       contents: read
       actions: write
@@ -161,7 +164,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 15
     needs: changes
-    if: needs.changes.outputs.scripts == 'true' || needs.changes.outputs.dependencies == 'true'
+    if: needs.changes.outputs.scripts == 'true' || needs.changes.outputs.dependencies == 'true' || needs.changes.outputs.workflows == 'true'
     permissions:
       contents: read
       actions: write
@@ -200,6 +203,10 @@ jobs:
         with:
           reporter: github-pr-review
           fail_on_error: true
+          actionlint_flags: >-
+            .github/workflows/*.yml
+            .github/workflows/templates/*.yml
+            templates/workflows/*.yml
 
   pr-size-check:
     name: PR Size Check

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -39,8 +39,7 @@ jobs:
         github.event.issue.author_association
       ) &&
       (
-        (github.event_name == 'issue_comment' && contains(github.event.comment.body || '', '@claude') &&
-          !(github.event.issue.pull_request && github.event.issue.pull_request.url && github.event.issue.draft == true)) ||
+        (github.event_name == 'issue_comment' && contains(github.event.comment.body || '', '@claude')) ||
         (github.event_name == 'pull_request_review_comment' && contains(github.event.comment.body || '', '@claude') &&
           github.event.pull_request.draft == false) ||
         (github.event_name == 'pull_request_review' && contains(github.event.review.body || '', '@claude') &&
@@ -57,13 +56,32 @@ jobs:
       actions: read # Required for Claude to read CI results on PRs
       checks: read
     steps:
+      - name: Check PR draft state
+        id: pr_draft
+        if: github.event_name == 'issue_comment' && github.event.issue.pull_request
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9
+        with:
+          script: |
+            const { data: pull } = await github.rest.pulls.get({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              pull_number: context.issue.number,
+            });
+            core.setOutput('is_draft', pull.draft ? 'true' : 'false');
+
+      - name: Skip draft PR
+        if: steps.pr_draft.outputs.is_draft == 'true'
+        run: echo "Skipping Claude Code for draft PR."
+
       - name: Checkout repository
+        if: steps.pr_draft.outputs.is_draft != 'true'
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
         with:
           fetch-depth: 1
 
       - name: Run Claude Code
         id: claude
+        if: steps.pr_draft.outputs.is_draft != 'true'
         uses: anthropics/claude-code-action@d5726de019ec4498aa667642bc3a80fca83aa102 # v1
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}

--- a/templates/workflows/claude.yml
+++ b/templates/workflows/claude.yml
@@ -54,8 +54,7 @@ jobs:
         github.event.issue.author_association
       ) &&
       (
-        (github.event_name == 'issue_comment' && contains(github.event.comment.body || '', '@claude') &&
-          !(github.event.issue.pull_request && github.event.issue.pull_request.url && github.event.issue.draft == true)) ||
+        (github.event_name == 'issue_comment' && contains(github.event.comment.body || '', '@claude')) ||
         (github.event_name == 'pull_request_review_comment' && contains(github.event.comment.body || '', '@claude') &&
           github.event.pull_request.draft == false) ||
         (github.event_name == 'pull_request_review' && contains(github.event.review.body || '', '@claude') &&
@@ -72,13 +71,32 @@ jobs:
       actions: read # Required for Claude to read CI results on PRs
       checks: read
     steps:
+      - name: Check PR draft state
+        id: pr_draft
+        if: github.event_name == 'issue_comment' && github.event.issue.pull_request
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9
+        with:
+          script: |
+            const { data: pull } = await github.rest.pulls.get({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              pull_number: context.issue.number,
+            });
+            core.setOutput('is_draft', pull.draft ? 'true' : 'false');
+
+      - name: Skip draft PR
+        if: steps.pr_draft.outputs.is_draft == 'true'
+        run: echo "Skipping Claude Code for draft PR."
+
       - name: Checkout repository
+        if: steps.pr_draft.outputs.is_draft != 'true'
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
         with:
           fetch-depth: 1
 
       - name: Run Claude Code
         id: claude
+        if: steps.pr_draft.outputs.is_draft != 'true'
         uses: anthropics/claude-code-action@d5726de019ec4498aa667642bc3a80fca83aa102 # v1
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}

--- a/templates/workflows/terraform-drift.yml
+++ b/templates/workflows/terraform-drift.yml
@@ -30,11 +30,12 @@ on:
   workflow_dispatch:
     inputs:
       environment:
-        description: 'スキャン対象の環境（空の場合は全環境）'
+        description: 'スキャン対象の環境'
         required: false
         type: choice
+        default: all
         options:
-          - ''
+          - all
           - dev
           - staging
           - production
@@ -86,13 +87,6 @@ jobs:
           - environment: production
             tf_directory: terraform/environments/production
 
-    # --- 環境フィルタ ---
-    # 手動実行で特定環境が指定された場合、その環境のみ実行する
-    if: >-
-      github.event_name == 'schedule' ||
-      github.event.inputs.environment == '' ||
-      github.event.inputs.environment == matrix.environment
-
     # TODO: GitHub Environments を使用する場合はコメントを外す
     # environment: ${{ matrix.environment }}
 
@@ -103,15 +97,35 @@ jobs:
 
     steps:
       # -----------------------------------------------------------------
+      # 対象環境の判定
+      # -----------------------------------------------------------------
+      - name: Select environment
+        id: selected
+        run: |
+          TARGET="${{ github.event.inputs.environment }}"
+          if [ -z "$TARGET" ]; then
+            TARGET="all"
+          fi
+
+          if [ "$TARGET" = "all" ] || [ "$TARGET" = "${{ matrix.environment }}" ]; then
+            echo "run=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "run=false" >> "$GITHUB_OUTPUT"
+            echo "Skipping ${{ matrix.environment }} because target is ${TARGET}."
+          fi
+
+      # -----------------------------------------------------------------
       # リポジトリのチェックアウト
       # -----------------------------------------------------------------
       - name: Checkout repository
+        if: steps.selected.outputs.run == 'true'
         uses: actions/checkout@v6
 
       # -----------------------------------------------------------------
       # Terraform セットアップ
       # -----------------------------------------------------------------
       - name: Setup Terraform
+        if: steps.selected.outputs.run == 'true'
         uses: hashicorp/setup-terraform@v4
         with:
           # TODO: プロジェクトで使用する Terraform バージョンを指定する
@@ -151,6 +165,7 @@ jobs:
       # -----------------------------------------------------------------
       - name: Terraform Init
         id: init
+        if: steps.selected.outputs.run == 'true'
         working-directory: ${{ matrix.tf_directory }}
         run: terraform init -input=false -no-color
 
@@ -163,6 +178,7 @@ jobs:
       #   2 = 差分あり（ドリフト検出）
       - name: Terraform Plan (Drift Detection)
         id: plan
+        if: steps.selected.outputs.run == 'true'
         working-directory: ${{ matrix.tf_directory }}
         run: |
           set +e
@@ -364,7 +380,7 @@ jobs:
       # Terraform plan エラー時の Slack 通知
       # -----------------------------------------------------------------
       - name: Notify Slack on error
-        if: failure()
+        if: steps.selected.outputs.run == 'true' && failure()
         env:
           SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
         run: |

--- a/test/claude-workflow-contract.test.js
+++ b/test/claude-workflow-contract.test.js
@@ -72,6 +72,18 @@ describe('Claude workflow contracts', () => {
     expect(workflow).not.toContain('"allowedTools"');
   });
 
+  test.each(issueWorkflows)('%s skips draft PR issue comments through the Pulls API', (workflowPath) => {
+    const workflow = readWorkflow(workflowPath);
+
+    expect(workflow).not.toContain('github.event.issue.draft');
+    expect(workflow).toContain('name: Check PR draft state');
+    expect(workflow).toContain('github.rest.pulls.get');
+    expect(workflow).toContain('pull_number: context.issue.number');
+    expect(workflow).toContain("core.setOutput('is_draft', pull.draft ? 'true' : 'false')");
+    expect(workflow).toContain("if: steps.pr_draft.outputs.is_draft != 'true'");
+    expect(workflow).toContain('name: Skip draft PR');
+  });
+
   test.each(maintenanceWorkflows)('%s creates maintenance PRs in a post-Claude Actions step', (workflowPath) => {
     const workflow = readWorkflow(workflowPath);
 

--- a/test/integration/workflows.bats
+++ b/test/integration/workflows.bats
@@ -36,7 +36,12 @@ load ../test_helper/test_helper
   grep -Fq "'**.yml'" "$workflow"
   grep -Fq "'**.yaml'" "$workflow"
   grep -Fq "'.github/actionlint.yaml'" "$workflow"
+  grep -Fq "'templates/workflows/**'" "$workflow"
+  grep -Fq "'templates/github/labels.yml'" "$workflow"
   grep -Fq "workflows:" "$workflow"
+  grep -Fq "needs.changes.outputs.workflows == 'true'" "$workflow"
+  grep -Fq "actionlint_flags:" "$workflow"
+  grep -Fq "templates/workflows/*.yml" "$workflow"
 }
 
 @test "CI workflow uses secure practices" {

--- a/test/integration/workflows.bats
+++ b/test/integration/workflows.bats
@@ -41,7 +41,7 @@ load ../test_helper/test_helper
   grep -Fq "workflows:" "$workflow"
   grep -Fq "needs.changes.outputs.workflows == 'true'" "$workflow"
   grep -Fq "actionlint_flags:" "$workflow"
-  grep -Fq "templates/workflows/*.yml" "$workflow"
+  grep -Fq "templates/workflows/*.y*ml" "$workflow"
 }
 
 @test "CI workflow uses secure practices" {


### PR DESCRIPTION
## Summary

- Fix Claude Code issue_comment handling so draft PR comments are skipped by fetching the PR draft state via the Pulls API.
- Make CI path filtering connect workflow/template/label YAML changes to lint, unit tests, integration tests, and workflow lint.
- Extend actionlint coverage to workflow templates and fix the existing terraform drift template issues that blocked full template linting.
- Add regression coverage for draft PR issue comments and template/label workflow validation triggers.

## Verification

- actionlint
- actionlint .github/workflows/*.yml .github/workflows/templates/*.yml templates/workflows/*.yml
- npm run format:check
- npm run lint
- npm test
- npm run shellcheck
- npx bats test/integration/workflows.bats
- npx bats test/integration/
- bash script/update-agents-md.sh --check
- git diff --check
- npm audit --audit-level=high

## Notes

PR #838 was merged before these follow-up fixes could be included. This PR contains only the additional fixes found during review.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved draft pull request handling in AI-assisted code review workflows by adding explicit draft state detection.

* **Chores**
  * Enhanced CI workflow to detect additional configuration file changes and trigger appropriate validation jobs.
  * Refined environment selection logic for infrastructure drift detection with manual input options.

* **Tests**
  * Added validation tests for workflow draft PR handling and CI configuration change detection.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->