### PR TITLE
docs: document on-demand agent triggers

### DIFF
--- a/.claude/agents/README.md
+++ b/.claude/agents/README.md
@@ -126,6 +126,22 @@ This directory contains 11 specialized AI agents designed to provide comprehensi
 
 ## Agent Invocation
 
+### On-Demand Trigger Registry
+
+The agents below are intentionally retained even when static search finds no
+command, hook, or workflow invocation. Claude Code activates them through their
+frontmatter `description` and through explicit manual requests, so their active
+trigger is the natural-language contract documented here.
+
+| Agent                            | Active Trigger                                                                  | Retention Decision                                               |
+| -------------------------------- | ------------------------------------------------------------------------------- | ---------------------------------------------------------------- |
+| `act-local-ci-manager.md`        | User asks to run, debug, or configure GitHub Actions locally with `act`.        | Keep as an on-demand CI debugging specialist.                    |
+| `docs-consistency-checker.md`    | PR or task changes docs/API specs, or a PR description needs Why/What/How/Risk. | Keep as an on-demand documentation and PR-description reviewer.  |
+| `playwright-test-generator.md`   | User asks to create E2E tests from browser flows or manual test cases.          | Keep as the Playwright test generation specialist.               |
+| `playwright-test-healer.md`      | User asks to fix failing Playwright tests, selectors, timing, or assertions.    | Keep as the Playwright failure diagnosis specialist.             |
+| `playwright-test-planner.md`     | User asks to plan E2E coverage, regression suites, or user-flow test matrices.  | Keep as the Playwright coverage planning specialist.             |
+| `issue-resolver-orchestrator.md` | User asks to process the issue backlog or resolve multiple GitHub issues.       | Keep and route issue categories to the issue-resolver subagents. |
+
 ### Proactive Invocation
 
 Agents are automatically invoked by Claude Code based on context and code changes:

--- a/.claude/agents/issue-resolver-orchestrator.md
+++ b/.claude/agents/issue-resolver-orchestrator.md
@@ -1,3 +1,9 @@
+---
+name: issue-resolver-orchestrator
+description: Use this agent when you need to triage open GitHub issues, classify them by category, route them to the issue-resolver-* agents, and create follow-up pull requests for safe issue resolution. Use when the user asks to process the issue backlog, resolve multiple issues in order, or run the issue resolver workflow.
+color: indigo
+---
+
 # Issue Resolver: Orchestrator Agent
 
 ## 目的

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -109,7 +109,7 @@ Development infrastructure template repository providing DevContainer images, CI
 | `issue-resolver-code-quality`  | コード品質に関するIssueを自動的に解決し、PRを作成する。TODO/FIXMEコメントの処理、複雑なコードのリファクタリング、コードスタイルの改善を行う。 |
 | `issue-resolver-dependencies`  | 依存関係に関するIssueを解決し、古いパッケージの更新、脆弱性の修正、不要な依存関係の削除を行う。                                               |
 | `issue-resolver-documentation` | ドキュメントに関するIssueを解決し、README、API文書、コードコメント、アーキテクチャドキュメントを充実させる。                                  |
-| `issue-resolver-orchestrator`  | GitHubのIssueを分析し、適切なIssue Resolverエージェントを選択・実行して、自動的にIssueを解決しPRを作成する統合オーケストレーター。            |
+| `issue-resolver-orchestrator`  | Use this agent when you need to triage open GitHub issues, classify them by category, route them ...                                          |
 | `issue-resolver-security`      | セキュリティに関するIssueを解決し、ハードコードされた秘密情報の除去、脆弱性の修正、セキュリティベストプラクティスの実装を行う。               |
 | `issue-resolver-test-coverage` | テストカバレッジに関するIssueを解決し、単体テスト・統合テスト・E2Eテストを追加して70%以上のカバレッジを達成する。                             |
 | `playwright-test-generator`    | Use this agent to automatically generate Playwright E2E tests by observing browser interactions.                                              |

--- a/test/claude-agents.test.js
+++ b/test/claude-agents.test.js
@@ -1,0 +1,57 @@
+const fs = require('fs');
+const path = require('path');
+
+const repoRoot = path.join(__dirname, '..');
+const agentsDir = path.join(repoRoot, '.claude', 'agents');
+
+const onDemandAgents = [
+  'act-local-ci-manager',
+  'docs-consistency-checker',
+  'playwright-test-generator',
+  'playwright-test-healer',
+  'playwright-test-planner',
+  'issue-resolver-orchestrator',
+];
+
+function readAgent(name) {
+  return fs.readFileSync(path.join(agentsDir, `${name}.md`), 'utf8');
+}
+
+function parseFrontmatter(content) {
+  expect(content.startsWith('---\n')).toBe(true);
+  const end = content.indexOf('\n---', 4);
+  expect(end).toBeGreaterThan(0);
+
+  return content
+    .slice(4, end)
+    .split('\n')
+    .filter(Boolean)
+    .reduce((frontmatter, line) => {
+      const separator = line.indexOf(':');
+      if (separator === -1) {
+        return frontmatter;
+      }
+      const key = line.slice(0, separator).trim();
+      const value = line.slice(separator + 1).trim();
+      return { ...frontmatter, [key]: value };
+    }, {});
+}
+
+describe('Claude on-demand agent trigger contracts', () => {
+  test.each(onDemandAgents)('%s has discoverable agent frontmatter', (agentName) => {
+    const frontmatter = parseFrontmatter(readAgent(agentName));
+
+    expect(frontmatter.name).toBe(agentName);
+    expect(frontmatter.description).toMatch(/Use this agent/i);
+    expect(frontmatter.description.length).toBeGreaterThan(80);
+  });
+
+  test('on-demand agents are documented in the trigger registry', () => {
+    const readme = fs.readFileSync(path.join(agentsDir, 'README.md'), 'utf8');
+
+    expect(readme).toContain('### On-Demand Trigger Registry');
+    onDemandAgents.forEach((agentName) => {
+      expect(readme).toContain(`\`${agentName}.md\``);
+    });
+  });
+});


### PR DESCRIPTION
## Summary

- documented active natural-language trigger contracts for the unused-agent candidates
- added Claude agent frontmatter to issue-resolver-orchestrator so it is discoverable as an on-demand agent
- added Jest coverage to keep on-demand agent frontmatter and README trigger registry in sync
- regenerated AGENTS.md from the repository source of truth

Closes #846
Closes #847
Closes #848
Closes #849
Closes #850
Closes #851

## Verification

- npm test -- test/claude-agents.test.js
- npm run format:check
- npm run lint
- npm test
- npm run test:integration
- npm run shellcheck
- bash script/update-agents-md.sh --check
- git diff --check