### PR TITLE
Manage macOS Dock, menu bar, and productivity controls

### DIFF
--- a/nix/hosts/darwin/default.nix
+++ b/nix/hosts/darwin/default.nix
@@ -55,6 +55,24 @@
         persistent-apps = [ ];
         persistent-others = [ ];
       };
+      # Menu bar
+      controlcenter = {
+        AirDrop = false;
+        BatteryShowPercentage = true;
+        Bluetooth = false;
+        Display = false;
+        FocusModes = false;
+        NowPlaying = false;
+        Sound = false;
+      };
+      menuExtraClock = {
+        Show24Hour = true;
+        ShowAMPM = false;
+        ShowDate = 1;
+        ShowDayOfMonth = true;
+        ShowDayOfWeek = true;
+        ShowSeconds = false;
+      };
       # Finder
       finder = {
         AppleShowAllExtensions = true;

--- a/nix/hosts/darwin/default.nix
+++ b/nix/hosts/darwin/default.nix
@@ -85,6 +85,20 @@
         KeyRepeat = 2;
       };
       CustomUserPreferences = {
+        "com.jordanbaird.Ice" = {
+          AutoRehide = true;
+          EnableAlwaysHiddenSection = false;
+          HideApplicationMenus = true;
+          ShowIceIcon = true;
+          ShowOnClick = true;
+          ShowOnHover = false;
+          ShowOnScroll = true;
+          ShowSectionDividers = false;
+          UseIceBar = false;
+        };
+        "com.apple.Spotlight" = {
+          "NSStatusItem VisibleCC Item-0" = false;
+        };
         "com.apple.HIToolbox" = {
           AppleEnabledInputSources = [
             {
@@ -129,6 +143,18 @@
     keyboard = {
       enableKeyMapping = true;
       remapCapsLockToControl = true;
+    };
+  };
+
+  launchd.user.agents.ice = {
+    serviceConfig = {
+      ProgramArguments = [
+        "/usr/bin/open"
+        "-g"
+        "-a"
+        "Ice"
+      ];
+      RunAtLoad = true;
     };
   };
 

--- a/nix/hosts/darwin/default.nix
+++ b/nix/hosts/darwin/default.nix
@@ -52,18 +52,7 @@
         autohide = true;
         show-recents = false;
         mru-spaces = false;
-        persistent-apps = [
-          "/Applications/Google Chrome.app"
-          "/Applications/Arc.app"
-          "/Applications/Cursor.app"
-          "/Applications/Visual Studio Code.app"
-          "/Applications/Codex.app"
-          "/Applications/cmux.app"
-          "/System/Applications/Utilities/Terminal.app"
-          "/Applications/Slack.app"
-          "/Applications/1Password.app"
-          "/Applications/Raycast.app"
-        ];
+        persistent-apps = [ ];
         persistent-others = [ ];
       };
       # Finder

--- a/nix/modules/homebrew.nix
+++ b/nix/modules/homebrew.nix
@@ -83,6 +83,7 @@
       "deepl"
       "dropbox"
       "google-japanese-ime"
+      "jordanbaird-ice"
       "parallels-client"
       "qblocker"
       "the-unarchiver"

--- a/test/nix-darwin-config.test.js
+++ b/test/nix-darwin-config.test.js
@@ -38,6 +38,27 @@ describe('nix-darwin and home-manager macOS configuration', () => {
     expect(darwinHost).not.toContain('"/Applications/Raycast.app"');
   });
 
+  test('menu bar keeps only work-essential system controls visible', () => {
+    const darwinHost = readRepoFile('nix/hosts/darwin/default.nix');
+
+    expect(darwinHost).toContain('controlcenter = {');
+    expect(darwinHost).toContain('BatteryShowPercentage = true;');
+    expect(darwinHost).toContain('AirDrop = false;');
+    expect(darwinHost).toContain('Bluetooth = false;');
+    expect(darwinHost).toContain('Display = false;');
+    expect(darwinHost).toContain('FocusModes = false;');
+    expect(darwinHost).toContain('NowPlaying = false;');
+    expect(darwinHost).toContain('Sound = false;');
+
+    expect(darwinHost).toContain('menuExtraClock = {');
+    expect(darwinHost).toContain('Show24Hour = true;');
+    expect(darwinHost).toContain('ShowAMPM = false;');
+    expect(darwinHost).toContain('ShowDate = 1;');
+    expect(darwinHost).toContain('ShowDayOfMonth = true;');
+    expect(darwinHost).toContain('ShowDayOfWeek = true;');
+    expect(darwinHost).toContain('ShowSeconds = false;');
+  });
+
   test('home-manager imports cmux and input source helpers without Karabiner', () => {
     const homeDefault = readRepoFile('nix/home/default.nix');
 

--- a/test/nix-darwin-config.test.js
+++ b/test/nix-darwin-config.test.js
@@ -27,6 +27,17 @@ describe('nix-darwin and home-manager macOS configuration', () => {
     expect(darwinHost).toContain('com.google.inputmethod.Japanese.Roman');
   });
 
+  test('Dock shows running apps without pinned or recent apps', () => {
+    const darwinHost = readRepoFile('nix/hosts/darwin/default.nix');
+
+    expect(darwinHost).toContain('dock = {');
+    expect(darwinHost).toContain('show-recents = false;');
+    expect(darwinHost).toContain('persistent-apps = [ ];');
+    expect(darwinHost).toContain('persistent-others = [ ];');
+    expect(darwinHost).not.toContain('"/Applications/Google Chrome.app"');
+    expect(darwinHost).not.toContain('"/Applications/Raycast.app"');
+  });
+
   test('home-manager imports cmux and input source helpers without Karabiner', () => {
     const homeDefault = readRepoFile('nix/home/default.nix');
 

--- a/test/nix-darwin-config.test.js
+++ b/test/nix-darwin-config.test.js
@@ -57,6 +57,19 @@ describe('nix-darwin and home-manager macOS configuration', () => {
     expect(darwinHost).toContain('ShowDayOfMonth = true;');
     expect(darwinHost).toContain('ShowDayOfWeek = true;');
     expect(darwinHost).toContain('ShowSeconds = false;');
+
+    expect(darwinHost).toContain('"com.apple.Spotlight"');
+    expect(darwinHost).toContain('"NSStatusItem VisibleCC Item-0" = false;');
+    expect(darwinHost).toContain('"com.jordanbaird.Ice"');
+    expect(darwinHost).toContain('HideApplicationMenus = true;');
+    expect(darwinHost).toContain('ShowOnClick = true;');
+    expect(darwinHost).toContain('ShowOnScroll = true;');
+    expect(darwinHost).toContain('UseIceBar = false;');
+    expect(darwinHost).toContain('launchd.user.agents.ice');
+    expect(darwinHost).toContain('"/usr/bin/open"');
+    expect(darwinHost).toContain('"-a"');
+    expect(darwinHost).toContain('"Ice"');
+    expect(darwinHost).toContain('RunAtLoad = true;');
   });
 
   test('home-manager imports cmux and input source helpers without Karabiner', () => {
@@ -80,6 +93,7 @@ describe('nix-darwin and home-manager macOS configuration', () => {
     expect(homebrewModule).toContain('"flutter"');
     expect(homebrewModule).toContain('"google-chrome"');
     expect(homebrewModule).toContain('"google-japanese-ime"');
+    expect(homebrewModule).toContain('"jordanbaird-ice"');
     expect(homebrewModule).not.toContain('"mattermost"');
     expect(homebrewModule).not.toContain('"messenger"');
     expect(homebrewModule).not.toContain('"karabiner-elements"');


### PR DESCRIPTION
## Summary
- Keep the Dock focused on running apps by clearing persistent Dock items and disabling recents.
- Trim built-in menu bar extras, keep the clock/battery useful, and manage third-party menu items with Ice.
- Standardize the productivity stack around Raycast, AeroSpace, and BetterTouchTool by removing Alfred/yabai from managed packages.
- Start Raycast, Ice, and BetterTouchTool at login, and route common apps into AeroSpace workspaces 1-9.

## Verification
- nixfmt on changed Nix files
- `jest --runInBand test/nix-darwin-config.test.js`
- `nix flake check /private/tmp/config-dock-worktree.5YJ526/nix`
- `sudo darwin-rebuild switch --flake /private/tmp/config-dock-worktree.5YJ526/nix#keitonoMacBook-Pro`
- Uninstalled local Alfred cask and yabai formula after removing them from managed config
- `aerospace reload-config --dry-run --no-gui`
- `aerospace list-workspaces --all` -> 1 through 9