### PR TITLE
chore: claude-code-action を v1.0.181 に更新し nix-eval ホストを動的列挙にする

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -280,10 +280,16 @@ jobs:
 
       # 評価はプラットフォーム非依存なので Linux ランナーで aarch64-darwin の
       # darwinConfigurations を検証できる（ビルドはしない）
+      # ホストは flake から動的に列挙する（ホスト追加時に CI 修正を不要にする）
       - name: Evaluate darwin configurations
         working-directory: nix
         run: |
-          for host in keitonoMacBook-Pro oykotnoMacBook-Air; do
+          hosts=$(nix eval --json .#darwinConfigurations --apply builtins.attrNames | jq -r '.[]')
+          if [ -z "$hosts" ]; then
+            echo "::error::darwinConfigurations にホストが見つかりません"
+            exit 1
+          fi
+          for host in $hosts; do
             echo "Evaluating darwinConfigurations.${host}..."
             nix eval --raw ".#darwinConfigurations.\"${host}\".system.drvPath"
             echo

--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -103,7 +103,7 @@ jobs:
       - name: Run Claude Code Review
         id: claude-review
         if: steps.claude-auth.outputs.available == 'true'
-        uses: anthropics/claude-code-action@af0559ee4f514d1ef21826982bed13f7edc3c35e # v1
+        uses: anthropics/claude-code-action@44423bdec74b97d67543eb16c110546762c110b2 # v1.0.181
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -82,7 +82,7 @@ jobs:
       - name: Run Claude Code
         id: claude
         if: steps.pr_draft.outputs.is_draft != 'true'
-        uses: anthropics/claude-code-action@af0559ee4f514d1ef21826982bed13f7edc3c35e # v1
+        uses: anthropics/claude-code-action@44423bdec74b97d67543eb16c110546762c110b2 # v1.0.181
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
 

--- a/.github/workflows/scheduled-maintenance.yml
+++ b/.github/workflows/scheduled-maintenance.yml
@@ -57,7 +57,7 @@ jobs:
 
       - name: Run scheduled maintenance
         id: maintenance
-        uses: anthropics/claude-code-action@af0559ee4f514d1ef21826982bed13f7edc3c35e # v1
+        uses: anthropics/claude-code-action@44423bdec74b97d67543eb16c110546762c110b2 # v1.0.181
         env:
           CLAUDE_BRANCH: ${{ env.CLAUDE_BRANCH }}
         with:

--- a/templates/workflows/claude-health-check.yml
+++ b/templates/workflows/claude-health-check.yml
@@ -18,7 +18,7 @@ jobs:
     steps:
       - name: Check Claude Code token validity
         id: check
-        uses: anthropics/claude-code-action@b47fd721da662d48c5680e154ad16a73ed74d2e0 # v1
+        uses: anthropics/claude-code-action@44423bdec74b97d67543eb16c110546762c110b2 # v1.0.181
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           prompt: 'Reply with only: OK'

--- a/templates/workflows/claude.yml
+++ b/templates/workflows/claude.yml
@@ -97,7 +97,7 @@ jobs:
       - name: Run Claude Code
         id: claude
         if: steps.pr_draft.outputs.is_draft != 'true'
-        uses: anthropics/claude-code-action@af0559ee4f514d1ef21826982bed13f7edc3c35e # v1
+        uses: anthropics/claude-code-action@44423bdec74b97d67543eb16c110546762c110b2 # v1.0.181
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
 

--- a/templates/workflows/scheduled-maintenance.yml
+++ b/templates/workflows/scheduled-maintenance.yml
@@ -57,7 +57,7 @@ jobs:
 
       - name: Run scheduled maintenance
         id: maintenance
-        uses: anthropics/claude-code-action@af0559ee4f514d1ef21826982bed13f7edc3c35e # v1
+        uses: anthropics/claude-code-action@44423bdec74b97d67543eb16c110546762c110b2 # v1.0.181
         env:
           CLAUDE_BRANCH: ${{ env.CLAUDE_BRANCH }}
         with:


### PR DESCRIPTION
## Summary

claude-review の連続失敗対策として claude-code-action のピンを最新に更新し、CI の Nix Config Eval をホスト名直書きから flake 動的列挙に変更する。

## Why

- claude-review が直近 3 回連続で Action 内部エラー（"Internal error: directory mismatch"）で失敗していた。ピンは v1.0.178 相当で、最新は v1.0.181
- ci.yml にホスト名（keitonoMacBook-Pro / oykotnoMacBook-Air）を直書きしているため、ホスト追加のたびに CI 修正が必要だった

## What

- claude-code-action のピンを `44423bd` (v1.0.181) に更新（.github/workflows 3 件 + templates 3 件を同一 SHA に統一）
- Nix Config Eval: `nix eval --json .#darwinConfigurations --apply builtins.attrNames` でホストを動的列挙し、空なら明示的に失敗

## How to test

- [x] `npm run workflow:sync:check` テンプレート同期 OK
- [x] `npx jest --runInBand` 779 件全パス
- [x] ホスト列挙コマンドをローカルで実行し `["keitonoMacBook-Pro","oykotnoMacBook-Air"]` を確認
- [ ] 本 PR の CI で Nix Config Eval（動的列挙版）と claude-review（新バージョン）が通ること

## Checklist

- [x] セルフレビュー済み
- [ ] テストを追加・更新した（該当なし）
- [ ] ドキュメントを更新した（該当なし）
- [x] 破壊的変更がない

🤖 Generated with [Claude Code](https://claude.com/claude-code)