### PR TITLE
ci: allow repo-maintenance PR creation

### DIFF
--- a/.github/workflows/scheduled-maintenance.yml
+++ b/.github/workflows/scheduled-maintenance.yml
@@ -75,12 +75,12 @@ jobs:
             - What was updated
             - What needs manual attention
 
-            If changes were committed and pushed, do NOT create a pull request yourself.
-            This workflow creates the pull request from the Claude branch after Claude finishes.
+            If `script/repo-maintenance.sh --create-pr` creates a pull request, do not create another one.
+            If the script only pushes the branch, this workflow creates the pull request from the Claude branch after Claude finishes.
 
             If no updates are needed, do NOT create an issue.
           claude_args: |
-            --allowedTools "Bash(gh api:*),Bash(gh repo view:*),Bash(gh issue create:*),Bash(gh issue list:*),Bash(gh pr view:*),Bash(gh pr list:*),Bash(gh pr checks:*),Bash(gh run view:*),Bash(npm:*),Bash(pnpm:*),Bash(npx:*),Bash(node:*),Bash(git:*),Bash(curl:*),Bash(jq:*),Bash(script/check-trivyignore-review.sh:*)"
+            --allowedTools "Bash(gh api:*),Bash(gh repo view:*),Bash(gh issue create:*),Bash(gh issue list:*),Bash(gh pr create:*),Bash(gh pr view:*),Bash(gh pr list:*),Bash(gh pr checks:*),Bash(gh run view:*),Bash(npm:*),Bash(pnpm:*),Bash(npx:*),Bash(node:*),Bash(git:*),Bash(curl:*),Bash(jq:*),Bash(script/check-trivyignore-review.sh:*)"
 
       - name: Create maintenance pull request
         if: env.CLAUDE_BRANCH != ''

--- a/docs/adr/0007-separate-claude-pr-creation-step.md
+++ b/docs/adr/0007-separate-claude-pr-creation-step.md
@@ -14,9 +14,9 @@ The action exposes a `branch_name` output. GitHub Actions can use that output af
 
 Issue-driven Claude workflows will let Claude create commits and push its branch, then a separate GitHub Actions shell step will create the pull request from `steps.<claude-step>.outputs.branch_name`.
 
-Scheduled maintenance runs in trusted agent mode and can update workflow files, so it must set and check out `CLAUDE_BRANCH` before invoking the Claude action and must provide `github_token: ${{ secrets.CLAUDE_PR_GITHUB_TOKEN }}`. The maintenance command uses that branch name for checkout and push, and the post-Claude step uses the same branch and token for pull request creation.
+Scheduled maintenance runs in trusted agent mode and can update workflow files, so it must set and check out `CLAUDE_BRANCH` before invoking the Claude action and must provide `github_token: ${{ secrets.CLAUDE_PR_GITHUB_TOKEN }}`. The maintenance command uses that branch name for checkout and push. Because `/repo-maintenance --create-pr` delegates to `script/repo-maintenance.sh`, scheduled maintenance allows `Bash(gh pr create:*)` for that script path. The post-Claude step remains as an idempotent fallback and skips when a PR already exists for the branch.
 
-Claude workflow prompts must tell Claude not to run `gh pr create`. Claude allowed tools must not include `Bash(gh pr create:*)`, and the Claude action must not receive `github_token: ${{ github.token }}` as an input. The post-Claude step is responsible for:
+Issue-driven Claude workflow prompts must tell Claude not to run `gh pr create`. Issue-driven Claude allowed tools must not include `Bash(gh pr create:*)`, and the Claude action must not receive `github_token: ${{ github.token }}` as an input. The post-Claude step is responsible for:
 
 - detecting whether a PR already exists for the branch,
 - checking that the branch was actually pushed,
@@ -27,6 +27,6 @@ Claude workflow prompts must tell Claude not to run `gh pr create`. Claude allow
 
 This reduces token exposure in Claude-controlled Bash commands and makes PR creation easier to test with workflow contract tests.
 
-Scheduled maintenance requires `CLAUDE_PR_GITHUB_TOKEN` with the minimum repository permissions needed to push maintenance branches, update workflow files, and create pull requests. Issue-driven workflows do not pass `github_token: ${{ github.token }}` into Claude-controlled execution.
+Scheduled maintenance requires `CLAUDE_PR_GITHUB_TOKEN` with the minimum repository permissions needed to push maintenance branches, update workflow files, and create pull requests. That token is exposed only to the trusted maintenance workflow, not to issue-driven Claude workflows. Issue-driven workflows do not pass `github_token: ${{ github.token }}` into Claude-controlled execution.
 
 The workflow now depends on the Claude Code Action `branch_name` output. If the action changes that output contract, the post-Claude PR creation step will skip or fail visibly instead of silently asking Claude to create a PR itself.

--- a/templates/workflows/scheduled-maintenance.yml
+++ b/templates/workflows/scheduled-maintenance.yml
@@ -75,12 +75,12 @@ jobs:
             - What was updated
             - What needs manual attention
 
-            If changes were committed and pushed, do NOT create a pull request yourself.
-            This workflow creates the pull request from the Claude branch after Claude finishes.
+            If `script/repo-maintenance.sh --create-pr` creates a pull request, do not create another one.
+            If the script only pushes the branch, this workflow creates the pull request from the Claude branch after Claude finishes.
 
             If no updates are needed, do NOT create an issue.
           claude_args: |
-            --allowedTools "Bash(gh api:*),Bash(gh repo view:*),Bash(gh issue create:*),Bash(gh issue list:*),Bash(gh pr view:*),Bash(gh pr list:*),Bash(gh pr checks:*),Bash(gh run view:*),Bash(npm:*),Bash(pnpm:*),Bash(npx:*),Bash(node:*),Bash(git:*),Bash(curl:*),Bash(jq:*),Bash(script/check-trivyignore-review.sh:*)"
+            --allowedTools "Bash(gh api:*),Bash(gh repo view:*),Bash(gh issue create:*),Bash(gh issue list:*),Bash(gh pr create:*),Bash(gh pr view:*),Bash(gh pr list:*),Bash(gh pr checks:*),Bash(gh run view:*),Bash(npm:*),Bash(pnpm:*),Bash(npx:*),Bash(node:*),Bash(git:*),Bash(curl:*),Bash(jq:*),Bash(script/check-trivyignore-review.sh:*)"
 
       - name: Create maintenance pull request
         if: env.CLAUDE_BRANCH != ''

--- a/test/claude-workflow-contract.test.js
+++ b/test/claude-workflow-contract.test.js
@@ -122,7 +122,7 @@ describe('Claude workflow contracts', () => {
     expect(workflow).toContain('gh pr create');
     expect(workflow).toContain('git ls-remote --exit-code --heads origin "$CLAUDE_BRANCH"');
     expect(workflow).not.toContain('steps.maintenance.outputs.branch_name');
-    expect(workflow).not.toMatch(/Bash\(gh pr create:\*\)/);
+    expect(workflow).toContain('Bash(gh pr create:*)');
     expect(workflow).toContain('Bash(gh api:*)');
     expect(workflow).toContain('script/check-trivyignore-review.sh');
     expect(workflow).toContain('Bash(script/check-trivyignore-review.sh:*)');


### PR DESCRIPTION
## Summary

- allow the trusted scheduled repo-maintenance workflow to run `gh pr create`
- keep issue-driven Claude workflows on the separate post-Claude PR creation step
- update the workflow contract test and ADR to document the split

## Downstream PRs

- Elu-co-jp/cloud_provisioning: https://github.com/Elu-co-jp/cloud_provisioning/pull/585
- OYKOT-jp/shift_management: https://github.com/OYKOT-jp/shift_management/pull/59
- keito4/extensions: https://github.com/keito4/extensions/pull/121

## Verification

- `actionlint .github/workflows/scheduled-maintenance.yml`
- `actionlint templates/workflows/scheduled-maintenance.yml`
- `npm test -- --runTestsByPath test/claude-workflow-contract.test.js`
- `npx prettier --check .github/workflows/scheduled-maintenance.yml templates/workflows/scheduled-maintenance.yml test/claude-workflow-contract.test.js docs/adr/0007-separate-claude-pr-creation-step.md`
- `git diff --check`
- `npm run workflow:sync:check`
- `npx eslint test/claude-workflow-contract.test.js`
- pre-commit: `npm run format:check`, `npm run lint`, `npm test`
