### PR TITLE
fix: add cmux IME simultaneous key fallbacks

### DIFF
--- a/nix/home/karabiner.nix
+++ b/nix/home/karabiner.nix
@@ -1,12 +1,21 @@
-{ ... }:
+{ config, ... }:
 
 let
+  inputSourceCommand = "${config.home.homeDirectory}/.local/bin/agent-select-input-source";
+
+  cmuxJapaneseInputSource = "com.google.inputmethod.Japanese.base";
+  cmuxEnglishInputSource = "com.google.inputmethod.Japanese.Roman";
+
   cmuxBundleCondition = {
     type = "frontmost_application_if";
     bundle_identifiers = [ "^com\\.cmuxterm\\.app$" ];
   };
 
-  cmuxImeShortcutWithModifiers = mandatoryModifiers: fromKey: toKey: {
+  selectInputSource = inputSourceID: {
+    shell_command = "${inputSourceCommand} ${inputSourceID}";
+  };
+
+  cmuxImeShortcutWithModifiers = mandatoryModifiers: fromKey: inputSourceID: {
     type = "basic";
     from = {
       key_code = fromKey;
@@ -15,7 +24,7 @@ let
         optional = [ "any" ];
       };
     };
-    to = [ { key_code = toKey; } ];
+    to = [ (selectInputSource inputSourceID) ];
     conditions = [ cmuxBundleCondition ];
   };
 
@@ -29,7 +38,7 @@ let
     "shift"
   ];
 
-  cmuxImeSimultaneousShortcut = modifierKey: fromKey: toKey: {
+  cmuxImeSimultaneousShortcut = modifierKey: fromKey: inputSourceID: {
     type = "basic";
     from = {
       simultaneous = [
@@ -46,7 +55,7 @@ let
         optional = [ "any" ];
       };
     };
-    to = [ { key_code = toKey; } ];
+    to = [ (selectInputSource inputSourceID) ];
     conditions = [ cmuxBundleCondition ];
   };
 
@@ -55,10 +64,6 @@ let
       {
         name = "Default profile";
         selected = true;
-
-        virtual_hid_keyboard = {
-          keyboard_type_v2 = "jis";
-        };
 
         simple_modifications = [
           {
@@ -79,21 +84,21 @@ let
             {
               description = "cmux: keep Google Japanese IME shortcuts out of terminal";
               manipulators = [
-                (cmuxImeShortcut "j" "japanese_kana")
-                (cmuxImeShortcut "semicolon" "japanese_eisuu")
-                (cmuxImeShortcut "quote" "japanese_eisuu")
-                (cmuxCapsLockImeShortcut "j" "japanese_kana")
-                (cmuxCapsLockImeShortcut "semicolon" "japanese_eisuu")
-                (cmuxCapsLockImeShortcut "quote" "japanese_eisuu")
-                (cmuxImeSimultaneousShortcut "left_control" "j" "japanese_kana")
-                (cmuxImeSimultaneousShortcut "right_control" "j" "japanese_kana")
-                (cmuxImeSimultaneousShortcut "caps_lock" "j" "japanese_kana")
-                (cmuxImeSimultaneousShortcut "left_control" "semicolon" "japanese_eisuu")
-                (cmuxImeSimultaneousShortcut "right_control" "semicolon" "japanese_eisuu")
-                (cmuxImeSimultaneousShortcut "caps_lock" "semicolon" "japanese_eisuu")
-                (cmuxImeSimultaneousShortcut "left_control" "quote" "japanese_eisuu")
-                (cmuxImeSimultaneousShortcut "right_control" "quote" "japanese_eisuu")
-                (cmuxImeSimultaneousShortcut "caps_lock" "quote" "japanese_eisuu")
+                (cmuxImeShortcut "j" cmuxJapaneseInputSource)
+                (cmuxImeShortcut "semicolon" cmuxEnglishInputSource)
+                (cmuxImeShortcut "quote" cmuxEnglishInputSource)
+                (cmuxCapsLockImeShortcut "j" cmuxJapaneseInputSource)
+                (cmuxCapsLockImeShortcut "semicolon" cmuxEnglishInputSource)
+                (cmuxCapsLockImeShortcut "quote" cmuxEnglishInputSource)
+                (cmuxImeSimultaneousShortcut "left_control" "j" cmuxJapaneseInputSource)
+                (cmuxImeSimultaneousShortcut "right_control" "j" cmuxJapaneseInputSource)
+                (cmuxImeSimultaneousShortcut "caps_lock" "j" cmuxJapaneseInputSource)
+                (cmuxImeSimultaneousShortcut "left_control" "semicolon" cmuxEnglishInputSource)
+                (cmuxImeSimultaneousShortcut "right_control" "semicolon" cmuxEnglishInputSource)
+                (cmuxImeSimultaneousShortcut "caps_lock" "semicolon" cmuxEnglishInputSource)
+                (cmuxImeSimultaneousShortcut "left_control" "quote" cmuxEnglishInputSource)
+                (cmuxImeSimultaneousShortcut "right_control" "quote" cmuxEnglishInputSource)
+                (cmuxImeSimultaneousShortcut "caps_lock" "quote" cmuxEnglishInputSource)
               ];
             }
           ];
@@ -106,5 +111,16 @@ in
   home.file.".config/karabiner/karabiner.json" = {
     force = true;
     text = builtins.toJSON karabinerConfig + "\n";
+  };
+
+  home.file.".config/karabiner/select-input-source.swift" = {
+    source = ../../script/macos/select-input-source.swift;
+    force = true;
+  };
+
+  home.file.".local/bin/agent-select-input-source" = {
+    source = ../../script/macos/agent-select-input-source.sh;
+    executable = true;
+    force = true;
   };
 }

--- a/nix/home/karabiner.nix
+++ b/nix/home/karabiner.nix
@@ -29,6 +29,27 @@ let
     "shift"
   ];
 
+  cmuxImeSimultaneousShortcut = modifierKey: fromKey: toKey: {
+    type = "basic";
+    from = {
+      simultaneous = [
+        { key_code = modifierKey; }
+        { key_code = fromKey; }
+      ];
+      simultaneous_options = {
+        detect_key_down_uninterruptedly = true;
+        key_down_order = "insensitive";
+        key_up_order = "insensitive";
+      };
+      modifiers = {
+        mandatory = [ "shift" ];
+        optional = [ "any" ];
+      };
+    };
+    to = [ { key_code = toKey; } ];
+    conditions = [ cmuxBundleCondition ];
+  };
+
   karabinerConfig = {
     profiles = [
       {
@@ -64,6 +85,15 @@ let
                 (cmuxCapsLockImeShortcut "j" "japanese_kana")
                 (cmuxCapsLockImeShortcut "semicolon" "japanese_eisuu")
                 (cmuxCapsLockImeShortcut "quote" "japanese_eisuu")
+                (cmuxImeSimultaneousShortcut "left_control" "j" "japanese_kana")
+                (cmuxImeSimultaneousShortcut "right_control" "j" "japanese_kana")
+                (cmuxImeSimultaneousShortcut "caps_lock" "j" "japanese_kana")
+                (cmuxImeSimultaneousShortcut "left_control" "semicolon" "japanese_eisuu")
+                (cmuxImeSimultaneousShortcut "right_control" "semicolon" "japanese_eisuu")
+                (cmuxImeSimultaneousShortcut "caps_lock" "semicolon" "japanese_eisuu")
+                (cmuxImeSimultaneousShortcut "left_control" "quote" "japanese_eisuu")
+                (cmuxImeSimultaneousShortcut "right_control" "quote" "japanese_eisuu")
+                (cmuxImeSimultaneousShortcut "caps_lock" "quote" "japanese_eisuu")
               ];
             }
           ];

--- a/script/macos/agent-select-input-source.sh
+++ b/script/macos/agent-select-input-source.sh
@@ -1,0 +1,6 @@
+#!/bin/sh
+set -eu
+
+src="${HOME}/.config/karabiner/select-input-source.swift"
+
+exec /usr/bin/xcrun swift "$src" "$@"

--- a/script/macos/select-input-source.swift
+++ b/script/macos/select-input-source.swift
@@ -1,0 +1,83 @@
+import Carbon
+import Foundation
+
+func stringProperty(_ source: TISInputSource, _ key: CFString) -> String {
+  guard let property = TISGetInputSourceProperty(source, key) else {
+    return ""
+  }
+
+  return Unmanaged<CFString>.fromOpaque(property).takeUnretainedValue() as String
+}
+
+func inputSources(includeAllInstalled: Bool) -> [TISInputSource] {
+  guard let unmanagedSources = TISCreateInputSourceList(nil, includeAllInstalled) else {
+    return []
+  }
+
+  return unmanagedSources.takeRetainedValue() as! [TISInputSource]
+}
+
+func inputSource(withID targetID: String) -> TISInputSource? {
+  let targetCFID = targetID as CFString
+  let query = [kTISPropertyInputSourceID as String: targetCFID] as CFDictionary
+  if
+    let unmanagedSources = TISCreateInputSourceList(query, false),
+    let sources = unmanagedSources.takeRetainedValue() as? [TISInputSource],
+    let source = sources.first
+  {
+    return source
+  }
+
+  return inputSources(includeAllInstalled: false).first {
+    stringProperty($0, kTISPropertyInputSourceID) == targetID
+      || stringProperty($0, kTISPropertyInputModeID) == targetID
+  }
+}
+
+func describe(_ source: TISInputSource) -> String {
+  let sourceID = stringProperty(source, kTISPropertyInputSourceID)
+  let modeID = stringProperty(source, kTISPropertyInputModeID)
+  let localizedName = stringProperty(source, kTISPropertyLocalizedName)
+
+  return "\(sourceID)\t\(modeID)\t\(localizedName)"
+}
+
+if CommandLine.arguments.count == 2, CommandLine.arguments[1] == "--list" {
+  for source in inputSources(includeAllInstalled: true) {
+    print(describe(source))
+  }
+  exit(0)
+}
+
+if CommandLine.arguments.count == 2, CommandLine.arguments[1] == "--current" {
+  guard let source = TISCopyCurrentKeyboardInputSource()?.takeRetainedValue() else {
+    fputs("current input source not found\n", stderr)
+    exit(66)
+  }
+
+  print(describe(source))
+  exit(0)
+}
+
+guard CommandLine.arguments.count == 2 else {
+  fputs("usage: select-input-source <input-source-id>\n", stderr)
+  exit(64)
+}
+
+let targetID = CommandLine.arguments[1]
+guard let source = inputSource(withID: targetID) else {
+  fputs("input source not found: \(targetID)\n", stderr)
+  exit(66)
+}
+
+let enableStatus = TISEnableInputSource(source)
+if enableStatus != noErr {
+  fputs("failed to enable input source: \(enableStatus)\n", stderr)
+  exit(1)
+}
+
+let status = TISSelectInputSource(source)
+if status != noErr {
+  fputs("failed to select input source: \(status)\n", stderr)
+  exit(1)
+}

--- a/test/nix-darwin-config.test.js
+++ b/test/nix-darwin-config.test.js
@@ -75,19 +75,27 @@ describe('nix-darwin and home-manager macOS configuration', () => {
     const karabinerModule = readRepoFile('nix/home/karabiner.nix');
 
     expect(karabinerModule).toContain('home.file.".config/karabiner/karabiner.json"');
-    expect(karabinerModule).toContain('keyboard_type_v2 = "jis"');
+    expect(karabinerModule).not.toContain('keyboard_type_v2 = "jis"');
     expect(karabinerModule).toContain('key_code = "caps_lock"');
     expect(karabinerModule).toContain('key_code = "left_control"');
     expect(karabinerModule).toContain('^com\\\\.cmuxterm\\\\.app$');
-    expect(karabinerModule).toContain('cmuxImeShortcut "j" "japanese_kana"');
-    expect(karabinerModule).toContain('cmuxImeShortcut "semicolon" "japanese_eisuu"');
-    expect(karabinerModule).toContain('cmuxImeShortcut "quote" "japanese_eisuu"');
-    expect(karabinerModule).toContain('cmuxCapsLockImeShortcut "j" "japanese_kana"');
-    expect(karabinerModule).toContain('cmuxCapsLockImeShortcut "semicolon" "japanese_eisuu"');
-    expect(karabinerModule).toContain('cmuxCapsLockImeShortcut "quote" "japanese_eisuu"');
-    expect(karabinerModule).toContain('cmuxImeSimultaneousShortcut "left_control" "j" "japanese_kana"');
-    expect(karabinerModule).toContain('cmuxImeSimultaneousShortcut "right_control" "j" "japanese_kana"');
-    expect(karabinerModule).toContain('cmuxImeSimultaneousShortcut "caps_lock" "j" "japanese_kana"');
+    expect(karabinerModule).toContain('cmuxJapaneseInputSource = "com.google.inputmethod.Japanese.base";');
+    expect(karabinerModule).toContain('cmuxEnglishInputSource = "com.google.inputmethod.Japanese.Roman";');
+    expect(karabinerModule).toContain('shell_command = "${inputSourceCommand} ${inputSourceID}"');
+    expect(karabinerModule).toContain('cmuxImeShortcut "j" cmuxJapaneseInputSource');
+    expect(karabinerModule).toContain('cmuxImeShortcut "semicolon" cmuxEnglishInputSource');
+    expect(karabinerModule).toContain('cmuxImeShortcut "quote" cmuxEnglishInputSource');
+    expect(karabinerModule).toContain('cmuxCapsLockImeShortcut "j" cmuxJapaneseInputSource');
+    expect(karabinerModule).toContain('cmuxImeSimultaneousShortcut "left_control" "j" cmuxJapaneseInputSource');
+    expect(karabinerModule).toContain('home.file.".local/bin/agent-select-input-source"');
+    expect(karabinerModule).toContain('source = ../../script/macos/agent-select-input-source.sh;');
+
+    const selectInputSourceScript = readRepoFile('script/macos/select-input-source.swift');
+    expect(selectInputSourceScript).toContain('TISSelectInputSource');
+    expect(selectInputSourceScript).toContain('TISCopyCurrentKeyboardInputSource');
+
+    const selectInputSourceWrapper = readRepoFile('script/macos/agent-select-input-source.sh');
+    expect(selectInputSourceWrapper).toContain('exec /usr/bin/xcrun swift "$src" "$@"');
   });
 
   test('portable user dotfiles are managed without credential state', () => {

--- a/test/nix-darwin-config.test.js
+++ b/test/nix-darwin-config.test.js
@@ -85,6 +85,9 @@ describe('nix-darwin and home-manager macOS configuration', () => {
     expect(karabinerModule).toContain('cmuxCapsLockImeShortcut "j" "japanese_kana"');
     expect(karabinerModule).toContain('cmuxCapsLockImeShortcut "semicolon" "japanese_eisuu"');
     expect(karabinerModule).toContain('cmuxCapsLockImeShortcut "quote" "japanese_eisuu"');
+    expect(karabinerModule).toContain('cmuxImeSimultaneousShortcut "left_control" "j" "japanese_kana"');
+    expect(karabinerModule).toContain('cmuxImeSimultaneousShortcut "right_control" "j" "japanese_kana"');
+    expect(karabinerModule).toContain('cmuxImeSimultaneousShortcut "caps_lock" "j" "japanese_kana"');
   });
 
   test('portable user dotfiles are managed without credential state', () => {


### PR DESCRIPTION
## Summary
- add simultaneous left_control/right_control/caps_lock + key fallbacks for cmux IME shortcuts
- keep the existing modifier-based Ctrl+Shift and CapsLock-as-Ctrl mappings
- cover the fallback in nix-darwin config tests

## Tests
- npm test -- --runTestsByPath test/nix-darwin-config.test.js
- npm run format:check
- npm run lint
- karabiner_cli --lint-complex-modifications .context/karabiner.generated.json

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  - Enhanced input source switching with additional keyboard shortcuts, including simultaneous key combinations for faster switching on macOS

<!-- end of auto-generated comment: release notes by coderabbit.ai -->