### PR TITLE
chore(claude): add mattpocock/skills plugin

### DIFF
--- a/.claude/plugins/README.md
+++ b/.claude/plugins/README.md
@@ -111,6 +111,7 @@ make claude-plugins
 - **intellectronica/agent-skills** (`intellectronica-skills`) - ライブラリ・フレームワークの最新ドキュメント
 - **anthropics/skills** (`anthropic-agent-skills`) - Anthropic公式スキル
 - **lackeyjb/playwright-skill** (`playwright-skill`) - Playwright自動化スキル
+- **mattpocock/skills** (`mattpocock`) - 実務エンジニアリング向けスキル（grill-me / to-spec / to-tickets / tdd / improve-codebase-architecture ほか）
 
 ## 推奨プラグイン
 

--- a/.claude/plugins/known_marketplaces.json.template
+++ b/.claude/plugins/known_marketplaces.json.template
@@ -55,6 +55,14 @@
     "installLocation": "{{HOME}}/.claude/plugins/marketplaces/intellectronica-skills",
     "lastUpdated": "2025-01-01T00:00:00.000Z"
   },
+  "mattpocock": {
+    "source": {
+      "source": "github",
+      "repo": "mattpocock/skills"
+    },
+    "installLocation": "{{HOME}}/.claude/plugins/marketplaces/mattpocock",
+    "lastUpdated": "2025-01-01T00:00:00.000Z"
+  },
   "playwright-skill": {
     "source": {
       "source": "github",

--- a/.claude/plugins/plugins.txt
+++ b/.claude/plugins/plugins.txt
@@ -35,3 +35,8 @@ agent-browser@agent-browser
 
 # === Context7 (Plugin) ===
 context7@intellectronica-skills
+
+# === Matt Pocock Skills (Plugin) ===
+# Skills for real engineering: grill-me / to-spec / to-tickets / tdd / improve-codebase-architecture ほか
+# 導入後、各リポジトリで /setup-matt-pocock-skills を1回実行する
+mattpocock-skills@mattpocock

--- a/script/lib/claude_plugins.sh
+++ b/script/lib/claude_plugins.sh
@@ -17,6 +17,7 @@ readonly PLUGINS_KNOWN_MARKETPLACES_FALLBACK=(
     "claude-code-workflows:wshobson/agents"
     "claude-plugins-official:anthropics/claude-plugins-official"
     "intellectronica-skills:intellectronica/agent-skills"
+    "mattpocock:mattpocock/skills"
     "playwright-skill:lackeyjb/playwright-skill"
     "supabase-agent-skills:supabase/agent-skills"
 )

--- a/test/integration/audit_references.bats
+++ b/test/integration/audit_references.bats
@@ -21,7 +21,7 @@ assert_tsv_row() {
   assert_tsv_row docs script/README.md docs/README.md
   assert_tsv_row test script/audit-references.sh test/integration/core-scripts.bats
   assert_tsv_row code/ci templates/workflows/claude.yml templates/workflows/claude-health-check.yml
-  assert_tsv_row test templates/workflows/claude-health-check.yml test/template-workflows.test.js
+  assert_tsv_row test templates/workflows/claude-health-check.yml test/template-workflows-claude.test.js
 }
 
 @test "audit-references markdown includes zero code/test summary" {


### PR DESCRIPTION
## Why
Matt Pocock の [mattpocock/skills](https://github.com/mattpocock/skills)（MIT・53k+ stars）を全端末の Claude Code に配布する。実務エンジニアリングのフロー（アイデア→徹底ヒアリング→仕様→チケット→TDD→アーキテクチャ改善）を回すためのスキル群。ローカルで動作確認済みのため config リポジトリに反映して各端末へ展開する。

## What
管理型 Claude Code プラグインとして `mattpocock-skills@mattpocock`（v1.2.0 / 全22スキル）を追加。

- `.claude/plugins/plugins.txt`: `mattpocock-skills@mattpocock` を追加
- `.claude/plugins/known_marketplaces.json.template`: `mattpocock` マーケットプレイス（`mattpocock/skills`）を追加
- `script/lib/claude_plugins.sh`: フォールバック配列に `mattpocock:mattpocock/skills` を追加（テンプレートと同期）
- `.claude/plugins/README.md`: 利用可能なマーケットプレイス一覧に追記

主なスキル: `grill-me` / `grill-with-docs` / `to-spec` / `to-tickets` / `tdd` / `improve-codebase-architecture` / `code-review` / `implement` ほか。

## How
各端末で `make claude-setup`（`setup-claude.sh`）を実行すると、`plugins.txt` からユーザースコープでインストールされる。
導入後、各リポジトリで一度だけ `/setup-matt-pocock-skills` を実行し、issueトラッカー・triageラベル・docs保存先を設定する。

## Risk
- 読み取り専用の管理型プラグインのため既存設定を汚さない。低リスク。
- JSON妥当性（`jq empty`）・`shellcheck` ともにパス済み。
- 既存プラグイン/マーケットプレイスとの名前衝突なし。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added the Matt Pocock Skills marketplace and Claude Code plugin.
  * Included setup guidance to run `/setup-matt-pocock-skills` once per repository after installation.
  * Added fallback marketplace support for environments without marketplace metadata.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->