### PR TITLE
[codex] manage BetterTouchTool gestures

### DIFF
--- a/docs/adr/0017-manage-bettertouchtool-gestures.md
+++ b/docs/adr/0017-manage-bettertouchtool-gestures.md
@@ -1,0 +1,67 @@
+# ADR 0017: Manage BetterTouchTool Gesture Setup Through GitHub
+
+## Status
+
+Accepted
+
+## Context
+
+BetterTouchTool stores gesture configuration in local application state under the
+user profile. Full BetterTouchTool exports and sync stores may contain personal
+settings, generated metadata, device-specific identifiers, and backups that are
+not suitable as a normal repository source of truth.
+
+The macOS desktop setup now uses:
+
+- AeroSpace for window focus and workspace movement.
+- Raycast as the launcher.
+- BetterTouchTool for gesture entry points.
+
+The desired BetterTouchTool setup must preserve historical and manually-created
+triggers while adding a small managed set of gestures.
+
+## Decision
+
+Manage BetterTouchTool through a JXA setup script:
+
+- `script/macos/setup-bettertouchtool.js` is the GitHub-tracked source.
+- The script adds only missing `CODEX-BTT-*` triggers.
+- The script does not delete existing triggers, including older manual or backup
+  restored triggers.
+- BetterTouchTool remains installed and launched through the nix-darwin
+  Homebrew and launchd configuration.
+- BetterTouchTool preset exports stay local backups, not repository-managed
+  artifacts.
+
+The managed gesture set is:
+
+- 3 finger swipe left/right: AeroSpace workspace next/previous.
+- 3 finger swipe down: send `Cmd+W`.
+- 3 finger tap: AeroSpace workspace back-and-forth.
+- 3 finger click: middle click.
+- 4 finger swipe left/right/up/down: AeroSpace focus movement.
+- 4 finger tap: open Raycast.
+
+## Consequences
+
+### Positive
+
+- The expected gestures can be recreated from GitHub without committing
+  BetterTouchTool's full local state.
+- Past BetterTouchTool triggers are preserved by default.
+- Window-management behavior stays centralized in AeroSpace.
+- Launcher behavior stays centralized in Raycast.
+
+### Negative
+
+- Applying the setup still requires BetterTouchTool to be installed and scriptable
+  on the local Mac.
+- Changes to existing managed triggers require a deliberate manual cleanup or a
+  future migration path, because the default script is append-only.
+
+### Mitigation
+
+- Keep local `.bttpreset` and ZIP backups for full restore scenarios.
+- Prefer adding new stable `CODEX-BTT-*` UUIDs when introducing new gestures.
+- Use the repository script for repeatable setup and BetterTouchTool exports for
+  disaster recovery.

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -21,6 +21,7 @@
 | [0014](0014-manage-cmux-karabiner-with-home-manager.md)         | Manage cmux and Karabiner Configuration with Home Manager    | Superseded by 0016 |
 | [0015](0015-manage-portable-user-dotfiles-with-home-manager.md) | Manage Portable User Dotfiles with Home Manager              | Accepted           |
 | [0016](0016-use-kanary-for-keyboard-remapping.md)               | Use Kanary and skhd for Keyboard Remapping                   | Accepted           |
+| [0017](0017-manage-bettertouchtool-gestures.md)                 | Manage BetterTouchTool Gesture Setup Through GitHub          | Accepted           |
 
 ## ADR テンプレート
 

--- a/script/README.md
+++ b/script/README.md
@@ -4,18 +4,42 @@ This directory contains utility scripts for managing configuration, credentials,
 
 ## Quick Reference
 
-| Script                | Purpose                                                  | Used By                |
-| --------------------- | -------------------------------------------------------- | ---------------------- |
-| `setup-claude.sh`     | Claude Code CLI setup                                    | Makefile, DevContainer |
-| `credentials.sh`      | 1Password credential management                          | Makefile               |
-| `update-libraries.sh` | Refresh `npm/global.json` (Dependabot owns package.json) | package.json           |
-| `version.sh`          | Semantic versioning                                      | Makefile               |
-| `update-agents-md.sh` | AGENTS.md 自動生成セクション更新                         | repo-maintenance       |
-| `repo-maintenance.sh` | Repository maintenance executable workflow               | `/repo-maintenance`    |
-| `setup-ci.sh`         | CI/CD workflow setup                                     | `/setup-ci`            |
-| `setup-new-repo.sh`   | New repository bootstrap                                 | `/setup-new-repo`      |
+| Script                           | Purpose                                                  | Used By                |
+| -------------------------------- | -------------------------------------------------------- | ---------------------- |
+| `setup-claude.sh`                | Claude Code CLI setup                                    | Makefile, DevContainer |
+| `credentials.sh`                 | 1Password credential management                          | Makefile               |
+| `update-libraries.sh`            | Refresh `npm/global.json` (Dependabot owns package.json) | package.json           |
+| `version.sh`                     | Semantic versioning                                      | Makefile               |
+| `update-agents-md.sh`            | AGENTS.md 自動生成セクション更新                         | repo-maintenance       |
+| `repo-maintenance.sh`            | Repository maintenance executable workflow               | `/repo-maintenance`    |
+| `setup-ci.sh`                    | CI/CD workflow setup                                     | `/setup-ci`            |
+| `setup-new-repo.sh`              | New repository bootstrap                                 | `/setup-new-repo`      |
+| `macos/setup-bettertouchtool.js` | BetterTouchTool gesture setup for AeroSpace/Raycast      | Local macOS setup      |
 
 ## Configuration Management
+
+### macos/setup-bettertouchtool.js
+
+Adds the managed BetterTouchTool gesture entry points for the macOS desktop
+setup. The script is append-only: it adds missing `CODEX-BTT-*` triggers and
+preserves existing BetterTouchTool triggers.
+
+**Usage**:
+
+```bash
+osascript -l JavaScript ./script/macos/setup-bettertouchtool.js
+```
+
+**Managed gestures**:
+
+| Gesture                           | Action                             |
+| --------------------------------- | ---------------------------------- |
+| 3 finger swipe left/right         | AeroSpace workspace next/previous  |
+| 3 finger swipe down               | `Cmd+W`                            |
+| 3 finger tap                      | AeroSpace workspace back-and-forth |
+| 3 finger click                    | Middle click                       |
+| 4 finger swipe left/right/up/down | AeroSpace focus movement           |
+| 4 finger tap                      | Open Raycast                       |
 
 ### export.sh
 

--- a/script/macos/setup-bettertouchtool.js
+++ b/script/macos/setup-bettertouchtool.js
@@ -1,0 +1,134 @@
+/* global Application */
+
+const BTT = Application('/Applications/BetterTouchTool.app');
+
+const aerospace = '/opt/homebrew/bin/aerospace';
+
+const shellTriggers = [
+  {
+    uuid: 'CODEX-BTT-AEROSPACE-WORKSPACE-NEXT',
+    type: 100,
+    description: '3 Finger Swipe Left',
+    name: 'AeroSpace workspace next',
+    command: `${aerospace} workspace --wrap-around next`,
+    order: 10,
+  },
+  {
+    uuid: 'CODEX-BTT-AEROSPACE-WORKSPACE-PREV',
+    type: 101,
+    description: '3 Finger Swipe Right',
+    name: 'AeroSpace workspace previous',
+    command: `${aerospace} workspace --wrap-around prev`,
+    order: 20,
+  },
+  {
+    uuid: 'CODEX-BTT-AEROSPACE-WORKSPACE-BACK',
+    type: 104,
+    description: '3 Finger Tap',
+    name: 'AeroSpace workspace back and forth',
+    command: `${aerospace} workspace-back-and-forth`,
+    order: 30,
+  },
+  {
+    uuid: 'CODEX-BTT-AEROSPACE-FOCUS-LEFT',
+    type: 105,
+    description: '4 Finger Swipe Left',
+    name: 'AeroSpace focus left',
+    command: `${aerospace} focus left`,
+    order: 40,
+  },
+  {
+    uuid: 'CODEX-BTT-AEROSPACE-FOCUS-RIGHT',
+    type: 106,
+    description: '4 Finger Swipe Right',
+    name: 'AeroSpace focus right',
+    command: `${aerospace} focus right`,
+    order: 50,
+  },
+  {
+    uuid: 'CODEX-BTT-AEROSPACE-FOCUS-DOWN',
+    type: 107,
+    description: '4 Finger Swipe Down',
+    name: 'AeroSpace focus down',
+    command: `${aerospace} focus down`,
+    order: 60,
+  },
+  {
+    uuid: 'CODEX-BTT-AEROSPACE-FOCUS-UP',
+    type: 108,
+    description: '4 Finger Swipe Up',
+    name: 'AeroSpace focus up',
+    command: `${aerospace} focus up`,
+    order: 70,
+  },
+  {
+    uuid: 'CODEX-BTT-RAYCAST',
+    type: 110,
+    description: '4 Finger Tap',
+    name: 'Open Raycast',
+    command: '/usr/bin/open -a Raycast',
+    order: 80,
+  },
+];
+
+const directTriggers = [
+  {
+    BTTUUID: 'CODEX-BTT-CMD-W',
+    BTTTriggerType: 103,
+    BTTTriggerTypeDescription: '3 Finger Swipe Down',
+    BTTTriggerClass: 'BTTTriggerTypeTouchpadAll',
+    BTTPredefinedActionType: 264,
+    BTTPredefinedActionName: 'Send Keyboard Shortcut',
+    BTTShortcutToSend: '55,13',
+    BTTEnabled: 1,
+    BTTEnabled2: 1,
+    BTTOrder: 25,
+  },
+  {
+    BTTUUID: 'CODEX-BTT-MIDDLE-CLICK',
+    BTTTriggerType: 112,
+    BTTTriggerTypeDescription: '3 Finger Click',
+    BTTTriggerClass: 'BTTTriggerTypeTouchpadAll',
+    BTTPredefinedActionType: 1,
+    BTTPredefinedActionName: 'Middle Click',
+    BTTEnabled: 1,
+    BTTEnabled2: 1,
+    BTTOrder: 90,
+  },
+];
+
+const triggers = [
+  ...shellTriggers.map((trigger) => ({
+    BTTUUID: trigger.uuid,
+    BTTTriggerType: trigger.type,
+    BTTTriggerTypeDescription: trigger.description,
+    BTTTriggerClass: 'BTTTriggerTypeTouchpadAll',
+    BTTPredefinedActionType: 137,
+    BTTPredefinedActionName: trigger.name,
+    BTTTerminalCommand: trigger.command,
+    BTTEnabled: 1,
+    BTTEnabled2: 1,
+    BTTOrder: trigger.order,
+  })),
+  ...directTriggers,
+];
+
+const existing = JSON.parse(BTT.get_triggers());
+const existingUuids = new Set(existing.map((trigger) => trigger.BTTUUID));
+
+let addedTriggers = 0;
+for (const trigger of triggers) {
+  if (existingUuids.has(trigger.BTTUUID)) {
+    continue;
+  }
+
+  BTT.add_new_trigger(JSON.stringify(trigger));
+  existingUuids.add(trigger.BTTUUID);
+  addedTriggers += 1;
+}
+
+JSON.stringify({
+  preservedExistingTriggers: existing.length,
+  addedTriggers,
+  managedTriggers: triggers.length,
+});

--- a/test/nix-darwin-config.test.js
+++ b/test/nix-darwin-config.test.js
@@ -137,6 +137,27 @@ describe('nix-darwin and home-manager macOS configuration', () => {
     expect(aerospaceConfig).toContain("run = 'move-node-to-workspace 9'");
   });
 
+  test('BetterTouchTool gesture setup is GitHub-managed and preserves existing triggers', () => {
+    const bttSetup = readRepoFile('script/macos/setup-bettertouchtool.js');
+    const adr = readRepoFile('docs/adr/0017-manage-bettertouchtool-gestures.md');
+
+    expect(fs.existsSync(path.join(repoPath, 'script/macos/setup-bettertouchtool.js'))).toBe(true);
+    expect(bttSetup).toContain("Application('/Applications/BetterTouchTool.app')");
+    expect(bttSetup).toContain('existingUuids.has(trigger.BTTUUID)');
+    expect(bttSetup).not.toContain('delete_triggers');
+    expect(bttSetup).toContain('CODEX-BTT-CMD-W');
+    expect(bttSetup).toContain("BTTShortcutToSend: '55,13'");
+    expect(bttSetup).toContain("const aerospace = '/opt/homebrew/bin/aerospace'");
+    expect(bttSetup).toContain('workspace --wrap-around next');
+    expect(bttSetup).toContain('workspace --wrap-around prev');
+    expect(bttSetup).toContain('workspace-back-and-forth');
+    expect(bttSetup).toContain('focus left');
+    expect(bttSetup).toContain('/usr/bin/open -a Raycast');
+    expect(adr).toContain('The script adds only missing `CODEX-BTT-*` triggers.');
+    expect(adr).toContain('The script does not delete existing triggers');
+    expect(adr).toContain('3 finger swipe down: send `Cmd+W`.');
+  });
+
   test('skhd binds IME shortcuts without Karabiner', () => {
     const darwinHost = readRepoFile('nix/hosts/darwin/default.nix');
 


### PR DESCRIPTION
## Summary

- Add a GitHub-managed BetterTouchTool setup script for the AeroSpace/Raycast gesture layer.
- Document the decision to keep full BetterTouchTool exports local while tracking the repeatable setup script.
- Add coverage that the setup is append-only and does not delete existing BetterTouchTool triggers.

## Validation

- `./node_modules/.bin/eslint script/macos/setup-bettertouchtool.js test/nix-darwin-config.test.js`
- `./node_modules/.bin/jest --runInBand test/nix-darwin-config.test.js`
- `/run/current-system/sw/bin/nix flake check` from `nix/`
- `osascript -l JavaScript script/macos/setup-bettertouchtool.js` against the local BetterTouchTool app returned `addedTriggers: 0`, preserving the existing 10 managed triggers.

## Notes

BetterTouchTool preset exports and old backup ZIPs stay local backup artifacts. The repository manages only the append-only setup script so older/manual triggers are preserved.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for managing a set of BetterTouchTool gestures while preserving existing custom triggers and only appending missing managed ones.
  * Introduced updated gesture mappings for workspace and focus actions.

* **Documentation**
  * Added an ADR describing the supported gesture-management approach and its expected behavior.
  * Updated the setup documentation and quick reference to include the new macOS gesture setup flow.

* **Tests**
  * Added coverage to verify the new setup behavior and the documented trigger-preservation rules.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->