### PR TITLE
fix: 新規マシンセットアップで踏んだ残りの問題を改善

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -100,6 +100,7 @@
       "integrity": "sha512-RgHBCvtjbOK2gXSNBNIkNoEc9qoVEtau3hj8gEqKQuL3HZAibKarWFEI3Lfm6EYKkLalOh8eSrj9b+ch9H/VBA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.29.7",
         "@babel/generator": "^7.29.7",
@@ -1830,6 +1831,7 @@
       "integrity": "sha512-DhGl4xMVFGVIyMwswXeyzdL4uXD5OGILGX5N8Y+f6W7LhC1Ze2poSNrkF/fedpVDHEEZ+PHFW0vL14I+mm8K3Q==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@octokit/auth-token": "^6.0.0",
         "@octokit/graphql": "^9.0.3",
@@ -2612,6 +2614,7 @@
       "integrity": "sha512-jp2P3tQMSxWugkCUKLRPVUpGaL5MVFwF8RDuSRztfwgN1wmqJeMSbKlnEtQqU8UrhTmzEmZdu2I6v2dpp7XIxw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "undici-types": "~7.18.0"
       }
@@ -2929,6 +2932,7 @@
       "integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -3059,6 +3063,20 @@
       "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
       "dev": true,
       "license": "Python-2.0"
+    },
+    "node_modules/argue-cli": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/argue-cli/-/argue-cli-3.1.0.tgz",
+      "integrity": "sha512-DhBpBfXL4SS2uC0N922MMajKR3CdrTG0u2or1PNYgXMsrSzViJrbtvT0nCLlLGUI0plam/ZZCs7aAauHtW9thw==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">=22"
+      },
+      "funding": {
+        "url": "https://ko-fi.com/dangreen"
+      }
     },
     "node_modules/argv-formatter": {
       "version": "1.0.0",
@@ -3266,6 +3284,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.10.12",
         "caniuse-lite": "^1.0.30001782",
@@ -3843,6 +3862,7 @@
       "integrity": "sha512-hr4ihw+DBqcvrsEDioRO31Z17x71pUYoNe/4h6Z0wB72p7MU7/9gH8Q3s12NFhHPfYBBOV3qyfUxmr/Yn3shnQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "env-paths": "^2.2.1",
         "import-fresh": "^3.3.0",
@@ -4281,6 +4301,7 @@
       "integrity": "sha512-GVTD7s1vdIl6UYvAfriOPeY1Df8LIZjfofLvHwde+erDHGGuHyuM6xoxRxmHiebhYuD2p1vN4wWh0XzPARSGDQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "workspaces": [
         "packages/*"
       ],
@@ -6599,6 +6620,7 @@
       "integrity": "sha512-8dD6FusOQSrpv9Z1rdNMdlSgQOIP880DHqnohobOmYLElGEqAL/JvxvuxZO16r4HtjTlfPRDC1hbvxC9dPN2nA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "marked": "bin/marked.js"
       },
@@ -8734,6 +8756,7 @@
       "dev": true,
       "inBundle": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -9684,6 +9707,7 @@
       "integrity": "sha512-w/iZ0bur36rKffXZYmIUmy068eoBY3Ij1DCCddx2JwWEM5Tg+eU9ld/E9qSInVvPASyyR2Ln/XGfQ9OZrMlhtw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@semantic-release/commit-analyzer": "^13.0.1",
         "@semantic-release/error": "^4.0.0",
@@ -10819,6 +10843,7 @@
       "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=12"
       },

--- a/script/README.md
+++ b/script/README.md
@@ -57,6 +57,8 @@ Imports configuration settings from the home directory back to the repository.
 
 **Check mode**: `./script/import.sh --check`
 
+**Repository clone**: `./script/import.sh --with-repos` — GitHub の全リポジトリを ghq で一括クローンする（デフォルトはスキップ）
+
 ## Credential Management
 
 ### credentials.sh
@@ -291,6 +293,8 @@ Installs global npm packages defined in `npm/global.json`.
 Uses npm's legacy peer dependency resolver for global CLI packages to match DevContainer builds.
 
 **Used by**: DevContainer postCreateCommand
+
+**Note**: npm prefix が読み取り専用の Nix store を指す環境（macOS の nix 管理 npm）ではスキップされる。CLI ツールは `nix/home/packages.nix` で管理する。
 
 ### create-codespace.sh
 

--- a/script/import.sh
+++ b/script/import.sh
@@ -20,10 +20,18 @@ fi
 
 REPO_PATH="${REPO_PATH:-$(pwd)}"
 
-if [[ "${1:-}" == "--check" ]]; then
-	echo "Import source checked: $REPO_PATH"
-	exit 0
-fi
+WITH_REPOS=false
+for arg in "$@"; do
+	case "$arg" in
+	--check)
+		echo "Import source checked: $REPO_PATH"
+		exit 0
+		;;
+	--with-repos)
+		WITH_REPOS=true
+		;;
+	esac
+done
 
 if ! type brew >/dev/null 2>&1; then
 	/bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)" </dev/null
@@ -110,6 +118,13 @@ if type jq >/dev/null 2>&1 && type npm >/dev/null 2>&1; then
 fi
 
 # Clone repositories using ghq
-if type gh >/dev/null 2>&1 && type ghq >/dev/null 2>&1; then
-	gh api user/repos --paginate | jq -r '.[].ssh_url' | xargs -L1 ghq get
+# 全リポジトリの一括クローンは重い副作用のためオプトイン (--with-repos)
+if [[ "$WITH_REPOS" == true ]]; then
+	if type gh >/dev/null 2>&1 && type ghq >/dev/null 2>&1; then
+		gh api user/repos --paginate | jq -r '.[].ssh_url' | xargs -L1 ghq get
+	else
+		echo "⚠️  --with-repos には gh と ghq が必要です"
+	fi
+else
+	echo "リポジトリの一括クローンはスキップしました (--with-repos で有効化)"
 fi

--- a/script/install-npm-globals.sh
+++ b/script/install-npm-globals.sh
@@ -21,6 +21,15 @@ if [[ ! -f "$GLOBAL_JSON" ]]; then
     exit 1
 fi
 
+# Nix 管理の npm (macOS) は prefix が読み取り専用の Nix store を指すため
+# npm install -g できない。CLI ツールは nix/home/packages.nix 側で管理する。
+npm_prefix="$(npm config get prefix 2>/dev/null || echo "")"
+if [[ "$npm_prefix" == /nix/store/* ]]; then
+    warning "npm prefix が読み取り専用の Nix store を指しています: ${npm_prefix}"
+    warning "この環境では npm グローバルは管理対象外のためスキップします (nix/home/packages.nix を参照)"
+    exit 0
+fi
+
 # インストールするパッケージリスト（Node.js feature でリセットされるもの）
 PACKAGES=(
     "happy"

--- a/script/lib/output.sh
+++ b/script/lib/output.sh
@@ -12,6 +12,16 @@
 if [[ -n "${OUTPUT_LIB_SOURCED:-}" ]]; then
     return
 fi
+
+# macOS 標準の bash 3.2 は typeset -g をサポートせず、
+# 「typeset: -g: invalid option」という分かりにくいエラーで失敗する。
+# 先に明示的なメッセージで落とす (zsh では BASH_VERSION が空なのでスキップ)。
+if [[ -n "${BASH_VERSION:-}" && "${BASH_VERSINFO[0]}" -lt 4 ]]; then
+    echo "エラー: このライブラリは bash 4.0 以降が必要です (現在: ${BASH_VERSION})" >&2
+    echo "macOS の場合: brew install bash を実行し、PATH に /opt/homebrew/bin を追加してください" >&2
+    return 1 2>/dev/null || exit 1
+fi
+
 typeset -g OUTPUT_LIB_SOURCED=1
 
 # Color definitions


### PR DESCRIPTION
## Summary

PR #1004 の続き。新規マシンセットアップ (oykotnoMacBook-Air) で実際に踏んだ、環境差分による失敗 4 件を改善する。

## Why

- npm 11.17 生成の package-lock.json は npm 11.6 の `npm ci` で「Missing: argue-cli@3.1.0 from lock file」になり、ローカルの npm バージョン次第でセットアップが壊れる
- `script/lib/output.sh` を macOS 標準 bash 3.2 で source すると `typeset: -g: invalid option` という原因の分かりにくいエラーで失敗する（jest 17 件の失敗として表面化）
- `import.sh` が設定インポートの副作用として GitHub の全リポジトリを無条件に ghq クローンする
- `install-npm-globals.sh` は Nix 管理 npm（prefix が読み取り専用の Nix store）では動作しない

## What

- package-lock.json を npm 11.6 で再生成（peer フラグ + optional 依存を含む上位互換形式。npm 11.6 / 11.17 両方で `npm ci` が通ることを確認）
- output.sh に bash 4 未満の明示的なバージョンガードを追加（brew bash 導入を促すメッセージ）
- import.sh の全リポジトリクローンを `--with-repos` オプトインに分離（script/README.md に追記）
- install-npm-globals.sh に Nix store prefix 検出のガードを追加してスキップ（script/README.md に追記）

## How to test

- [x] `npm ci` が npm 11.6.2 / 11.17.0 の両方で成功
- [x] `npx jest --runInBand` 779 件全パス
- [x] shellcheck 通過
- [x] bash 3.2 で output.sh を source すると明示的なエラーメッセージで exit 1
- [x] bash 5 / zsh では従来どおり動作
- [x] `import.sh --check` の従来動作を維持
- [x] Nix 管理 npm 環境で install-npm-globals.sh が警告を出して exit 0

## Checklist

- [x] セルフレビュー済み
- [x] テストを追加・更新した（該当する場合）
- [x] ドキュメントを更新した（script/README.md）
- [x] 破壊的変更がない（import.sh の一括クローンはデフォルト無効に変更 — 意図的な挙動変更）

## Related

- #1004

🤖 Generated with [Claude Code](https://claude.com/claude-code)