### PR TITLE
feat: 新規マシンでも nix-darwin セットアップが通るようにする

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -366,7 +366,8 @@
     "sentry@claude-plugins-official": true,
     "postgres-best-practices@supabase-agent-skills": true,
     "agent-browser@agent-browser": true,
-    "context7@intellectronica-skills": true
+    "context7@intellectronica-skills": true,
+    "mattpocock-skills@mattpocock": true
   },
   "extraKnownMarketplaces": {
     "claude-plugins-official": {
@@ -397,6 +398,12 @@
       "source": {
         "source": "git",
         "url": "https://github.com/supabase/agent-skills.git"
+      }
+    },
+    "mattpocock": {
+      "source": {
+        "source": "git",
+        "url": "https://github.com/mattpocock/skills.git"
       }
     }
   }

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,6 +13,8 @@ on:
       - '**.yaml'
       - '**.sh'
       - '**.bats'
+      - '**.nix'
+      - 'nix/**'
       - '.github/actions/**'
       - '.github/workflows/**'
       - '.github/actionlint.yaml'
@@ -33,6 +35,8 @@ on:
       - '**.yaml'
       - '**.sh'
       - '**.bats'
+      - '**.nix'
+      - 'nix/**'
       - '.github/actions/**'
       - '.github/workflows/**'
       - '.github/actionlint.yaml'
@@ -62,6 +66,7 @@ jobs:
       scripts: ${{ steps.filter.outputs.scripts }}
       workflows: ${{ steps.filter.outputs.workflows }}
       dependencies: ${{ steps.filter.outputs.dependencies }}
+      nix: ${{ steps.filter.outputs.nix }}
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
@@ -92,6 +97,9 @@ jobs:
             dependencies:
               - 'package.json'
               - 'package-lock.json'
+            nix:
+              - '**.nix'
+              - 'nix/**'
 
   lint:
     name: Lint & Format
@@ -258,6 +266,29 @@ jobs:
       - name: Check workflow templates match actual workflows
         run: npm run workflow:sync:check
 
+  nix-eval:
+    name: Nix Config Eval
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    needs: changes
+    if: needs.changes.outputs.nix == 'true'
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+
+      - name: Install Nix
+        uses: DeterminateSystems/nix-installer-action@ef8a148080ab6020fd15196c2084a2eea5ff2d25 # v22
+
+      # 評価はプラットフォーム非依存なので Linux ランナーで aarch64-darwin の
+      # darwinConfigurations を検証できる（ビルドはしない）
+      - name: Evaluate darwin configurations
+        working-directory: nix
+        run: |
+          for host in keitonoMacBook-Pro oykotnoMacBook-Air; do
+            echo "Evaluating darwinConfigurations.${host}..."
+            nix eval --raw ".#darwinConfigurations.\"${host}\".system.drvPath"
+            echo
+          done
+
   pr-size-check:
     name: PR Size Check
     runs-on: ubuntu-latest
@@ -281,7 +312,7 @@ jobs:
     name: Quality Gate
     runs-on: ubuntu-latest
     timeout-minutes: 5
-    needs: [changes, lint, test, integration-test, actionlint, workflow-template-sync]
+    needs: [changes, lint, test, integration-test, actionlint, workflow-template-sync, nix-eval]
     if: always()
     steps:
       - name: Check job results
@@ -291,6 +322,7 @@ jobs:
           INTEGRATION_RESULT: ${{ needs.integration-test.result }}
           ACTIONLINT_RESULT: ${{ needs.actionlint.result }}
           WORKFLOW_TEMPLATE_SYNC_RESULT: ${{ needs.workflow-template-sync.result }}
+          NIX_EVAL_RESULT: ${{ needs.nix-eval.result }}
         run: |
           echo "## Quality Gate Results" >> $GITHUB_STEP_SUMMARY
           echo "" >> $GITHUB_STEP_SUMMARY
@@ -301,6 +333,7 @@ jobs:
           echo "| Integration Tests | $INTEGRATION_RESULT |" >> $GITHUB_STEP_SUMMARY
           echo "| Workflow Lint | $ACTIONLINT_RESULT |" >> $GITHUB_STEP_SUMMARY
           echo "| Workflow Template Sync | $WORKFLOW_TEMPLATE_SYNC_RESULT |" >> $GITHUB_STEP_SUMMARY
+          echo "| Nix Config Eval | $NIX_EVAL_RESULT |" >> $GITHUB_STEP_SUMMARY
 
       - name: Verify all checks passed
         env:
@@ -309,6 +342,7 @@ jobs:
           INTEGRATION_RESULT: ${{ needs.integration-test.result }}
           ACTIONLINT_RESULT: ${{ needs.actionlint.result }}
           WORKFLOW_TEMPLATE_SYNC_RESULT: ${{ needs.workflow-template-sync.result }}
+          NIX_EVAL_RESULT: ${{ needs.nix-eval.result }}
         run: |
           # skipped は成功扱い（該当ファイルの変更がない場合）
           function check_result() {
@@ -335,6 +369,10 @@ jobs:
           fi
           if ! check_result "$WORKFLOW_TEMPLATE_SYNC_RESULT"; then
             echo "::error::Workflow Template Sync failed"
+            FAILED=true
+          fi
+          if ! check_result "$NIX_EVAL_RESULT"; then
+            echo "::error::Nix Config Eval failed"
             FAILED=true
           fi
 

--- a/.zsh/configs/pre/path.zsh
+++ b/.zsh/configs/pre/path.zsh
@@ -5,6 +5,9 @@ PATH="/opt/homebrew/bin:$PATH"
 # ensure dotfiles bin directory is loaded first
 PATH="$HOME/.bin:/usr/local/sbin:$PATH"
 
+# claude / codex などのネイティブインストーラーは ~/.local/bin に入れる
+PATH="$HOME/.local/bin:$PATH"
+
 # mkdir .git/safe in the root of repositories you trust
 PATH=".git/safe/../../bin:$PATH"
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -123,7 +123,7 @@ Development infrastructure template repository providing DevContainer images, CI
 | `ci-check`               | PR作成後にCIの結果を確認し、失敗している場合は修正する。PR作成完了後に自動的にこのスキルを適用してCIの状態を監視し、失敗時は修正を行うこと。                      |
 | `codex-review`           | PR作成後にOpenAI Codexによるコードレビューを実行する。Codex CLIがインストール済みの場合、PR作成完了後に自動的にこのスキルを適用してレビューを実行すること。       |
 | `gemini-review`          | PR作成後にGoogle Gemini CLIによるコードレビューを実行する。Gemini CLIがインストール済みの場合、PR作成完了後に自動的にこのスキルを適用してレビューを実行すること。 |
-| `n8n-workflow-pr-review` | keito4-org/n8n_custom_node の n8n ワークフロー/テンプレートPRをレビューする。ワークフロー同期PR（workflow-sync/\*）の退行判定、資格情報のMAS...                   |
+| `n8n-workflow-pr-review` | keito4-org/n8n_custom_node の n8n ワークフロー/テンプレートPRをレビューする。ワークフロー同期PR（workflow-sync/*）の退行判定、資格情報のMAS...                    |
 
 ## CI/CD Workflows
 
@@ -149,12 +149,12 @@ Development infrastructure template repository providing DevContainer images, CI
 
 The following scripts are auto-detected and run before git commit/push:
 
-| Script | Command | Purpose |
-| ----------------------------------------------------------------------------------------------------------------------- | ---------------------------------- | -------------------------- | ----------------------- |
-| `format:check` | `prettier --check .` | Code formatting validation |
-| `lint` | `eslint . --ext .js` | Code quality validation |
-| `test` | `jest --runInBand` | Unit test execution |
-| `shellcheck` | `find script -name '\*.sh' -type f | xargs -r shellcheck -x` | Shell script validation |
+| Script                                                                                                                  | Command                           | Purpose                    |
+| ----------------------------------------------------------------------------------------------------------------------- | --------------------------------- | -------------------------- |
+| `format:check`                                                                                                          | `prettier --check .`              | Code formatting validation |
+| `lint`                                                                                                                  | `eslint . --ext .js`              | Code quality validation    |
+| `test`                                                                                                                  | `jest --runInBand`                | Unit test execution        |
+| `shellcheck`                                                                                                            | `find script -name '*.sh' -type f | xargs -r shellcheck -x`    | Shell script validation |
 | Additional test commands: `test:integration` (BATS), `test:coverage` (Jest + coverage), `test:all` (unit + integration) |
 
 ## Hooks

--- a/README.md
+++ b/README.md
@@ -65,6 +65,7 @@ Use the setup guides instead of copying snippets from this README:
 - [Mobile: Android](docs/setup/mobile-android.md)
 - [Mobile: Flutter](docs/setup/mobile-flutter.md)
 - [Windows](docs/setup/windows.md)
+- [macOS 新規マシン](docs/setup/macos.md)
 
 ## Security
 

--- a/docs/setup/README.md
+++ b/docs/setup/README.md
@@ -28,6 +28,7 @@
 | [mobile-android.md](./mobile-android.md)             | モバイル (Android)    |
 | [desktop-extension-ts.md](./desktop-extension-ts.md) | デスクトップ拡張 (TS) |
 | [windows.md](./windows.md)                           | Windows ネイティブ    |
+| [macos.md](./macos.md)                               | macOS 新規マシン      |
 
 ---
 

--- a/docs/setup/macos.md
+++ b/docs/setup/macos.md
@@ -1,0 +1,118 @@
+# macOS 新規マシンセットアップ
+
+新規 Mac (Apple Silicon) をこのリポジトリの nix-darwin 構成で立ち上げる手順。
+実際の新規マシンセットアップ (oykotnoMacBook-Air, 2026-07) で検証済み。
+
+## 前提
+
+- Apple Silicon Mac (`aarch64-darwin`)
+- 管理者権限のあるユーザー
+- `git` が使えること (初回 `git` 実行時に Xcode Command Line Tools が入る)
+
+## 1. リポジトリの取得
+
+ghq 階層に配置する (zsh エイリアスや private-config 参照がこのパスを前提とする)。
+
+```bash
+mkdir -p ~/develop/github.com/keito4
+git clone https://github.com/keito4/config.git ~/develop/github.com/keito4/config
+```
+
+## 2. Homebrew のインストール
+
+nix-darwin の homebrew モジュールは brew 本体がインストール済みであることを前提とする。
+
+```bash
+/bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"
+```
+
+サードパーティ tap の信頼設定 (Homebrew 6+) は activation 時に自動で行われる
+(`nix/modules/homebrew.nix` の preActivation)。
+
+## 3. Nix のインストール
+
+```bash
+curl -fsSL https://install.determinate.systems/nix | sh -s -- install
+```
+
+> **Note**: Determinate Nix を使う場合、nix-darwin の Nix 管理と衝突するため
+> flake のホスト定義で `determinateNix = true` を指定する (手順 5)。
+
+## 4. GUI 前提の準備
+
+- **App Store にサインイン**する (`masApps` の Xcode / LINE 等のインストールに必要)
+- **Kanary を手動インストール**する ([ADR 0016](../adr/0016-use-kanary-for-keyboard-remapping.md))。
+  <https://kanary.download/download> から ZIP を取得し、`Kanary.app` を
+  `/Applications` または `~/Applications` に配置する。無いと activation が
+  システムチェックで失敗する。
+
+## 5. flake にホストを追加
+
+`nix/flake.nix` の `darwinConfigurations` に新規マシンのエントリを追加する。
+
+```nix
+"<hostname>" = mkDarwin {
+  hostname = "<hostname>";   # scutil --get LocalHostName の値
+  username = "<username>";   # whoami の値
+  determinateNix = true;     # Determinate Nix の場合のみ
+};
+```
+
+## 6. 初回の darwin-rebuild
+
+初回は darwin-rebuild が未導入のため `nix run` で実行する。
+
+```bash
+sudo /nix/var/nix/profiles/default/bin/nix run nix-darwin/master#darwin-rebuild \
+  --extra-experimental-features "nix-command flakes" \
+  -- switch --flake ~/develop/github.com/keito4/config/nix
+```
+
+初回は Cask 群のインストールで時間がかかる。2 回目以降は `make nix-switch`
+(または zsh エイリアス `nix-switch`) で適用できる。
+
+## 7. Claude Code / エージェント設定
+
+```bash
+# Claude Code CLI (ネイティブインストーラー、~/.local/bin に配置)
+curl -fsSL https://claude.ai/install.sh | bash
+
+# private-config (dotfiles の symlink 先)
+gh repo clone keito4/private-config ~/develop/github.com/keito4/private-config
+
+# 設定同期 + プラグインインストール
+cd ~/develop/github.com/keito4/config
+make claude-setup
+```
+
+`.claude` / `.mcp.json` / codex / cursor / gemini の設定取り込みは
+`./script/import.sh` (または `script/lib/config.sh` の `config::import_*`) で行う。
+
+## 8. 個人設定
+
+```bash
+# Git の個人情報 (リポジトリ側は意図的に未設定)
+git config --global user.name "Your Name"
+git config --global user.email "your.email@example.com"
+
+# 1Password にサインインした後
+make credentials
+```
+
+## 9. 権限の許可 (GUI)
+
+初回起動時に macOS の許可が必要:
+
+- **Kanary**: Gatekeeper の確認、アクセシビリティ / 入力監視
+- **skhd**: アクセシビリティ (許可しないと IME ショートカットが動かない)
+- **Xcode**: 初回起動時のライセンス同意
+
+## トラブルシューティング
+
+| 症状                                                     | 原因 / 対処                                                                   |
+| -------------------------------------------------------- | ----------------------------------------------------------------------------- |
+| `error: Determinate detected, aborting activation`       | flake のホスト定義に `determinateNix = true` を指定する                       |
+| `error: Kanary.app is required for keyboard remapping.`  | 手順 4 の Kanary をインストールする                                           |
+| `Refusing to load formula ... from untrusted tap`        | preActivation が自動で `brew trust` する。手動なら `brew trust <tap>`         |
+| `typeset: -g: invalid option` でスクリプトやテストが失敗 | macOS 標準 bash 3.2 が原因。brew の `bash` (Brewfile 管理) が入っているか確認 |
+| `warning: $HOME ... is not owned by you`                 | sudo 実行時の無害な警告                                                       |

--- a/nix/flake.nix
+++ b/nix/flake.nix
@@ -24,29 +24,49 @@
     }:
     let
       system = "aarch64-darwin";
-      username = "keito";
-      hostname = "keitonoMacBook-Pro";
       configRoot = ../.;
+
+      mkDarwin =
+        {
+          hostname,
+          username,
+          # Determinate Nix はデーモンを自前管理するため nix-darwin の Nix 管理と衝突する
+          determinateNix ? false,
+        }:
+        nix-darwin.lib.darwinSystem {
+          inherit system;
+          specialArgs = {
+            inherit username determinateNix;
+          };
+          modules = [
+            ./hosts/darwin
+
+            home-manager.darwinModules.home-manager
+            {
+              home-manager = {
+                useGlobalPkgs = true;
+                useUserPackages = true;
+                backupFileExtension = "before-home-manager";
+                extraSpecialArgs = {
+                  inherit configRoot username;
+                };
+                users.${username} = import ./home;
+              };
+            }
+          ];
+        };
     in
     {
-      darwinConfigurations.${hostname} = nix-darwin.lib.darwinSystem {
-        inherit system;
-        modules = [
-          ./hosts/darwin
-
-          home-manager.darwinModules.home-manager
-          {
-            home-manager = {
-              useGlobalPkgs = true;
-              useUserPackages = true;
-              backupFileExtension = "before-home-manager";
-              extraSpecialArgs = {
-                inherit configRoot;
-              };
-              users.${username} = import ./home;
-            };
-          }
-        ];
+      darwinConfigurations = {
+        "keitonoMacBook-Pro" = mkDarwin {
+          hostname = "keitonoMacBook-Pro";
+          username = "keito";
+        };
+        "oykotnoMacBook-Air" = mkDarwin {
+          hostname = "oykotnoMacBook-Air";
+          username = "oykot";
+          determinateNix = true;
+        };
       };
 
       # nix fmt

--- a/nix/home/default.nix
+++ b/nix/home/default.nix
@@ -1,4 +1,9 @@
-{ pkgs, lib, ... }:
+{
+  pkgs,
+  lib,
+  username,
+  ...
+}:
 
 {
   imports = [
@@ -14,8 +19,8 @@
 
   home = {
     stateVersion = "24.11";
-    username = "keito";
-    homeDirectory = lib.mkForce "/Users/keito";
+    inherit username;
+    homeDirectory = lib.mkForce "/Users/${username}";
   };
 
   # Let home-manager manage itself

--- a/nix/home/dotfiles.nix
+++ b/nix/home/dotfiles.nix
@@ -8,7 +8,7 @@ let
   # 組織情報を含む設定は keito4/private-config（別リポジトリ・非公開）で管理し、
   # ローカルチェックアウトを out-of-store symlink で参照する（編集は rebuild 不要で即反映）
   privateConfig = path: {
-    source = config.lib.file.mkOutOfStoreSymlink "/Users/keito/develop/github.com/keito4/private-config/${path}";
+    source = config.lib.file.mkOutOfStoreSymlink "${config.home.homeDirectory}/develop/github.com/keito4/private-config/${path}";
     force = true;
   };
 in

--- a/nix/home/kanary.nix
+++ b/nix/home/kanary.nix
@@ -19,7 +19,9 @@
   # result Caps Lock -> Control only takes effect when Kanary's own
   # `capsLockRemappedToControl` is true. Re-assert it on every activation.
   # The helper is idempotent and a silent no-op once the setting is correct.
-  home.activation.enforceKanaryCapsControl = lib.hm.dag.entryAfter [ "writeBoundary" ] ''
+  # linkGeneration の後に実行する（初回 activation ではリンク生成前だと
+  # ~/.local/bin/kanary-enforce-caps-control がまだ存在しない）
+  home.activation.enforceKanaryCapsControl = lib.hm.dag.entryAfter [ "linkGeneration" ] ''
     $DRY_RUN_CMD "${config.home.homeDirectory}/.local/bin/kanary-enforce-caps-control" || true
   '';
 }

--- a/nix/home/packages.nix
+++ b/nix/home/packages.nix
@@ -17,6 +17,7 @@
     awscli2
     aws-sam-cli
     azure-cli
+    google-cloud-sdk
     kubernetes-helm
     sops
     terraform

--- a/nix/hosts/darwin/default.nix
+++ b/nix/hosts/darwin/default.nix
@@ -1,4 +1,9 @@
-{ pkgs, ... }:
+{
+  pkgs,
+  username,
+  determinateNix,
+  ...
+}:
 
 {
   imports = [
@@ -7,29 +12,37 @@
   ];
 
   # Nix settings
-  nix = {
-    settings = {
-      experimental-features = [
-        "nix-command"
-        "flakes"
-      ];
-      # Trusted users for remote builds
-      trusted-users = [
-        "root"
-        "keito"
-      ];
-    };
-    # Garbage collection
-    gc = {
-      automatic = true;
-      interval = {
-        Weekday = 0;
-        Hour = 2;
-        Minute = 0;
+  # Determinate Nix 環境では nix-darwin による Nix 管理を無効化する
+  # （experimental-features や GC は Determinate 側が管理）
+  nix =
+    if determinateNix then
+      {
+        enable = false;
+      }
+    else
+      {
+        settings = {
+          experimental-features = [
+            "nix-command"
+            "flakes"
+          ];
+          # Trusted users for remote builds
+          trusted-users = [
+            "root"
+            username
+          ];
+        };
+        # Garbage collection
+        gc = {
+          automatic = true;
+          interval = {
+            Weekday = 0;
+            Hour = 2;
+            Minute = 0;
+          };
+          options = "--delete-older-than 30d";
+        };
       };
-      options = "--delete-older-than 30d";
-    };
-  };
 
   # System packages (available to all users)
   environment.systemPackages = with pkgs; [
@@ -44,7 +57,7 @@
     stateVersion = 6;
 
     # Primary user (required for homebrew, system.defaults, etc.)
-    primaryUser = "keito";
+    primaryUser = username;
 
     defaults = {
       # Dock
@@ -191,8 +204,8 @@
   services.skhd = {
     enable = true;
     skhdConfig = ''
-      ctrl + shift - j    : /Users/keito/.local/bin/send-ime-key kana
-      ctrl + shift - 0x29 : /Users/keito/.local/bin/send-ime-key eisuu
+      ctrl + shift - j    : /Users/${username}/.local/bin/send-ime-key kana
+      ctrl + shift - 0x29 : /Users/${username}/.local/bin/send-ime-key eisuu
     '';
   };
 
@@ -209,11 +222,11 @@
       ];
       RunAtLoad = true;
       KeepAlive = true;
-      StandardOutPath = "/Users/keito/Library/Logs/agent-deck-web.log";
-      StandardErrorPath = "/Users/keito/Library/Logs/agent-deck-web.err.log";
+      StandardOutPath = "/Users/${username}/Library/Logs/agent-deck-web.log";
+      StandardErrorPath = "/Users/${username}/Library/Logs/agent-deck-web.err.log";
       EnvironmentVariables = {
         # claude/codex (~/.local/bin, ~/.bin)・node/gh (nix profile)・agent-deck (homebrew) を解決できる PATH
-        PATH = "/Users/keito/.local/bin:/Users/keito/.bin:/opt/homebrew/bin:/etc/profiles/per-user/keito/bin:/run/current-system/sw/bin:/usr/local/bin:/usr/bin:/bin";
+        PATH = "/Users/${username}/.local/bin:/Users/${username}/.bin:/opt/homebrew/bin:/etc/profiles/per-user/${username}/bin:/run/current-system/sw/bin:/usr/local/bin:/usr/bin:/bin";
       };
     };
   };

--- a/nix/modules/homebrew.nix
+++ b/nix/modules/homebrew.nix
@@ -1,6 +1,29 @@
-{ ... }:
+{ config, lib, ... }:
 
+let
+  # brew trust（Homebrew 6+）にも渡すため let で束ねる
+  taps = [
+    "1password/tap"
+    "asheshgoplani/tap"
+    "koekeishiya/formulae"
+    "nikitabobko/tap"
+    "supabase/tap"
+    "ynqa/tap"
+    "yukiarrr/tap"
+  ];
+in
 {
+  # Homebrew 6+ はサードパーティ tap を明示的に信頼しないと formula/cask を
+  # 読み込まない（新規マシンで brew bundle が失敗する）。trust.json は
+  # ユーザー単位の設定なので primaryUser として事前に登録する。
+  system.activationScripts.preActivation.text = ''
+    if [ -x /opt/homebrew/bin/brew ] && sudo -u ${config.system.primaryUser} -H /opt/homebrew/bin/brew trust --help >/dev/null 2>&1; then
+      ${lib.concatMapStringsSep "\n    " (
+        tap: ''sudo -u ${config.system.primaryUser} -H /opt/homebrew/bin/brew trust "${tap}" || true''
+      ) taps}
+    fi
+  '';
+
   homebrew = {
     enable = true;
 
@@ -11,19 +34,12 @@
     };
 
     # === Taps ===
-    taps = [
-      "1password/tap"
-      "asheshgoplani/tap"
-      "koekeishiya/formulae"
-      "nikitabobko/tap"
-      "supabase/tap"
-      "ynqa/tap"
-      "yukiarrr/tap"
-    ];
+    inherit taps;
 
     # === Formulae (Nix にないもの / tap 依存 / macOS 固有) ===
     brews = [
       "asheshgoplani/tap/agent-deck" # Agent Deck CLI
+      "bash" # bash 4+ (setup-claude.sh や typeset -g を使うスクリプトが必要。macOS 標準は 3.2)
       "cliclick" # macOS automation
       "mas" # Mac App Store CLI
       "pinentry-mac" # GPG pinentry for macOS
@@ -42,12 +58,13 @@
       "1password-cli"
 
       # Development Tools
+      # gcloud は nixpkgs の google-cloud-sdk で管理（cask の postinstall が
+      # virtualenv コマンドを要求し、新規マシンで失敗するため）
       "android-studio"
       "cursor"
       "dotnet-sdk"
       "elgato-stream-deck"
       "flutter"
-      "gcloud-cli"
       "ngrok"
       "orbstack"
       "tableplus"

--- a/test/nix-darwin-config.test.js
+++ b/test/nix-darwin-config.test.js
@@ -168,8 +168,8 @@ describe('nix-darwin and home-manager macOS configuration', () => {
     expect(darwinHost).toContain('enable = true;');
     expect(darwinHost).toContain('ctrl + shift - j');
     expect(darwinHost).toContain('ctrl + shift - 0x29');
-    expect(darwinHost).toContain('/Users/keito/.local/bin/send-ime-key kana');
-    expect(darwinHost).toContain('/Users/keito/.local/bin/send-ime-key eisuu');
+    expect(darwinHost).toContain('/Users/${username}/.local/bin/send-ime-key kana');
+    expect(darwinHost).toContain('/Users/${username}/.local/bin/send-ime-key eisuu');
   });
 
   test('cmux terminal config leaves IME shortcuts to skhd', () => {


### PR DESCRIPTION
## Summary

新規マシン（別ユーザー名・別ホスト名・Determinate Nix・Homebrew 6+）で `darwin-rebuild switch` が最後まで通らない問題を解消する。oykotnoMacBook-Air での初回セットアップで実際に踏んだ失敗を一つずつ潰し、再発防止として nix 設定の CI 検証とセットアップガイドを追加した。

## Why

flake が `keito` / `keitonoMacBook-Pro` 固定で新規マシンに適用できず、さらに以下の環境差分で activation が失敗するため:

1. Determinate Nix が nix-darwin の Nix 管理と衝突（`error: Determinate detected, aborting activation`）
2. Homebrew 6+ が untrusted tap の formula 読み込みを拒否（`brew bundle` 失敗）
3. gcloud-cli cask の postinstall が `virtualenv` コマンドを要求して失敗
4. brew bash 未導入だと `typeset -g` を使うスクリプト（setup-claude.sh 等）が macOS 標準 bash 3.2 で動かない
5. 初回 activation で enforceKanaryCapsControl がリンク生成前に実行され失敗
6. `~/.local/bin`（claude / codex のネイティブインストール先）が PATH に無い

また、nix ファイルは文字列ベースの jest テストしかなく、構成の破損を CI で検出できなかった。

## What

- flake をマルチホスト対応にし、`mkDarwin` ヘルパーで username / hostname をパラメータ化（oykotnoMacBook-Air を追加）
- `determinateNix` オプションを追加し、有効時は `nix.enable = false`（既存ホストは従来どおり nix-darwin が Nix を管理）
- preActivation で primaryUser として宣言済み tap を `brew trust`（brew trust 未対応の旧 Homebrew ではスキップ）
- gcloud-cli cask を nixpkgs の `google-cloud-sdk` に置き換え
- `bash` を brews に追加
- enforceKanaryCapsControl を `linkGeneration` の後に実行
- `~/.local/bin` を PATH に追加（path.zsh）
- `/Users/keito` 固定パス（skhd・agent-deck launchd・dotfiles の private-config 参照）を username 変数化
- **CI: Nix Config Eval ジョブを追加** — 両ホストの darwinConfigurations を Linux ランナーで評価検証し、Quality Gate に組み込み
- **docs/setup/macos.md を追加** — 実機検証済みの新規 Mac セットアップ手順（トラブルシューティング付き）
- テストの期待値をパラメータ化後の記述に追従

## How to test

- [x] `nix eval .#darwinConfigurations.oykotnoMacBook-Air.system.drvPath` / `keitonoMacBook-Pro` 両方成功
- [x] `npx jest --runInBand` 779 件全パス（brew bash 導入後）
- [x] oykotnoMacBook-Air（新規 MacBook Air, Determinate Nix）で switch 完走・brew bundle 60 件・home-manager activation 成功を実機確認
- [x] CI の Nix Config Eval ジョブが両ホストの評価に成功すること（本 PR で初回実行）
- [ ] keitonoMacBook-Pro で `make nix-switch` が従来どおり通ること

## Checklist

- [x] セルフレビュー済み
- [x] テストを追加・更新した（該当する場合）
- [x] ドキュメントを更新した（docs/setup/macos.md、README、AGENTS.md 自動生成セクション）
- [x] 破壊的変更がない（ある場合は詳細を記述）

## Related

- ADR 0016（Kanary は引き続き手動インストール前提）

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added macOS setup guide for provisioning a new Apple Silicon machine.
  * Introduced host-specific macOS/Nix configuration generation with optional Determinate Nix behavior.
  * Added Google Cloud SDK to the Home environment.
  * Added automatic Homebrew tap trust during setup.
  * CI now evaluates Nix configuration changes via a dedicated Nix evaluation step.

* **Improvements**
  * Made user-specific paths and settings fully dynamic for each configured username.
  * Updated shortcut/agent log locations and PATH behavior to use the active user home.
  * Adjusted IME-related tests and re-ordered Kanary activation for reliable first-run behavior.
  * Refreshed contributor docs and settings for better automation/readability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->