### PR TITLE
feat: skhd を安定パスから起動して TCC 許可の再付与を不要にする

### DIFF
--- a/docs/setup/macos.md
+++ b/docs/setup/macos.md
@@ -104,15 +104,21 @@ make credentials
 初回起動時に macOS の許可が必要:
 
 - **Kanary**: Gatekeeper の確認、アクセシビリティ / 入力監視
-- **skhd**: アクセシビリティ (許可しないと IME ショートカットが動かない)
-- **Xcode**: 初回起動時のライセンス同意
+- **skhd**: アクセシビリティ (許可しないと IME ショートカットが動かない)。
+  許可対象は `/usr/local/bin/skhd` (activation がコピーする安定パス)。
+  ファイル選択ダイアログでは Cmd+Shift+G でパスを直接入力する。
+  許可後は `launchctl kickstart -k gui/$(id -u)/org.nixos.skhd` で再起動する
+- **Xcode**: 初回起動時のライセンス同意 (`sudo xcodebuild -license accept` でも可)
 
 ## トラブルシューティング
 
-| 症状                                                     | 原因 / 対処                                                                   |
-| -------------------------------------------------------- | ----------------------------------------------------------------------------- |
-| `error: Determinate detected, aborting activation`       | flake のホスト定義に `determinateNix = true` を指定する                       |
-| `error: Kanary.app is required for keyboard remapping.`  | 手順 4 の Kanary をインストールする                                           |
-| `Refusing to load formula ... from untrusted tap`        | preActivation が自動で `brew trust` する。手動なら `brew trust <tap>`         |
-| `typeset: -g: invalid option` でスクリプトやテストが失敗 | macOS 標準 bash 3.2 が原因。brew の `bash` (Brewfile 管理) が入っているか確認 |
-| `warning: $HOME ... is not owned by you`                 | sudo 実行時の無害な警告                                                       |
+| 症状                                                          | 原因 / 対処                                                                                                                                                                                         |
+| ------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `error: Determinate detected, aborting activation`            | flake のホスト定義に `determinateNix = true` を指定する                                                                                                                                             |
+| `error: Kanary.app is required for keyboard remapping.`       | 手順 4 の Kanary をインストールする                                                                                                                                                                 |
+| `Refusing to load formula ... from untrusted tap`             | preActivation が自動で `brew trust` する。手動なら `brew trust <tap>`                                                                                                                               |
+| `typeset: -g: invalid option` でスクリプトやテストが失敗      | macOS 標準 bash 3.2 が原因。brew の `bash` (Brewfile 管理) が入っているか確認                                                                                                                       |
+| `warning: $HOME ... is not owned by you`                      | sudo 実行時の無害な警告                                                                                                                                                                             |
+| 日本語 IME を選択できるのに変換されない (入力が ASCII のまま) | Google 日本語入力の Converter / Renderer の launchd エージェントがログイン後のインストールで未ロード。ログアウト → ログイン (または再起動) で解消                                                   |
+| 入力ソースに ことえり / ABC など不要な項目が復活する          | TIS API やその場の無効化は macOS に差し戻される。`defaults write com.apple.HIToolbox AppleEnabledInputSources` で希望のリストを書き込み、ログインし直す (nix 設定の CustomUserPreferences と同内容) |
+| `op` / `make credentials` が `account is not signed in`       | 1Password アプリで 設定 → 開発者 → CLI 統合を有効化し、アプリを再起動する。それでも失敗するシェルでは同一シェル内で `eval "$(op signin --account my.1password.com)"` を実行してから使う             |

--- a/nix/hosts/darwin/default.nix
+++ b/nix/hosts/darwin/default.nix
@@ -196,12 +196,34 @@
   # Security
   security.pam.services.sudo_local.touchIdAuth = true;
 
-  services.skhd = {
-    enable = true;
-    skhdConfig = ''
-      ctrl + shift - j    : /Users/${username}/.local/bin/send-ime-key kana
-      ctrl + shift - 0x29 : /Users/${username}/.local/bin/send-ime-key eisuu
-    '';
+  # skhd: services.skhd は nix store パスのバイナリを launchd に登録するため、
+  # skhd 更新のたびに TCC (アクセシビリティ) 許可の再付与が必要になる。
+  # activation で /usr/local/bin/skhd に実体コピーした安定パスから起動することで、
+  # 許可対象のパスを固定する。
+  environment.etc."skhdrc".text = ''
+    ctrl + shift - j    : /Users/${username}/.local/bin/send-ime-key kana
+    ctrl + shift - 0x29 : /Users/${username}/.local/bin/send-ime-key eisuu
+  '';
+
+  system.activationScripts.postActivation.text = ''
+    if ! cmp -s "${pkgs.skhd}/bin/skhd" /usr/local/bin/skhd; then
+      mkdir -p /usr/local/bin
+      install -m 755 "${pkgs.skhd}/bin/skhd" /usr/local/bin/skhd
+      echo "installed skhd to /usr/local/bin/skhd"
+    fi
+  '';
+
+  launchd.user.agents.skhd = {
+    serviceConfig = {
+      ProgramArguments = [
+        "/usr/local/bin/skhd"
+        "-c"
+        "/etc/skhdrc"
+      ];
+      KeepAlive = true;
+      RunAtLoad = true;
+      ProcessType = "Interactive";
+    };
   };
 
   # Agent Deck Web UI (headless) — http://127.0.0.1:8420

--- a/test/nix-darwin-config.test.js
+++ b/test/nix-darwin-config.test.js
@@ -164,8 +164,12 @@ describe('nix-darwin and home-manager macOS configuration', () => {
   test('skhd binds IME shortcuts without Karabiner', () => {
     const darwinHost = readRepoFile('nix/hosts/darwin/default.nix');
 
-    expect(darwinHost).toContain('services.skhd = {');
-    expect(darwinHost).toContain('enable = true;');
+    // TCC 許可を安定させるため、nix store 直参照ではなく
+    // /usr/local/bin/skhd (activation でコピーした安定パス) から起動する
+    expect(darwinHost).toContain('environment.etc."skhdrc".text');
+    expect(darwinHost).toContain('install -m 755 "${pkgs.skhd}/bin/skhd" /usr/local/bin/skhd');
+    expect(darwinHost).toContain('launchd.user.agents.skhd');
+    expect(darwinHost).toContain('"/usr/local/bin/skhd"');
     expect(darwinHost).toContain('ctrl + shift - j');
     expect(darwinHost).toContain('ctrl + shift - 0x29');
     expect(darwinHost).toContain('/Users/${username}/.local/bin/send-ime-key kana');


### PR DESCRIPTION
## Summary

skhd のアクセシビリティ (TCC) 許可が nix 更新のたびに剥がれる問題を解消し、macos.md に新規マシンセットアップで実際に踏んだ IME / 1Password のトラブルシューティングを追記する。

## Why

- `services.skhd` は nix store パスのバイナリを launchd に直接登録するため、skhd のバージョンが上がると許可対象のパスが変わり、アクセシビリティ許可の再付与が必要になる。システム設定にも古い /nix/store エントリが溜まり続ける
- Google IME の Converter 未ロード・入力ソースの差し戻し・op signin の 3 件は、次の新規マシンでも確実に踏む再現性のある問題のため文書化する

## What

- activation (postActivation) で `${pkgs.skhd}/bin/skhd` を `/usr/local/bin/skhd` に実体コピーし、launchd はその安定パスを起動するよう変更（skhdrc は environment.etc で従来同様に生成）
- テストの期待値を新構成に追従
- macos.md: skhd 許可手順の具体化（許可対象パス・kickstart コマンド）とトラブルシューティング 3 件を追記

## How to test

- [x] `nix eval` 両ホスト成功
- [x] `npx jest test/nix-darwin-config.test.js` 20 件パス
- [ ] oykotnoMacBook-Air で `make nix-switch` 後、/usr/local/bin/skhd への許可 1 回で IME ショートカットが動作すること（マージ後に実機確認）

## Checklist

- [x] セルフレビュー済み
- [x] テストを追加・更新した
- [x] ドキュメントを更新した（docs/setup/macos.md）
- [x] 破壊的変更がない（launchd ラベルは org.nixos.skhd のまま）

## Related

- ADR 0016（skhd を IME ショートカットに使う判断自体は変更なし。起動パスの実装詳細のみ変更）

🤖 Generated with [Claude Code](https://claude.com/claude-code)