### PR TITLE
feat(dotfiles): tmux クリップボード設定を home-manager 管理に追加

### DIFF
--- a/dot/tmux.conf
+++ b/dot/tmux.conf
@@ -1,0 +1,7 @@
+# --- Clipboard ---------------------------------------------------------------
+# cmux/Ghostty など OSC 52 対応ターミナルへコピーを転送する
+set -g set-clipboard on
+# tmux 内のアプリが発行するエスケープシーケンス（OSC 52 等）を外側へ通す
+set -g allow-passthrough on
+# macOS では copy-mode のヤンクを pbcopy に直結し、OSC 52 経路への依存を無くす
+if-shell 'command -v pbcopy' "set -s copy-command 'pbcopy'"

--- a/nix/home/dotfiles.nix
+++ b/nix/home/dotfiles.nix
@@ -24,6 +24,7 @@ in
 
     ".gitignore" = managedSource (configRoot + /git/gitignore);
     ".peco/config.json" = managedSource (configRoot + /dot/.peco/config.json);
+    ".tmux.conf" = managedSource (configRoot + /dot/tmux.conf);
     ".zshrc.devcontainer" = managedSource (configRoot + /dot/.zshrc.devcontainer);
 
     ".zsh/configs/aliases.zsh" = managedSource (configRoot + /.zsh/configs/aliases.zsh);


### PR DESCRIPTION
## Why

cmux（Ghostty ベース）→ agent-deck → tmux の構成で、コピーが macOS 本体のクリップボードへ伝播しないケースがあった。調査の結果、tmux → cmux の OSC 52 伝播自体は正常（`tmux set-buffer -w` で実証済み）だが、`~/.tmux.conf` が未管理・不存在で copy-mode のヤンクが OSC 52 経路のみに依存していた。

Closes #967

## What

- `dot/tmux.conf` を新規追加
  - `set-clipboard on`: OSC 52 対応ターミナルへのコピー転送
  - `allow-passthrough on`: 内側アプリのエスケープシーケンス通過
  - `copy-command pbcopy`: macOS では copy-mode のヤンクを pbcopy に直結（`if-shell` ガードで pbcopy 存在時のみ）
- `nix/home/dotfiles.nix` に `.tmux.conf` エントリを追加（既存の `managedSource` パターン）

## How（検証）

- `tmux -L adtest -f dot/tmux.conf new-session -d` で別サーバー起動 → 3 オプションすべて反映を確認
- `nix-instantiate --parse` で dotfiles.nix の構文 OK
- 実環境の tmux サーバーで `set-buffer -w` → macOS クリップボード到達を実証済み

## Risk

- 低。新規ファイル追加のみで既存設定の変更なし
- `copy-command` は if-shell ガード付きのため Linux/devcontainer では no-op
- 適用には各端末で `make claude-setup`（home-manager rebuild）が必要

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added tmux clipboard integration for smoother copy and paste.
  * Enabled clipboard forwarding through terminal escape sequences.
  * Added direct macOS clipboard support when available.

* **Chores**
  * Added the tmux configuration to managed home-directory setup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->