### PR TITLE
fix: keep context artifacts out of quality gates

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -4,7 +4,7 @@ import eslintConfigPrettier from 'eslint-config-prettier';
 
 export default [
   {
-    ignores: ['node_modules/', 'dist/', 'coverage/', '*.min.js', 'templates/'],
+    ignores: ['node_modules/', 'dist/', 'coverage/', '.context/', '*.min.js', 'templates/'],
   },
   js.configs.recommended,
   eslintConfigPrettier,

--- a/jest.config.js
+++ b/jest.config.js
@@ -1,6 +1,8 @@
 module.exports = {
   testEnvironment: 'node',
   testMatch: ['**/test/**/*.test.js', '**/test/**/*.spec.js'],
+  testPathIgnorePatterns: ['<rootDir>/.context/worktrees/'],
+  modulePathIgnorePatterns: ['<rootDir>/.context/worktrees/'],
   collectCoverageFrom: [
     '**/*.{js,mjs,cjs}',
     '!script/**/*',

--- a/script/update-agents-md.sh
+++ b/script/update-agents-md.sh
@@ -46,6 +46,17 @@ workflow_files() {
   find .github/workflows -maxdepth 1 -type f \( -name '*.yml' -o -name '*.yaml' \) | sort
 }
 
+dir_has_tracked_files() {
+  local dir="$1"
+
+  if git rev-parse --is-inside-work-tree >/dev/null 2>&1; then
+    [[ -n "$(git ls-files -- "$dir/" | head -n 1)" ]]
+    return
+  fi
+
+  [[ -n "$(find "$dir" -type f -print -quit)" ]]
+}
+
 # shellcheck disable=SC2034 # NODE_VER / PM consumed by template via eval
 NODE_VER=$(jq -r '.engines.node // empty' package.json 2>/dev/null)
 # shellcheck disable=SC2034
@@ -72,10 +83,11 @@ collect_dirs() {
     [[ "$d" == "./" || "$d" == "../" ]] && continue
     name="${d%/}"
     [[ "$name" == .git || "$name" == .git-* ]] && continue
+    dir_has_tracked_files "$name" || continue
 
     if [[ "$name" == ".claude" ]]; then
       for sub in "${CLAUDE_SUB_ORDER[@]}"; do
-        [[ -d ".claude/$sub" ]] && emit out "\`.claude/$sub/\`" "${CLAUDE_SUB_PURPOSE[$sub]}"
+        [[ -d ".claude/$sub" ]] && dir_has_tracked_files ".claude/$sub" && emit out "\`.claude/$sub/\`" "${CLAUDE_SUB_PURPOSE[$sub]}"
       done
       continue
     fi
@@ -90,6 +102,7 @@ collect_dirs() {
   for d in */; do
     name="${d%/}"
     [[ "$REG_DIR_SKIP" == *" $name "* ]] && continue
+    dir_has_tracked_files "$name" || continue
     purpose="${REG_DIR_PURPOSE[$name]:-$name}"
     emit out "\`$name/\`" "$purpose"
   done

--- a/test/claude-workflow-contract.test.js
+++ b/test/claude-workflow-contract.test.js
@@ -34,6 +34,39 @@ function runRequiredWorkflowScript(workflows) {
   }
 }
 
+function runUpdateAgentsScriptWithUntrackedDirectory() {
+  const contextDir = path.join(repoPath, '.context');
+  fs.mkdirSync(contextDir, { recursive: true });
+  const tempRoot = fs.mkdtempSync(path.join(contextDir, 'agents-md-test-'));
+
+  try {
+    fs.writeFileSync(
+      path.join(tempRoot, 'AGENTS.md'),
+      ['# Test Agents', '', '<!-- BEGIN AUTO-GENERATED -->', '<!-- END AUTO-GENERATED -->', ''].join('\n'),
+    );
+    fs.writeFileSync(
+      path.join(tempRoot, 'package.json'),
+      JSON.stringify({ scripts: {}, engines: { node: '24.14.1' } }, null, 2),
+    );
+    fs.mkdirSync(path.join(tempRoot, 'docs'), { recursive: true });
+    fs.writeFileSync(path.join(tempRoot, 'docs', 'README.md'), '# Docs\n');
+    fs.mkdirSync(path.join(tempRoot, 'next'), { recursive: true });
+
+    execFileSync('git', ['init'], { cwd: tempRoot, stdio: 'ignore' });
+    execFileSync('git', ['add', 'AGENTS.md', 'package.json', 'docs/README.md'], {
+      cwd: tempRoot,
+      stdio: 'ignore',
+    });
+
+    const scriptPath = path.join(repoPath, 'script', 'update-agents-md.sh');
+    execFileSync('bash', [scriptPath], { cwd: tempRoot, encoding: 'utf8' });
+
+    return fs.readFileSync(path.join(tempRoot, 'AGENTS.md'), 'utf8');
+  } finally {
+    fs.rmSync(tempRoot, { recursive: true, force: true });
+  }
+}
+
 describe('Claude workflow contracts', () => {
   const issueWorkflows = ['.github/workflows/claude.yml', 'templates/workflows/claude.yml'];
   const maintenanceWorkflows = [
@@ -228,6 +261,13 @@ describe('Claude workflow contracts', () => {
     expect(script).toContain('mktemp -d "$CONTEXT_DIR/agents-md-check-XXXXX"');
     expect(script).toContain('prettier --write --ignore-path /dev/null "$target"');
     expect(script).not.toContain('mktemp -d -t agents-md-check');
+  });
+
+  test('update-agents-md ignores untracked project directories', () => {
+    const generated = runUpdateAgentsScriptWithUntrackedDirectory();
+
+    expect(generated).toContain('`docs/`');
+    expect(generated).not.toContain('`next/`');
   });
 
   test('repo-maintenance scans yml and yaml workflows in cross-workflow checks', () => {

--- a/test/eslint-config.test.js
+++ b/test/eslint-config.test.js
@@ -13,7 +13,7 @@ function makeTempDir(prefix) {
 }
 
 function runEslint(filePath, extraArgs = []) {
-  return execFileSync(eslintBin, ['--config', configPath, ...extraArgs, filePath], {
+  return execFileSync(eslintBin, ['--config', configPath, '--no-ignore', ...extraArgs, filePath], {
     cwd: repoPath,
     encoding: 'utf8',
     stdio: ['ignore', 'pipe', 'pipe'],
@@ -33,6 +33,12 @@ function expectEslintFailure(filePath, extraArgs = []) {
 }
 
 describe('ESLint configuration runtime behavior', () => {
+  test('ignores shared context artifacts during full repository lint', () => {
+    const config = fs.readFileSync(configPath, 'utf8');
+
+    expect(config).toContain("'.context/'");
+  });
+
   test('allows console usage and ignored underscore arguments', () => {
     const tempDir = makeTempDir('eslint-valid');
     try {

--- a/test/integration/audit_references.bats
+++ b/test/integration/audit_references.bats
@@ -18,7 +18,7 @@ assert_tsv_row() {
   run "$REPO_ROOT/script/audit-references.sh" --format tsv
   assert_success
 
-  assert_tsv_row docs script/audit-references.sh .context/refactoring-baseline.md
+  assert_tsv_row docs script/README.md docs/README.md
   assert_tsv_row test script/audit-references.sh test/integration/core-scripts.bats
   assert_tsv_row code/ci templates/workflows/claude.yml templates/workflows/claude-health-check.yml
   assert_tsv_row test templates/workflows/claude-health-check.yml test/template-workflows.test.js

--- a/test/jest-config.test.js
+++ b/test/jest-config.test.js
@@ -35,6 +35,11 @@ function expectJestFailure(args) {
 }
 
 describe('Jest configuration runtime behavior', () => {
+  test('ignores persistent worktrees under .context', () => {
+    expect(baseJestConfig.testPathIgnorePatterns).toContain('<rootDir>/.context/worktrees/');
+    expect(baseJestConfig.modulePathIgnorePatterns).toContain('<rootDir>/.context/worktrees/');
+  });
+
   test('runs a matching test file in the Node environment', () => {
     const tempDir = makeTempDir('jest-runtime');
     try {


### PR DESCRIPTION
## Summary
- ignore shared .context artifacts in ESLint and persistent .context/worktrees in Jest
- prevent AGENTS.md generation from listing untracked local directories
- refresh audit reference integration expectation to use an existing docs reference

## Checks
- npm run format:check
- npm run lint
- npm test
- npm run test:integration
- npm run shellcheck
- bash script/update-agents-md.sh --check
- bash script/repo-maintenance.sh --mode check-only --skip cleanup
- npm audit --audit-level=moderate

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Configuration**
  * Updated ESLint and Jest to ignore `.context/worktrees/` directories, preventing interference with linting and test workflows.

* **Script Improvements**
  * Enhanced directory filtering to skip untracked directories during automated documentation generation.

* **Tests**
  * Added comprehensive test coverage validating context directory handling, script behavior, and configuration settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->