### PR TITLE
feat: 入力ソースを Google 日本語入力の 2 モードのみにする

### DIFF
--- a/nix/hosts/darwin/default.nix
+++ b/nix/hosts/darwin/default.nix
@@ -115,11 +115,6 @@
         "com.apple.HIToolbox" = {
           AppleEnabledInputSources = [
             {
-              InputSourceKind = "Keyboard Layout";
-              "KeyboardLayout ID" = 252;
-              "KeyboardLayout Name" = "ABC";
-            }
-            {
               "Bundle ID" = "com.google.inputmethod.Japanese";
               InputSourceKind = "Keyboard Input Method";
             }


### PR DESCRIPTION
## Summary

入力ソースを Google 日本語入力の **ひらがな / 英数** の 2 つだけにする。

## Why

AppleEnabledInputSources に ABC キーボードレイアウトが含まれていると、ログイン時に不要な第 3 の入力ソースとして登録され、入力切替の候補に出てしまう。Google 日本語入力が英数モードを提供するため ABC は不要。

## What

- `nix/hosts/darwin/default.nix` の AppleEnabledInputSources から ABC エントリを削除

## How to test

- [x] `nix eval` 両ホスト成功
- [x] oykotnoMacBook-Air で同内容を defaults に直接書き込み、再ログイン後に入力ソースが 2 つのみになることを確認（確認中）

## Checklist

- [x] セルフレビュー済み
- [ ] テストを追加・更新した（該当なし）
- [ ] ドキュメントを更新した（該当なし）
- [x] 破壊的変更がない

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Configuration**
  * Removed the ABC keyboard layout from the enabled macOS input sources.
  * Retained the configured Japanese input methods and default Japanese input selection.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->