### PR TITLE
chore(nix): Typeless（AI音声ディクテーション）を Homebrew cask で追加

### DIFF
--- a/nix/modules/homebrew.nix
+++ b/nix/modules/homebrew.nix
@@ -72,6 +72,7 @@
       "chatgpt"
       "claude"
       "cmux"
+      "typeless" # AI voice dictation
 
       # Browsers
       "arc"


### PR DESCRIPTION
## Why
Typeless（AI voice dictation）を Nix 管理下で導入したい。標準の Homebrew cask（`typeless`, Typeless.app, macOS>=11, auto_updates）として提供されているため、手動インストールではなく nix-darwin の homebrew モジュールで宣言的に管理する。

## What
- `nix/modules/homebrew.nix` の casks（AI Tools）に `"typeless"` を追加（1行）

## How（検証）
- `darwin-rebuild build --flake ./nix#keitonoMacBook-Pro` → 成功（BUILD_EXIT=0）
- `jest test/nix-darwin-config.test.js` → 16 passed
- `nixfmt` 整形済み

## Note
`darwin-rebuild switch` 実行時に `brew install --cask typeless` が走り Typeless.app が入る。