### PR TITLE
chore: 共有Claude設定を全CLAUDE_CONFIG_DIRへ同期する

### DIFF
--- a/script/setup-claude.sh
+++ b/script/setup-claude.sh
@@ -31,6 +31,12 @@ KNOWN_MARKETPLACES="${PLUGINS_DIR}/known_marketplaces.json"
 REPO_PLUGINS_DIR="${REPO_ROOT}/.claude/plugins"
 SETTINGS_LOCAL_FILE="${CLAUDE_DIR}/settings.local.json"
 DEFAULT_SETTINGS_LOCAL="${REPO_ROOT}/.devcontainer/claude-settings.local.json"
+SETTINGS_FILE="${CLAUDE_DIR}/settings.json"
+
+# 複数の CLAUDE_CONFIG_DIR に共有設定を配るためのキー。
+# ここに無いキー（model / theme / tui 等）は各 dir 固有として保持される。
+# shellcheck disable=SC2016  # jq に渡すJSONリテラル。$schema はシェル変数ではない
+CLAUDE_SHARED_SETTINGS_KEYS='["$schema","hooks","permissions","enabledPlugins","extraKnownMarketplaces","attribution"]'
 
 # settings.local.json のセットアップ
 # ホストに settings.local.json がない場合、デフォルトをコピー
@@ -52,6 +58,78 @@ setup_settings_local() {
     fi
 }
 
+# 追加の CLAUDE_CONFIG_DIR を列挙する
+# Agent Deck の config.toml が group ごとに config_dir を切り替えるため、
+# ~/.claude 以外の dir が存在しうる（例: ~/.claude-private, ~/.claude-elu）。
+# CLAUDE_EXTRA_CONFIG_DIRS で明示指定も可能（スペース区切り）。
+list_extra_config_dirs() {
+    if [[ -n "${CLAUDE_EXTRA_CONFIG_DIRS:-}" ]]; then
+        local -a explicit_dirs
+        read -r -a explicit_dirs <<< "$CLAUDE_EXTRA_CONFIG_DIRS"
+        printf '%s\n' "${explicit_dirs[@]}"
+        return
+    fi
+    local dir
+    for dir in "${HOME}"/.claude-*; do
+        [[ -d "$dir" ]] || continue
+        printf '%s\n' "$dir"
+    done
+}
+
+# 共有設定を追加の CLAUDE_CONFIG_DIR に同期する
+#
+# なぜ必要か: settings.json は CLAUDE_CONFIG_DIR ごとに独立しており、
+# ~/.claude の hooks / permissions / plugins は他の dir では一切読まれない。
+# 2026-07-15 時点で ~/.claude-private は hooks 1個・~/.claude-elu は 0個と、
+# Quality Gates も permissions も attribution も効かない状態になっていた。
+sync_settings_to_extra_config_dirs() {
+    if [[ ! -f "$SETTINGS_FILE" ]]; then
+        log_warn "正本の settings.json が見つかりません: ${SETTINGS_FILE}（同期をスキップ）"
+        return
+    fi
+    if ! command -v jq &> /dev/null; then
+        log_warn "jq が見つかりません。追加 config dir への設定同期をスキップします"
+        return
+    fi
+
+    local target_dir target_file tmp_file
+    while IFS= read -r target_dir; do
+        [[ -n "$target_dir" ]] || continue
+        target_file="${target_dir}/settings.json"
+
+        if [[ -e "$target_file" ]] && ! jq -e . "$target_file" > /dev/null 2>&1; then
+            log_warn "  ${target_file} が不正なJSONのためスキップします"
+            continue
+        fi
+
+        tmp_file="$(mktemp)"
+        if ! jq --argjson keys "$CLAUDE_SHARED_SETTINGS_KEYS" \
+            'with_entries(select(.key as $k | $keys | index($k)))' \
+            "$SETTINGS_FILE" > "$tmp_file" 2>/dev/null; then
+            log_warn "  共有設定の抽出に失敗しました: ${SETTINGS_FILE}"
+            rm -f "$tmp_file"
+            continue
+        fi
+
+        local merged_file
+        merged_file="$(mktemp)"
+        if jq -s '(.[0] // {}) + .[1]' \
+            <(if [[ -f "$target_file" ]]; then cat "$target_file"; else echo '{}'; fi) \
+            "$tmp_file" > "$merged_file" 2>/dev/null && jq -e . "$merged_file" > /dev/null 2>&1; then
+            if [[ -f "$target_file" ]] && cmp -s "$target_file" "$merged_file"; then
+                log_info "  ${target_dir} は最新です"
+            else
+                mkdir -p "$target_dir"
+                cp "$merged_file" "$target_file"
+                log_success "  ${target_dir} に共有設定を同期しました"
+            fi
+        else
+            log_warn "  ${target_file} のマージに失敗しました"
+        fi
+        rm -f "$tmp_file" "$merged_file"
+    done < <(list_extra_config_dirs)
+}
+
 main() {
     log_info "Claude Code セットアップを開始します..."
     log_info "環境: HOME=${HOME}"
@@ -69,6 +147,10 @@ main() {
 
     # settings.local.json のセットアップ
     setup_settings_local
+
+    # 追加の CLAUDE_CONFIG_DIR（~/.claude-private 等）へ共有設定を同期
+    log_info "追加の CLAUDE_CONFIG_DIR に共有設定を同期します..."
+    sync_settings_to_extra_config_dirs
 
     # Claude CLI の存在確認
     if ! command -v claude &> /dev/null; then


### PR DESCRIPTION
Closes #976

## 背景

`settings.json` は `CLAUDE_CONFIG_DIR` ごとに独立しており、`~/.claude` の hooks / permissions / plugins は他の config dir では一切読まれない。Agent Deck が group ごとに config dir を振り分けている（common/n8n/private → `~/.claude-private`、elu → `~/.claude-elu`）ため、大半のセッションで **Quality Gates も permissions の deny も attribution も効いていなかった**。

実測（2026-07-15・メインMac）:

```
~/.claude          hooks=29
~/.claude-private  hooks=1   ← model のみ
~/.claude-elu      hooks=0   ← theme/tui のみ
```

## 変更内容

`script/setup-claude.sh` に `sync_settings_to_extra_config_dirs()` を追加し、`main()` の設定セットアップ直後に実行する。

- `~/.claude/settings.json` の**共有キーのみ**を他の config dir へマージ
  - 共有：`$schema` / `hooks` / `permissions` / `enabledPlugins` / `extraKnownMarketplaces` / `attribution`
  - 保持：`model` / `theme` / `tui` 等の dir 固有キーはそのまま
- 対象 dir は `~/.claude-*` を自動検出（`CLAUDE_EXTRA_CONFIG_DIRS` で明示指定も可）
- **冪等**：差分がなければ書き込まない
- **安全側**：既存ファイルが不正JSONなら上書きせずスキップ。`jq` 不在・正本不在は警告のみで続行
- DevContainer は対象 dir が存在しないため no-op

手動コピーではなく配布スクリプトに寄せているのは、2系統に分かれた設定が必ずドリフトするため。

## 検証

隔離した偽 HOME で実施：

- 共有キーが private/elu に入り、`model`（opus[1m]）・`theme`（light）・`tui`（fullscreen）は保持されることを確認
- 2回目の実行で「最新です」となり書き込みが発生しないこと（冪等）を確認
- 対象ファイルを `not json` に壊した状態で実行し、上書きされずスキップされることを確認
- `shellcheck -S warning` クリーン（exit 0）

メインMacへの適用も実施済みで、3 dir すべてが hooks=29 / permissions.deny あり / attribution あり になることを実機で確認。SessionStart の人生システムメモリ注入フックが維持されることも確認済み。

## レビュー観点

- 共有キーの選定（`model` を共有に含めるべきか。現状 `~/.claude-elu` は model 未設定のまま）
- agent-deck / StreamDeck 連携フックも一律配布しているが、private/elu で二重発火などの副作用がないか

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added automatic synchronization of selected Claude settings—such as model, theme, and TUI preferences—across additional configuration directories.
  * Preserves directory-specific settings by merging only approved shared preferences.
  * Safely skips synchronization when configuration files are unavailable, invalid, or cannot be processed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->