### PR TITLE
fix: stop hook のドキュメントのみ変更スキップと settings ドリフト検出を追加

### DIFF
--- a/.claude/hooks/stop_test_verification.py
+++ b/.claude/hooks/stop_test_verification.py
@@ -6,6 +6,8 @@
 
 無限ループ防止: STOP_HOOK_ACTIVE 環境変数で再帰実行を防ぐ。
 Git 変更がない場合はスキップ（新規セッションでの空実行を防止）。
+変更がテストに影響しないファイル（ドキュメント・エディタ設定・.context/ 等）
+のみの場合もスキップし、セッション終了ごとのフルテスト実行を避ける。
 """
 import sys
 import json
@@ -24,6 +26,16 @@ repo_root = get_git_root()
 if not repo_root:
     sys.exit(0)
 
+# ── テストに影響しない変更の判定 ──────────────────────────
+# ドキュメント・エディタ設定・中間成果物のみの変更ではテストを走らせない
+IRRELEVANT_SUFFIXES = (".md", ".txt")
+IRRELEVANT_PREFIXES = (".context/", "docs/", ".gemini/", ".cursor/", ".vscode/", ".idea/")
+
+
+def affects_tests(path: str) -> bool:
+    return not (path.endswith(IRRELEVANT_SUFFIXES) or path.startswith(IRRELEVANT_PREFIXES))
+
+
 # ── Git 変更の有無を確認 ──────────────────────────────────
 # ステージング済み or 未ステージングの変更がなければスキップ
 try:
@@ -39,12 +51,13 @@ try:
         ["git", "ls-files", "--others", "--exclude-standard"],
         capture_output=True, text=True, timeout=10, cwd=repo_root
     )
-    has_changes = bool(
-        (diff_result.stdout or "").strip()
-        or (staged_result.stdout or "").strip()
-        or (untracked_result.stdout or "").strip()
-    )
-    if not has_changes:
+    changed_files = [
+        line.strip()
+        for result in (diff_result, staged_result, untracked_result)
+        for line in (result.stdout or "").splitlines()
+        if line.strip()
+    ]
+    if not any(affects_tests(path) for path in changed_files):
         sys.exit(0)
 except (subprocess.TimeoutExpired, FileNotFoundError):
     sys.exit(0)

--- a/.claude/hooks/stop_test_verification.py
+++ b/.claude/hooks/stop_test_verification.py
@@ -6,8 +6,6 @@
 
 無限ループ防止: STOP_HOOK_ACTIVE 環境変数で再帰実行を防ぐ。
 Git 変更がない場合はスキップ（新規セッションでの空実行を防止）。
-変更がテストに影響しないファイル（ドキュメント・エディタ設定・.context/ 等）
-のみの場合もスキップし、セッション終了ごとのフルテスト実行を避ける。
 """
 import sys
 import json
@@ -15,6 +13,30 @@ import subprocess
 import os
 from pathlib import Path
 from common import get_git_root, detect_package_manager, build_run_command
+
+
+# Test-irrelevant path definitions (skip tests when only these files changed)
+IRRELEVANT_SUFFIXES = ('.md', '.txt')
+IRRELEVANT_PREFIXES = (
+    'docs/',
+    '.context/',
+    '.gemini/',
+    '.cursor/',
+    '.vscode/',
+    '.idea/',
+)
+
+
+def affects_tests(files):
+    """Return True if any changed file could affect tests."""
+    for f in files:
+        if not (
+            f.endswith(IRRELEVANT_SUFFIXES)
+            or any(f.startswith(p) for p in IRRELEVANT_PREFIXES)
+        ):
+            return True
+    return False
+
 
 # 無限ループ防止
 if os.environ.get("STOP_HOOK_ACTIVE") == "1":
@@ -25,16 +47,6 @@ os.environ["STOP_HOOK_ACTIVE"] = "1"
 repo_root = get_git_root()
 if not repo_root:
     sys.exit(0)
-
-# ── テストに影響しない変更の判定 ──────────────────────────
-# ドキュメント・エディタ設定・中間成果物のみの変更ではテストを走らせない
-IRRELEVANT_SUFFIXES = (".md", ".txt")
-IRRELEVANT_PREFIXES = (".context/", "docs/", ".gemini/", ".cursor/", ".vscode/", ".idea/")
-
-
-def affects_tests(path: str) -> bool:
-    return not (path.endswith(IRRELEVANT_SUFFIXES) or path.startswith(IRRELEVANT_PREFIXES))
-
 
 # ── Git 変更の有無を確認 ──────────────────────────────────
 # ステージング済み or 未ステージングの変更がなければスキップ
@@ -51,13 +63,14 @@ try:
         ["git", "ls-files", "--others", "--exclude-standard"],
         capture_output=True, text=True, timeout=10, cwd=repo_root
     )
-    changed_files = [
-        line.strip()
-        for result in (diff_result, staged_result, untracked_result)
-        for line in (result.stdout or "").splitlines()
-        if line.strip()
-    ]
-    if not any(affects_tests(path) for path in changed_files):
+    changed_files = list(filter(None,
+        (diff_result.stdout or "").strip().splitlines()
+        + (staged_result.stdout or "").strip().splitlines()
+        + (untracked_result.stdout or "").strip().splitlines()
+    ))
+    if not changed_files:
+        sys.exit(0)
+    if not affects_tests(changed_files):
         sys.exit(0)
 except (subprocess.TimeoutExpired, FileNotFoundError):
     sys.exit(0)

--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -215,6 +215,6 @@ RUN echo "${IMAGE_VERSION}" > /etc/config-base-version \
 
 COPY package.json package-lock.json /tmp/
 COPY .husky /tmp/.husky/
-COPY git/commitlint.config.js /tmp/commitlint.config.js
+COPY commitlint.config.js /tmp/commitlint.config.js
 # package.json の overrides により handlebars >= 4.7.9 (CVE-2026-33937対応) が強制インストールされる
 RUN cd /tmp && npm ci && npm run prepare || true

--- a/.devcontainer/claude-settings.json
+++ b/.devcontainer/claude-settings.json
@@ -356,6 +356,24 @@
             "command": "python3 /home/vscode/.claude/hooks/post_pr_ai_review.py"
           }
         ]
+      },
+      {
+        "matcher": "Bash",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "python3 /home/vscode/.claude/hooks/post_pr_ci_watch.py"
+          }
+        ]
+      },
+      {
+        "matcher": "Bash",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "bash -c 'cd \"$(git rev-parse --show-toplevel 2>/dev/null || echo .)\" && python3 /home/vscode/.claude/hooks/post_commit_adr_reminder.py'"
+          }
+        ]
       }
     ],
     "Stop": [

--- a/test/hooks-integrity.test.js
+++ b/test/hooks-integrity.test.js
@@ -290,7 +290,13 @@ describe('Claude Code Hooks integrity', () => {
     });
 
     test('should check git changes before running tests', () => {
-      expect(content).toContain('has_changes');
+      expect(content).toContain('changed_files');
+    });
+
+    test('should skip when only test-irrelevant files changed', () => {
+      expect(content).toContain('affects_tests');
+      expect(content).toContain('IRRELEVANT_SUFFIXES');
+      expect(content).toContain('IRRELEVANT_PREFIXES');
     });
 
     test('should look for test script in package.json', () => {

--- a/test/settings-hooks.test.js
+++ b/test/settings-hooks.test.js
@@ -168,6 +168,35 @@ describe('.claude/settings.json — hooks configuration', () => {
     });
   });
 
+  describe('DevContainer settings parity', () => {
+    // .claude/settings.json（相対パス）と .devcontainer/claude-settings.json（絶対パス）は
+    // 同じ hooks を二重管理している。片方だけへの hook 追加＝ドリフトを検出する。
+    function referencedHookScripts(settingsObject) {
+      const scripts = new Set();
+      const events = Object.values(settingsObject.hooks || {});
+      for (const entries of events) {
+        for (const entry of entries) {
+          for (const hook of entry.hooks) {
+            for (const match of hook.command.matchAll(/hooks\/(\w+\.py)/g)) {
+              scripts.add(match[1]);
+            }
+          }
+        }
+      }
+      return scripts;
+    }
+
+    test('repo settings and devcontainer settings reference the same hook scripts', () => {
+      const devcontainerSettings = JSON.parse(
+        fs.readFileSync(path.join(repoPath, '.devcontainer', 'claude-settings.json'), 'utf8'),
+      );
+      const repoScripts = referencedHookScripts(settings);
+      const devcontainerScripts = referencedHookScripts(devcontainerSettings);
+
+      expect([...repoScripts].sort()).toEqual([...devcontainerScripts].sort());
+    });
+  });
+
   describe('Hook script existence', () => {
     // Verify that every hook script referenced in settings.json actually exists
     function extractScriptNames(commands) {


### PR DESCRIPTION
## Why

1. `stop_test_verification.py`（Stop hook）はセッション終了のたびにフルテストスイート（約17秒）を実行する。ドキュメントや `.context/` のみの変更でもテストが走り、待ち時間の無駄になっていた
2. hooks の登録は `.claude/settings.json`（相対パス）と `.devcontainer/claude-settings.json`（絶対パス）の二重管理で、ドリフトを検出する仕組みがなかった

## What

- **`stop_test_verification.py`**: 変更ファイルがすべてテスト無関係（`*.md`/`*.txt`、`docs/`、`.context/`、`.gemini/`、`.cursor/`、`.vscode/`、`.idea/`）ならテスト実行をスキップ
- **`test/settings-hooks.test.js`**: 両 settings ファイルの hook スクリプト参照集合の一致を検証するドリフト検出テストを追加
- **`.devcontainer/claude-settings.json`**: 新テストが即座に検出した**実在ドリフト**を修正 — `post_pr_ci_watch.py` と `post_commit_adr_reminder.py` が devcontainer 側に未登録だった（DevContainer 環境では PR CI 監視と ADR リマインドが無効になっていた）

## How

一時 git リポジトリでの実機検証済み: ドキュメントのみの変更 → hook が無出力でスキップ / コード変更あり → テスト実行して失敗を additionalContext で報告。

## Risk

スキップ判定は保守的（未知のパスはすべて「テストに影響あり」扱い）。誤ってスキップするのは列挙した明確に無関係なパスのみ。

Closes #924

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Test verification now skips running when only documentation, config, or other non-code changes are detected, reducing unnecessary test runs.
  * Development environment settings were aligned to keep hook behavior consistent.

* **Tests**
  * Expanded automated checks to cover the new skip behavior and ensure hook settings stay in sync across environments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->