### PR TITLE
feat: private-config の個人スキルを ~/.claude/skills に展開する導線を追加

### DIFF
--- a/script/setup-claude.sh
+++ b/script/setup-claude.sh
@@ -33,6 +33,10 @@ SETTINGS_LOCAL_FILE="${CLAUDE_DIR}/settings.local.json"
 DEFAULT_SETTINGS_LOCAL="${REPO_ROOT}/.devcontainer/claude-settings.local.json"
 SETTINGS_FILE="${CLAUDE_DIR}/settings.json"
 
+# 個人/組織情報を含むスキルの正本を置く非公開リポジトリ。
+# 端末ごとにパスが変わりうるため上書き可能にする。
+PRIVATE_CONFIG_DIR="${PRIVATE_CONFIG_DIR:-${HOME}/develop/github.com/keito4/private-config}"
+
 # 複数の CLAUDE_CONFIG_DIR に共有設定を配るためのキー。
 # ここに無いキー（model / theme / tui 等）は各 dir 固有として保持される。
 # shellcheck disable=SC2016  # jq に渡すJSONリテラル。$schema はシェル変数ではない
@@ -179,6 +183,48 @@ link_content_to_extra_config_dirs() {
     done < <(list_extra_config_dirs)
 }
 
+# private-config の個人スキルを ~/.claude/skills/<name>/SKILL.md として展開する。
+#
+# なぜ必要か: 組織メンバーのメール・Slack ID・内部 Notion ID を含むスキル（例 oykot-tasks）は
+# public な keito4/config には置けず、keito4/private-config が正本になる。setup-claude.sh は
+# これまで public リポジトリ→~/.claude しか同期しなかったため、private-config のスキルは
+# 新端末で materialize されず、OYKOT 作業の config-dir（既定=~/.claude）で呼べなかった。
+#
+# なぜ symlink か: private-config を正本にドリフトなく反映するため（settings 同期 #977 と同方針）。
+# Claude Code はスキルを <name>/SKILL.md ディレクトリ形式で読むので、フラットな
+# private-config/.claude/skills/<name>.md を <name>/SKILL.md にリンクする。private-config が
+# 正本であるため、既存の実体コピーや古いリンクは置き換える（追加 config-dir のケースと異なり
+# ここでは正本が明確なのでドリフト除去を優先する）。
+link_private_skills() {
+    local src_dir="${PRIVATE_CONFIG_DIR}/.claude/skills"
+    if [[ ! -d "$src_dir" ]]; then
+        log_info "private-config のスキルが見つからないためスキップします (${src_dir})"
+        return
+    fi
+
+    local skills_dir="${CLAUDE_DIR}/skills"
+    local md name target
+    shopt -s nullglob
+    for md in "$src_dir"/*.md; do
+        name="$(basename "$md" .md)"
+        target="${skills_dir}/${name}/SKILL.md"
+
+        if [[ -L "$target" ]] && [[ "$(readlink "$target")" == "$md" ]]; then
+            log_info "  スキル ${name} は最新です"
+            continue
+        fi
+
+        mkdir -p "${skills_dir}/${name}"
+        rm -f "$target"
+        if ln -s "$md" "$target"; then
+            log_success "  スキル ${name} -> ${md} をリンクしました"
+        else
+            log_warn "  スキル ${name} のリンクに失敗しました"
+        fi
+    done
+    shopt -u nullglob
+}
+
 main() {
     log_info "Claude Code セットアップを開始します..."
     log_info "環境: HOME=${HOME}"
@@ -200,6 +246,10 @@ main() {
     # 追加の CLAUDE_CONFIG_DIR（~/.claude-private 等）へ共有設定を同期
     log_info "追加の CLAUDE_CONFIG_DIR に共有設定を同期します..."
     sync_settings_to_extra_config_dirs
+
+    # private-config の個人スキルを ~/.claude/skills に展開（extra dir へのリンク前に実行）
+    log_info "private-config の個人スキルを ~/.claude/skills に展開します..."
+    link_private_skills
 
     # commands / agents / skills を追加の CLAUDE_CONFIG_DIR にリンク
     # claude CLI の有無に依存しないため、CLI チェックより前に実行する

--- a/test/integration/setup_claude.bats
+++ b/test/integration/setup_claude.bats
@@ -106,8 +106,11 @@ exit 0
 STUB
   chmod +x "${fake_home}/.stub-bin/claude"
 
+  # 既定では実在の private-config に触れないよう、存在しないパスへ向ける。
+  # 個別テストは PRIVATE_CONFIG_DIR を設定して上書きできる。
   HOME="$fake_home" \
   PATH="${fake_home}/.stub-bin:${PATH}" \
+  PRIVATE_CONFIG_DIR="${PRIVATE_CONFIG_DIR:-${fake_home}/no-private-config}" \
     run bash "${REPO_ROOT}/script/setup-claude.sh"
 }
 
@@ -182,4 +185,46 @@ STUB
   # ~/.claude に skills が無いなら壊れたリンクを作らない
   [ ! -e "${fake_home}/.claude-private/skills" ]
   [ ! -L "${fake_home}/.claude-private/skills" ]
+}
+
+# ---------------------------------------------------------------------------
+# private-config の個人スキルを ~/.claude/skills/<name>/SKILL.md に展開する
+# ---------------------------------------------------------------------------
+
+@test "setup-claude.sh materializes private-config skills as SKILL.md symlinks" {
+  local fake_home="${TEST_TEMP_DIR}/home"
+  local private="${TEST_TEMP_DIR}/private-config"
+  mkdir -p "${fake_home}/.claude" "${private}/.claude/skills"
+  printf -- '---\nname: oykot-tasks\n---\nbody\n' > "${private}/.claude/skills/oykot-tasks.md"
+
+  PRIVATE_CONFIG_DIR="$private" run_setup_in_fake_home "$fake_home"
+
+  # <name>/SKILL.md が正本ファイルへの symlink になっていること
+  [ -L "${fake_home}/.claude/skills/oykot-tasks/SKILL.md" ]
+  [ "$(readlink "${fake_home}/.claude/skills/oykot-tasks/SKILL.md")" = "${private}/.claude/skills/oykot-tasks.md" ]
+  # リンク越しに正本の内容が読めること（宣言ではなく実体で確認）
+  [ "$(cat "${fake_home}/.claude/skills/oykot-tasks/SKILL.md")" = "$(cat "${private}/.claude/skills/oykot-tasks.md")" ]
+}
+
+@test "setup-claude.sh replaces an existing real SKILL.md copy with a symlink to private-config" {
+  local fake_home="${TEST_TEMP_DIR}/home"
+  local private="${TEST_TEMP_DIR}/private-config"
+  mkdir -p "${fake_home}/.claude/skills/oykot-tasks" "${private}/.claude/skills"
+  echo "canonical" > "${private}/.claude/skills/oykot-tasks.md"
+  echo "stale copy" > "${fake_home}/.claude/skills/oykot-tasks/SKILL.md"
+
+  PRIVATE_CONFIG_DIR="$private" run_setup_in_fake_home "$fake_home"
+
+  [ -L "${fake_home}/.claude/skills/oykot-tasks/SKILL.md" ]
+  [ "$(cat "${fake_home}/.claude/skills/oykot-tasks/SKILL.md")" = "canonical" ]
+}
+
+@test "setup-claude.sh skips private skills when private-config is absent" {
+  local fake_home="${TEST_TEMP_DIR}/home"
+  mkdir -p "${fake_home}/.claude"
+
+  PRIVATE_CONFIG_DIR="${TEST_TEMP_DIR}/does-not-exist" run_setup_in_fake_home "$fake_home"
+
+  [ "$status" -eq 0 ]
+  [ ! -e "${fake_home}/.claude/skills/oykot-tasks" ]
 }


### PR DESCRIPTION
## Why

組織メンバーのメール・Slack ID・内部 Notion ID を含むスキル（例 `oykot-tasks`）は public な keito4/config には置けず、`keito4/private-config` が正本になる。しかし `setup-claude.sh` は public リポジトリ→`~/.claude` しか同期しないため、private-config のスキルが**新端末で materialize されず**、OYKOT 作業の config-dir（既定=`~/.claude`）でスキルとして呼べなかった。

## What

- `link_private_skills()` を `setup-claude.sh` に追加。`private-config/.claude/skills/<name>.md` を `~/.claude/skills/<name>/SKILL.md` へ **symlink**（Claude Code のスキル形式に合わせる）。
- private-config が正本のため既存の実体コピー/古いリンクは置換（ドリフト防止、settings 同期 #977 と同方針）。
- `PRIVATE_CONFIG_DIR` 環境変数で場所を上書き可能（端末差・CI 対応）。
- bats テスト3件追加（materialize / 実体コピー置換 / private-config 不在時スキップ）。

## How to verify

```
make claude-setup   # または PRIVATE_CONFIG_DIR=... ./script/setup-claude.sh
ls -la ~/.claude/skills/oykot-tasks/SKILL.md   # -> private-config を指す symlink
```

実機で `oykot-tasks` が private-config を指す symlink になることを確認済み。

## Risk

- 低。private-config 不在時は skip（既存挙動不変）。既存 bats 22件＋新規3件すべて green。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for loading private Claude skills from a configurable location.
  * Private skills are automatically linked into the local Claude skills directory.
  * Existing skill files are replaced with updated links, while missing private configurations are safely skipped.

* **Tests**
  * Added coverage for private skill linking, replacement behavior, and absent configuration paths.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->