### PR TITLE
Prefer Raycast and AeroSpace macOS controls

### DIFF
--- a/dot/aerospace.toml
+++ b/dot/aerospace.toml
@@ -1,12 +1,18 @@
 # Place a copy of this config to ~/.aerospace.toml
 # After that, you can edit ~/.aerospace.toml to your liking
 
+# Config version for compatibility and deprecations
+config-version = 2
+
 # You can use it to add commands that run after AeroSpace startup.
 # Available commands : https://nikitabobko.github.io/AeroSpace/commands
 after-startup-command = []
 
 # Start AeroSpace at login
-start-at-login = false
+start-at-login = true
+
+# Automatically reload the config when the config file is saved.
+auto-reload-config = true
 
 # Normalizations. See: https://nikitabobko.github.io/AeroSpace/guide#normalization
 enable-normalization-flatten-containers = true
@@ -37,6 +43,9 @@ on-focused-monitor-changed = ['move-mouse monitor-lazy-center']
 # Also see: https://nikitabobko.github.io/AeroSpace/goodies#disable-hide-app
 automatically-unhide-macos-hidden-apps = false
 
+# Keep the core workspaces addressable even before their first window appears.
+persistent-workspaces = ["1", "2", "3", "4", "5", "6", "7", "8", "9"]
+
 # Possible values: (qwerty|dvorak|colemak)
 # See https://nikitabobko.github.io/AeroSpace/guide#key-mapping
 [key-mapping]
@@ -51,12 +60,79 @@ automatically-unhide-macos-hidden-apps = false
 #                 See:
 #                 https://nikitabobko.github.io/AeroSpace/guide#assign-workspaces-to-monitors
 [gaps]
-    inner.horizontal = 0
-    inner.vertical =   0
-    outer.left =       0
-    outer.bottom =     0
-    outer.top =        0
-    outer.right =      0
+    inner.horizontal = 6
+    inner.vertical =   6
+    outer.left =       6
+    outer.bottom =     6
+    outer.top =        6
+    outer.right =      6
+
+# Workspaces:
+# 1 terminal/agents, 2 browsers, 3 editor, 4 AI, 5 communication,
+# 6 planning/docs, 7 mail/calendar, 8 infrastructure, 9 utilities.
+[[on-window-detected]]
+    if.app-id = 'com.cmuxterm.app'
+    run = 'move-node-to-workspace 1'
+
+[[on-window-detected]]
+    if.app-id = 'com.google.Chrome'
+    run = 'move-node-to-workspace 2'
+
+[[on-window-detected]]
+    if.app-id = 'company.thebrowser.Browser'
+    run = 'move-node-to-workspace 2'
+
+[[on-window-detected]]
+    if.app-id = 'com.todesktop.230313mzl4w4u92'
+    run = 'move-node-to-workspace 3'
+
+[[on-window-detected]]
+    if.app-id = 'com.microsoft.VSCode'
+    run = 'move-node-to-workspace 3'
+
+[[on-window-detected]]
+    if.app-id = 'com.openai.codex'
+    run = 'move-node-to-workspace 4'
+
+[[on-window-detected]]
+    if.app-id = 'com.anthropic.claudefordesktop'
+    run = 'move-node-to-workspace 4'
+
+[[on-window-detected]]
+    if.app-id = 'com.tinyspeck.slackmacgap'
+    run = 'move-node-to-workspace 5'
+
+[[on-window-detected]]
+    if.app-id = 'com.hnc.Discord'
+    run = 'move-node-to-workspace 5'
+
+[[on-window-detected]]
+    if.app-id = 'notion.id'
+    run = 'move-node-to-workspace 6'
+
+[[on-window-detected]]
+    if.app-id = 'com.linear'
+    run = 'move-node-to-workspace 6'
+
+[[on-window-detected]]
+    if.app-id = 'com.readdle.SparkDesktop'
+    run = 'move-node-to-workspace 7'
+
+[[on-window-detected]]
+    if.app-id = 'com.cron.electron'
+    run = 'move-node-to-workspace 7'
+
+[[on-window-detected]]
+    if.app-id = 'dev.kdrag0n.MacVirt'
+    run = 'move-node-to-workspace 8'
+
+[[on-window-detected]]
+    if.app-id = 'com.raycast.macos'
+    run = 'move-node-to-workspace 9'
+
+[[on-window-detected]]
+    if.app-id = 'com.hegenberg.BetterTouchTool'
+    run = 'move-node-to-workspace 9'
 
 # 'main' binding mode declaration
 # See: https://nikitabobko.github.io/AeroSpace/guide#binding-modes

--- a/nix/hosts/darwin/default.nix
+++ b/nix/hosts/darwin/default.nix
@@ -146,15 +146,39 @@
     };
   };
 
-  launchd.user.agents.ice = {
-    serviceConfig = {
-      ProgramArguments = [
-        "/usr/bin/open"
-        "-g"
-        "-a"
-        "Ice"
-      ];
-      RunAtLoad = true;
+  launchd.user.agents = {
+    bettertouchtool = {
+      serviceConfig = {
+        ProgramArguments = [
+          "/usr/bin/open"
+          "-g"
+          "-a"
+          "BetterTouchTool"
+        ];
+        RunAtLoad = true;
+      };
+    };
+    ice = {
+      serviceConfig = {
+        ProgramArguments = [
+          "/usr/bin/open"
+          "-g"
+          "-a"
+          "Ice"
+        ];
+        RunAtLoad = true;
+      };
+    };
+    raycast = {
+      serviceConfig = {
+        ProgramArguments = [
+          "/usr/bin/open"
+          "-g"
+          "-a"
+          "Raycast"
+        ];
+        RunAtLoad = true;
+      };
     };
   };
 

--- a/nix/modules/homebrew.nix
+++ b/nix/modules/homebrew.nix
@@ -30,7 +30,6 @@
 
       # Tap-dependent formulae
       "koekeishiya/formulae/skhd"
-      "koekeishiya/formulae/yabai"
       "supabase/tap/supabase"
       "ynqa/tap/jnv"
       "yukiarrr/tap/ecsk"
@@ -61,7 +60,6 @@
 
       # Productivity
       "aerospace"
-      "alfred"
       "bettertouchtool"
       "notion"
       "notion-calendar"

--- a/test/nix-darwin-config.test.js
+++ b/test/nix-darwin-config.test.js
@@ -65,10 +65,15 @@ describe('nix-darwin and home-manager macOS configuration', () => {
     expect(darwinHost).toContain('ShowOnClick = true;');
     expect(darwinHost).toContain('ShowOnScroll = true;');
     expect(darwinHost).toContain('UseIceBar = false;');
-    expect(darwinHost).toContain('launchd.user.agents.ice');
+    expect(darwinHost).toContain('launchd.user.agents = {');
+    expect(darwinHost).toContain('bettertouchtool = {');
+    expect(darwinHost).toContain('ice = {');
+    expect(darwinHost).toContain('raycast = {');
     expect(darwinHost).toContain('"/usr/bin/open"');
     expect(darwinHost).toContain('"-a"');
+    expect(darwinHost).toContain('"BetterTouchTool"');
     expect(darwinHost).toContain('"Ice"');
+    expect(darwinHost).toContain('"Raycast"');
     expect(darwinHost).toContain('RunAtLoad = true;');
   });
 
@@ -94,13 +99,42 @@ describe('nix-darwin and home-manager macOS configuration', () => {
     expect(homebrewModule).toContain('"google-chrome"');
     expect(homebrewModule).toContain('"google-japanese-ime"');
     expect(homebrewModule).toContain('"jordanbaird-ice"');
+    expect(homebrewModule).toContain('"aerospace"');
+    expect(homebrewModule).toContain('"bettertouchtool"');
+    expect(homebrewModule).toContain('"raycast"');
     expect(homebrewModule).not.toContain('"mattermost"');
     expect(homebrewModule).not.toContain('"messenger"');
+    expect(homebrewModule).not.toContain('"alfred"');
     expect(homebrewModule).not.toContain('"karabiner-elements"');
     expect(homebrewModule).not.toContain('"bartender"');
     expect(homebrewModule).not.toContain('"rancher"');
     expect(homebrewModule).not.toContain('"google-cloud-sdk"');
     expect(homebrewModule).not.toContain('"tailscale"');
+    expect(homebrewModule).not.toContain('"koekeishiya/formulae/yabai"');
+  });
+
+  test('AeroSpace owns window management with app workspace routing', () => {
+    const aerospaceConfig = readRepoFile('dot/aerospace.toml');
+
+    expect(aerospaceConfig).toContain('config-version = 2');
+    expect(aerospaceConfig).toContain('start-at-login = true');
+    expect(aerospaceConfig).toContain('auto-reload-config = true');
+    expect(aerospaceConfig).toContain('persistent-workspaces = ["1", "2", "3", "4", "5", "6", "7", "8", "9"]');
+    expect(aerospaceConfig).toContain('inner.horizontal = 6');
+    expect(aerospaceConfig).toContain('outer.top =        6');
+    expect(aerospaceConfig).toContain('[[on-window-detected]]');
+    expect(aerospaceConfig).toContain("if.app-id = 'com.cmuxterm.app'");
+    expect(aerospaceConfig).toContain("if.app-id = 'com.google.Chrome'");
+    expect(aerospaceConfig).toContain("if.app-id = 'company.thebrowser.Browser'");
+    expect(aerospaceConfig).toContain("if.app-id = 'com.todesktop.230313mzl4w4u92'");
+    expect(aerospaceConfig).toContain("if.app-id = 'com.openai.codex'");
+    expect(aerospaceConfig).toContain("if.app-id = 'com.anthropic.claudefordesktop'");
+    expect(aerospaceConfig).toContain("if.app-id = 'com.tinyspeck.slackmacgap'");
+    expect(aerospaceConfig).toContain("if.app-id = 'notion.id'");
+    expect(aerospaceConfig).toContain("if.app-id = 'com.readdle.SparkDesktop'");
+    expect(aerospaceConfig).toContain("if.app-id = 'com.raycast.macos'");
+    expect(aerospaceConfig).toContain("if.app-id = 'com.hegenberg.BetterTouchTool'");
+    expect(aerospaceConfig).toContain("run = 'move-node-to-workspace 9'");
   });
 
   test('skhd binds IME shortcuts without Karabiner', () => {


### PR DESCRIPTION
## Summary
- Remove Alfred and yabai from the managed Homebrew stack so Raycast and AeroSpace become the primary launcher/window-management tools.
- Enable AeroSpace at login, auto-reload its config, keep workspaces 1-9 available, add small gaps, and route common apps into dedicated workspaces.
- Start Raycast and BetterTouchTool at login alongside Ice.
- Extend config tests to cover the selected macOS productivity stack and AeroSpace routing.

## Verification
- nixfmt on changed Nix files
- `jest --runInBand test/nix-darwin-config.test.js`
- `nix flake check /private/tmp/config-dock-worktree.5YJ526/nix`
- `sudo darwin-rebuild switch --flake /private/tmp/config-dock-worktree.5YJ526/nix#keitonoMacBook-Pro`
- Uninstalled local Alfred cask and yabai formula
- `aerospace reload-config --dry-run --no-gui`
- `aerospace list-workspaces --all` -> 1 through 9