### PR TITLE
feat: add refactoring baseline audit

### DIFF
--- a/.context/refactoring-baseline.md
+++ b/.context/refactoring-baseline.md
@@ -1,0 +1,82 @@
+# Refactoring Baseline
+
+Issue: #812
+Captured at: 2026-06-17
+Baseline revision: `00f0fe92fb4da4dab1302d428d6209d08064e245`
+
+## CI
+
+Latest `main` CI run at capture time:
+
+- Run: <https://github.com/keito4/config/actions/runs/27680039201>
+- Title: `Merge pull request #839 from keito4/fix/workflow-template-validation-...`
+- Status: `completed`
+- Conclusion: `success`
+- Started: `2026-06-17T09:42:10Z`
+- Updated: `2026-06-17T09:43:25Z`
+- Duration: 75 seconds
+
+Recent `main` CI runs checked: 5 / 5 successful.
+
+## Repository Size
+
+Measured with tracked files only:
+
+```bash
+git ls-files | wc -l
+git ls-files -z | xargs -0 wc -l | tail -1
+```
+
+- Tracked files: 379
+- Total LOC: 69,933
+
+## Coverage
+
+Measured with:
+
+```bash
+npm run test:coverage
+```
+
+Jest coverage summary:
+
+| Metric     | Value  |
+| ---------- | ------ |
+| Statements | 95.23% |
+| Branches   | 100%   |
+| Functions  | 100%   |
+| Lines      | 94.73% |
+
+Test result:
+
+- Test suites: 17 passed / 17 total
+- Tests: 549 passed / 549 total
+
+## Reference Inventory
+
+Reference inventory script added in this phase:
+
+```bash
+script/audit-references.sh
+script/audit-references.sh --format tsv
+```
+
+The script scans tracked files under `script/` and `templates/`, includes `test/`
+and documentation sources, and classifies references into:
+
+- `code/ci`
+- `test`
+- `docs`
+
+## Phase Issues
+
+The phase issue set exists:
+
+- #812: Phase 0 safety net and baseline
+- #813: Phase 1 dead asset cleanup
+- #814: Phase 2 documentation SSoT
+- #815: Phase 3 template/entity sync
+- #816: Phase 4 CI/CD workflow consolidation
+- #817: Phase 5 scripts/hooks/commands DRY
+- #818: Phase 6 test quality recovery
+- #819: Phase 7 environment configuration cleanup

--- a/script/audit-references.sh
+++ b/script/audit-references.sh
@@ -13,7 +13,8 @@ Audits tracked files under script/ and templates/ and reports references from:
 - docs
 
 The scanner matches both the repository-relative path and basename so it can
-find references such as "script/foo.sh" and "foo.sh".
+find references such as "script/foo.sh" and "foo.sh". It uses rg when available
+and falls back to grep in minimal CI environments.
 USAGE
 }
 
@@ -93,6 +94,19 @@ emit_markdown_list() {
   fi
 }
 
+find_reference_sources() {
+  local target="$1"
+  local basename_target="$2"
+  shift 2
+
+  if command -v rg >/dev/null 2>&1; then
+    rg -l --fixed-strings -e "$target" -e "$basename_target" -- "$@" 2>/dev/null || true
+    return
+  fi
+
+  grep -IlF -e "$target" -e "$basename_target" -- "$@" 2>/dev/null || true
+}
+
 if [ "$FORMAT" = "markdown" ]; then
   cat <<'HEADER'
 # Reference Inventory
@@ -105,13 +119,16 @@ else
 fi
 
 ZERO_CODE_TEST=()
+SOURCES=()
+while IFS= read -r source; do
+  SOURCES+=("$source")
+done < <(tracked_files)
 
 while IFS= read -r target; do
   basename_target=$(basename "$target")
   code_refs=""
   test_refs=""
   docs_refs=""
-  mapfile -t sources < <(tracked_files)
 
   while IFS= read -r source; do
     [ "$source" != "$target" ] || continue
@@ -131,7 +148,7 @@ while IFS= read -r target; do
     if [ "$FORMAT" = "tsv" ]; then
       emit_tsv_row "$category" "$target" "$source"
     fi
-  done < <(rg -l --fixed-strings -e "$target" -e "$basename_target" -- "${sources[@]}" 2>/dev/null || true)
+  done < <(find_reference_sources "$target" "$basename_target" "${SOURCES[@]}")
 
   if [ -z "$code_refs$test_refs" ]; then
     ZERO_CODE_TEST+=("$target")

--- a/script/audit-references.sh
+++ b/script/audit-references.sh
@@ -1,0 +1,164 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+FORMAT="markdown"
+
+usage() {
+  cat <<'USAGE'
+Usage: script/audit-references.sh [--format markdown|tsv]
+
+Audits tracked files under script/ and templates/ and reports references from:
+- code/ci
+- test
+- docs
+
+The scanner matches both the repository-relative path and basename so it can
+find references such as "script/foo.sh" and "foo.sh".
+USAGE
+}
+
+while [ "$#" -gt 0 ]; do
+  case "$1" in
+    --format)
+      FORMAT="${2:-}"
+      shift 2
+      ;;
+    --help|-h)
+      usage
+      exit 0
+      ;;
+    *)
+      echo "Unknown argument: $1" >&2
+      usage >&2
+      exit 2
+      ;;
+  esac
+done
+
+case "$FORMAT" in
+  markdown|tsv) ;;
+  *)
+    echo "Unsupported format: $FORMAT" >&2
+    exit 2
+    ;;
+esac
+
+classify_source() {
+  local source="$1"
+
+  case "$source" in
+    test/*)
+      echo "test"
+      ;;
+    docs/*|README.md|AGENTS.md|CLAUDE.md|*.md)
+      echo "docs"
+      ;;
+    .github/workflows/*|.github/actions/*|.github/dependabot.*|.github/labels.yml|.github/policies/*)
+      echo "code/ci"
+      ;;
+    *)
+      echo "code/ci"
+      ;;
+  esac
+}
+
+tracked_files() {
+  git ls-files
+}
+
+target_files() {
+  git ls-files 'script/*' 'templates/*' | while IFS= read -r file; do
+    [ -f "$file" ] || continue
+    printf '%s\n' "$file"
+  done
+}
+
+emit_tsv_row() {
+  local category="$1"
+  local target="$2"
+  local source="$3"
+
+  printf '%s\t%s\t%s\n' "$category" "$target" "$source"
+}
+
+emit_markdown_list() {
+  local label="$1"
+  local refs="$2"
+
+  local count
+  count=$(printf '%s\n' "$refs" | sed '/^$/d' | wc -l | tr -d ' ')
+  printf -- '- %s (%s)\n' "$label" "$count"
+  if [ "$count" -gt 0 ]; then
+    printf '%s\n' "$refs" | sed '/^$/d' | sed 's/^/  - `/' | sed 's/$/`/'
+  fi
+}
+
+if [ "$FORMAT" = "markdown" ]; then
+  cat <<'HEADER'
+# Reference Inventory
+
+Targets: tracked files under `script/` and `templates/`.
+
+HEADER
+else
+  printf 'category\ttarget\tsource\n'
+fi
+
+ZERO_CODE_TEST=()
+
+while IFS= read -r target; do
+  basename_target=$(basename "$target")
+  code_refs=""
+  test_refs=""
+  docs_refs=""
+  mapfile -t sources < <(tracked_files)
+
+  while IFS= read -r source; do
+    [ "$source" != "$target" ] || continue
+    category=$(classify_source "$source")
+    case "$category" in
+      test)
+        test_refs="${test_refs}${source}"$'\n'
+        ;;
+      docs)
+        docs_refs="${docs_refs}${source}"$'\n'
+        ;;
+      *)
+        code_refs="${code_refs}${source}"$'\n'
+        ;;
+    esac
+
+    if [ "$FORMAT" = "tsv" ]; then
+      emit_tsv_row "$category" "$target" "$source"
+    fi
+  done < <(rg -l --fixed-strings -e "$target" -e "$basename_target" -- "${sources[@]}" 2>/dev/null || true)
+
+  if [ -z "$code_refs$test_refs" ]; then
+    ZERO_CODE_TEST+=("$target")
+  fi
+
+  if [ "$FORMAT" = "markdown" ]; then
+    printf "## \`%s\`\n\n" "$target"
+    emit_markdown_list "Code/CI references" "$code_refs"
+    emit_markdown_list "Test references" "$test_refs"
+    emit_markdown_list "Documentation references" "$docs_refs"
+    printf '\n'
+  elif [ -z "$code_refs$test_refs$docs_refs" ]; then
+    emit_tsv_row "none" "$target" "-"
+  fi
+done < <(target_files)
+
+if [ "$FORMAT" = "markdown" ]; then
+  cat <<'SUMMARY'
+## Zero Code/Test References
+
+These targets have no code/ci or test references. Documentation-only references
+are still listed above for each target.
+
+SUMMARY
+  if [ "${#ZERO_CODE_TEST[@]}" -eq 0 ]; then
+    printf -- '- None\n'
+  else
+    printf '%s\n' "${ZERO_CODE_TEST[@]}" | sed 's/^/- `/' | sed 's/$/`/'
+  fi
+fi

--- a/test/integration/audit_references.bats
+++ b/test/integration/audit_references.bats
@@ -1,0 +1,20 @@
+#!/usr/bin/env bats
+
+load ../test_helper/test_helper
+
+@test "audit-references reports references as TSV with required categories" {
+  run "$REPO_ROOT/script/audit-references.sh" --format tsv
+  assert_success
+
+  printf '%s\n' "$output" | grep -Fq $'test\tscript/check-image-version.sh\ttest/integration/core-scripts.bats'
+  printf '%s\n' "$output" | grep -Fq $'test\ttemplates/workflows/claude-health-check.yml\ttest/template-workflows.test.js'
+  printf '%s\n' "$output" | grep -Fq $'docs\tscript/check-image-version.sh\tscript/README.md'
+}
+
+@test "audit-references markdown includes zero code/test summary" {
+  run "$REPO_ROOT/script/audit-references.sh"
+  assert_success
+
+  printf '%s\n' "$output" | grep -Fq "# Reference Inventory"
+  printf '%s\n' "$output" | grep -Fq "## Zero Code/Test References"
+}

--- a/test/integration/audit_references.bats
+++ b/test/integration/audit_references.bats
@@ -2,13 +2,25 @@
 
 load ../test_helper/test_helper
 
+assert_tsv_row() {
+  local expected="$1"$'\t'"$2"$'\t'"$3"
+  local line
+
+  while IFS= read -r line; do
+    [ "$line" = "$expected" ] && return 0
+  done <<< "$output"
+
+  echo "missing TSV row: $expected" >&2
+  return 1
+}
+
 @test "audit-references reports references as TSV with required categories" {
   run "$REPO_ROOT/script/audit-references.sh" --format tsv
   assert_success
 
-  printf '%s\n' "$output" | grep -Fq $'test\tscript/check-image-version.sh\ttest/integration/core-scripts.bats'
-  printf '%s\n' "$output" | grep -Fq $'test\ttemplates/workflows/claude-health-check.yml\ttest/template-workflows.test.js'
-  printf '%s\n' "$output" | grep -Fq $'docs\tscript/check-image-version.sh\tscript/README.md'
+  assert_tsv_row test script/check-image-version.sh test/integration/core-scripts.bats
+  assert_tsv_row test templates/workflows/claude-health-check.yml test/template-workflows.test.js
+  assert_tsv_row docs script/check-image-version.sh script/README.md
 }
 
 @test "audit-references markdown includes zero code/test summary" {

--- a/test/integration/core-scripts.bats
+++ b/test/integration/core-scripts.bats
@@ -11,6 +11,11 @@ load ../test_helper/test_helper
     [ -x "$REPO_ROOT/script/branch-cleanup.sh" ]
 }
 
+@test "audit-references.sh exists and is executable" {
+    assert_file_exists "$REPO_ROOT/script/audit-references.sh"
+    [ -x "$REPO_ROOT/script/audit-references.sh" ]
+}
+
 @test "check-image-version.sh exists and is executable" {
     assert_file_exists "$REPO_ROOT/script/check-image-version.sh"
     [ -x "$REPO_ROOT/script/check-image-version.sh" ]


### PR DESCRIPTION
## Summary

Closes #812.

- Add `.context/refactoring-baseline.md` with the phase-0 baseline metrics for CI status, tracked LOC/file count, and Jest coverage.
- Add `script/audit-references.sh` to scan tracked `script/` and `templates/` files and classify references as `code/ci`, `test`, or `docs`.
- Add BATS coverage for the audit script and register it in the core script existence checks.

## Issue #812 checklist

- [x] 0-1: Record baseline metrics in `.context/refactoring-baseline.md`
- [x] 0-2: Add `script/audit-references.sh`, including test and docs reference categories
- [x] 0-3: Confirm phase issues #812-#819 exist

## Tests

- `script/audit-references.sh --format tsv`
- `npx bats test/integration/audit_references.bats test/integration/core-scripts.bats`
- `shellcheck -x script/audit-references.sh`
- `npm run format:check`
- `npm run lint`
- `npm test`
- `npm run shellcheck`
- `npm run test:integration`
- `bash script/update-agents-md.sh --check`
- `npm run test:coverage`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added a reference audit utility script for inventorying codebase references across `script/` and `templates/` directories with Markdown and TSV output formats.
  * Established a refactoring baseline snapshot documenting repository metrics, CI status, and test coverage for Issue `#812`.

* **Tests**
  * Added integration tests to validate reference audit script functionality and verify script permissions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->