### PR TITLE
feat: commands/agents/skills を全 CLAUDE_CONFIG_DIR にリンクする

### DIFF
--- a/script/setup-claude.sh
+++ b/script/setup-claude.sh
@@ -38,6 +38,10 @@ SETTINGS_FILE="${CLAUDE_DIR}/settings.json"
 # shellcheck disable=SC2016  # jq に渡すJSONリテラル。$schema はシェル変数ではない
 CLAUDE_SHARED_SETTINGS_KEYS='["$schema","hooks","permissions","enabledPlugins","extraKnownMarketplaces","attribution"]'
 
+# 追加の CLAUDE_CONFIG_DIR に ~/.claude からリンクするコンテンツ。
+# hooks は settings.json 側がプロジェクト相対 (.claude/hooks/...) で解決するため対象外。
+CLAUDE_LINKED_CONTENT_DIRS=(commands agents skills)
+
 # settings.local.json のセットアップ
 # ホストに settings.local.json がない場合、デフォルトをコピー
 setup_settings_local() {
@@ -130,6 +134,51 @@ sync_settings_to_extra_config_dirs() {
     done < <(list_extra_config_dirs)
 }
 
+# commands / agents / skills を追加の CLAUDE_CONFIG_DIR にシンボリックリンクする
+#
+# なぜコピーではなくリンクか: これらは dir ごとに差分を持つ理由が現状なく、
+# コピーだと make claude-setup を忘れた端末で静かにドリフトする。
+# リンクなら ~/.claude に置いた時点で全 dir に反映され、ドリフトが原理的に起きない。
+#
+# なぜリポジトリからではなく ~/.claude から配るか: keito4/config は public のため
+# 個人情報を含むコマンド（例: 個人 Notion の ID を持つ /session-close）は追跡できない。
+# 正本を ~/.claude に置く方針は settings.json の同期（#977）と同じ。
+link_content_to_extra_config_dirs() {
+    local target_dir name source_path target_path
+    while IFS= read -r target_dir; do
+        [[ -n "$target_dir" ]] || continue
+
+        for name in "${CLAUDE_LINKED_CONTENT_DIRS[@]}"; do
+            source_path="${CLAUDE_DIR}/${name}"
+            target_path="${target_dir}/${name}"
+
+            if [[ ! -e "$source_path" ]]; then
+                log_info "  ${source_path} が無いため ${name} のリンクをスキップします"
+                continue
+            fi
+
+            if [[ -L "$target_path" ]]; then
+                if [[ "$(readlink "$target_path")" == "$source_path" ]]; then
+                    log_info "  ${target_path} は最新です"
+                    continue
+                fi
+                rm -f "$target_path"
+            elif [[ -e "$target_path" ]]; then
+                # 実体があるものを消すと中身を失う。手動退避を促して触らない。
+                log_warn "  ${target_path} は実体のためスキップします（退避してから再実行してください）"
+                continue
+            fi
+
+            mkdir -p "$target_dir"
+            if ln -s "$source_path" "$target_path"; then
+                log_success "  ${target_path} -> ${source_path} をリンクしました"
+            else
+                log_warn "  ${target_path} のリンクに失敗しました"
+            fi
+        done
+    done < <(list_extra_config_dirs)
+}
+
 main() {
     log_info "Claude Code セットアップを開始します..."
     log_info "環境: HOME=${HOME}"
@@ -151,6 +200,11 @@ main() {
     # 追加の CLAUDE_CONFIG_DIR（~/.claude-private 等）へ共有設定を同期
     log_info "追加の CLAUDE_CONFIG_DIR に共有設定を同期します..."
     sync_settings_to_extra_config_dirs
+
+    # commands / agents / skills を追加の CLAUDE_CONFIG_DIR にリンク
+    # claude CLI の有無に依存しないため、CLI チェックより前に実行する
+    log_info "追加の CLAUDE_CONFIG_DIR に commands/agents/skills をリンクします..."
+    link_content_to_extra_config_dirs
 
     # Claude CLI の存在確認
     if ! command -v claude &> /dev/null; then

--- a/test/integration/setup_claude.bats
+++ b/test/integration/setup_claude.bats
@@ -89,3 +89,97 @@ load ../test_helper/test_helper
   grep -q 'if \[\[ ! -f' "${REPO_ROOT}/script/setup-claude.sh"
   grep -q 'log_warn' "${REPO_ROOT}/script/setup-claude.sh"
 }
+
+# ---------------------------------------------------------------------------
+# commands / agents / skills の追加 CLAUDE_CONFIG_DIR へのリンク
+# 実際にスクリプトを偽 HOME で起動し、リンクが張られたかを検証する
+# ---------------------------------------------------------------------------
+
+# 偽 HOME を用意して setup-claude.sh を実行する
+# claude CLI はスタブに差し替え、プラグイン導入で外部に触れないようにする
+run_setup_in_fake_home() {
+  local fake_home="$1"
+  mkdir -p "${fake_home}/.claude" "${fake_home}/.stub-bin"
+  cat > "${fake_home}/.stub-bin/claude" <<'STUB'
+#!/usr/bin/env bash
+exit 0
+STUB
+  chmod +x "${fake_home}/.stub-bin/claude"
+
+  HOME="$fake_home" \
+  PATH="${fake_home}/.stub-bin:${PATH}" \
+    run bash "${REPO_ROOT}/script/setup-claude.sh"
+}
+
+@test "setup-claude.sh links commands/agents/skills into extra config dirs" {
+  local fake_home="${TEST_TEMP_DIR}/home"
+  mkdir -p "${fake_home}/.claude"/{commands,agents,skills} "${fake_home}/.claude-private"
+  echo "canonical" > "${fake_home}/.claude/commands/session-close.md"
+
+  run_setup_in_fake_home "$fake_home"
+
+  local name
+  for name in commands agents skills; do
+    [ -L "${fake_home}/.claude-private/${name}" ]
+    [ "$(readlink "${fake_home}/.claude-private/${name}")" = "${fake_home}/.claude/${name}" ]
+  done
+
+  # リンク越しに正本のファイルが読めること（宣言ではなく実体で確認）
+  [ "$(cat "${fake_home}/.claude-private/commands/session-close.md")" = "canonical" ]
+}
+
+@test "setup-claude.sh links content into every extra config dir" {
+  local fake_home="${TEST_TEMP_DIR}/home"
+  mkdir -p "${fake_home}/.claude/commands" "${fake_home}/.claude-private" "${fake_home}/.claude-elu"
+
+  run_setup_in_fake_home "$fake_home"
+
+  [ -L "${fake_home}/.claude-private/commands" ]
+  [ -L "${fake_home}/.claude-elu/commands" ]
+}
+
+@test "setup-claude.sh content linking is idempotent" {
+  local fake_home="${TEST_TEMP_DIR}/home"
+  mkdir -p "${fake_home}/.claude/commands" "${fake_home}/.claude-private"
+
+  run_setup_in_fake_home "$fake_home"
+  [ -L "${fake_home}/.claude-private/commands" ]
+
+  run_setup_in_fake_home "$fake_home"
+  [ "$status" -eq 0 ]
+  [ -L "${fake_home}/.claude-private/commands" ]
+  [ "$(readlink "${fake_home}/.claude-private/commands")" = "${fake_home}/.claude/commands" ]
+}
+
+@test "setup-claude.sh does not clobber an existing real directory" {
+  local fake_home="${TEST_TEMP_DIR}/home"
+  mkdir -p "${fake_home}/.claude/commands" "${fake_home}/.claude-private/commands"
+  echo "dir-specific" > "${fake_home}/.claude-private/commands/local-only.md"
+
+  run_setup_in_fake_home "$fake_home"
+
+  # 実体ディレクトリは温存され、中身が消えていないこと
+  [ ! -L "${fake_home}/.claude-private/commands" ]
+  [ "$(cat "${fake_home}/.claude-private/commands/local-only.md")" = "dir-specific" ]
+}
+
+@test "setup-claude.sh replaces a symlink that points elsewhere" {
+  local fake_home="${TEST_TEMP_DIR}/home"
+  mkdir -p "${fake_home}/.claude/commands" "${fake_home}/.claude-private" "${fake_home}/stale"
+  ln -s "${fake_home}/stale" "${fake_home}/.claude-private/commands"
+
+  run_setup_in_fake_home "$fake_home"
+
+  [ "$(readlink "${fake_home}/.claude-private/commands")" = "${fake_home}/.claude/commands" ]
+}
+
+@test "setup-claude.sh skips content missing from the canonical dir" {
+  local fake_home="${TEST_TEMP_DIR}/home"
+  mkdir -p "${fake_home}/.claude/commands" "${fake_home}/.claude-private"
+
+  run_setup_in_fake_home "$fake_home"
+
+  # ~/.claude に skills が無いなら壊れたリンクを作らない
+  [ ! -e "${fake_home}/.claude-private/skills" ]
+  [ ! -L "${fake_home}/.claude-private/skills" ]
+}


### PR DESCRIPTION
Closes #981

## 背景

#977 で settings.json は全 `CLAUDE_CONFIG_DIR` に配られるようになったが、コンテンツ側は `~/.claude` にしか配られていなかった。実測で `~/.claude-private` / `~/.claude-elu` は commands / agents / skills が **0件（ディレクトリ自体が存在しない）**。private セッションでは `/session-close` を含む全スラッシュコマンドが使えない状態だった。

## 設計判断

| 判断 | 理由 |
| --- | --- |
| 正本は **リポジトリではなく `~/.claude`** | keito4/config は public。個人の Notion ID を含む `/session-close` は追跡できない。#977 と同じ思想 |
| **コピーではなくシンボリックリンク** | dir 固有の差分を持つ理由が現状ない。コピーは `make claude-setup` を忘れた端末で静かにドリフトする |
| **hooks は対象外** | settings.json 側がプロジェクト相対（`.claude/hooks/...`）で解決するため、config_dir 側に hooks は要らない |
| 実体ディレクトリは**触らず警告** | リンクに置き換えると中身を失うため |
| CLI チェック**より前**に実行 | リンクは claude CLI に依存しない |

## テスト

既存の bats は grep ベースで「リンクが実際に張られたか」を証明できないため、**偽 HOME で実際に `setup-claude.sh` を起動する**振る舞いテストを 6 件追加した。

- リンクが張られ、**リンク越しに正本のファイルが読める**こと
- 複数 dir（private / elu）すべてに張られること
- 冪等（2回目でも壊れない）
- 実体ディレクトリを潰さない（中身が残る）
- 別を指す古いリンクは張り替える
- 正本に無いものは壊れたリンクを作らない

実装を無効化して 4 件が赤くなることを確認済み（20・22 は破壊を防ぐ回帰ガードのため実装無しでも緑が正しい）。

`npm run shellcheck` 通過。

## マージ後

各端末で `make claude-setup` が必要。その後 private セッションを**新規起動**して `/session-close` が見えることを確認する。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Setup now shares commands, agents, and skills across additional Claude configuration directories.
  - Shared content remains accessible through automatic links to the primary configuration.
  - Linking runs even when the Claude CLI is not installed.

- **Bug Fixes**
  - Existing real directories are preserved safely.
  - Outdated links are corrected, while missing source directories do not create broken links.
  - Repeated setup runs remain safe and consistent.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->