### PR TITLE
feat: agent-deck セッションを peco で選んでアタッチする ada コマンドを追加

### DIFF
--- a/nix/home/agent-commands.nix
+++ b/nix/home/agent-commands.nix
@@ -14,6 +14,8 @@ in
       force = true;
     };
 
+    ".local/bin/ada" = managedCommand (configRoot + /script/agent/agent-deck-attach.sh);
+
     ".local/bin/agent-collect-local-configs" = managedCommand (
       configRoot + /script/agent/collect-local-configs.sh
     );

--- a/script/agent/agent-deck-attach.sh
+++ b/script/agent/agent-deck-attach.sh
@@ -1,0 +1,39 @@
+#!/usr/bin/env bash
+# agent-deck のセッションを peco で選んでアタッチする
+# agent-deck 独自の attach は使わず、素の tmux attach でアタッチする
+set -euo pipefail
+
+sel=$(agent-deck list --json 2>/dev/null \
+  | jq -r '.[] | select(.archived | not) | [.id, .group, .title, .status, .path] | @tsv' \
+  | column -t -s $'\t' \
+  | peco --prompt 'agent-deck>' --query "${1:-}")
+
+[ -z "$sel" ] && exit 0
+id="${sel%% *}"
+
+tmux_session=$(agent-deck list --json 2>/dev/null \
+  | jq -r --arg id "$id" '.[] | select(.id == $id) | .tmux_session')
+
+if [ -z "$tmux_session" ] || [ "$tmux_session" = "null" ]; then
+  echo "セッション情報が取得できませんでした: $id" >&2
+  exit 1
+fi
+
+# tmux プロセスが死んでいたら起動を待ってからアタッチ
+if ! tmux has-session -t "=$tmux_session" 2>/dev/null; then
+  agent-deck session start "$id"
+  for _ in $(seq 1 20); do
+    tmux has-session -t "=$tmux_session" 2>/dev/null && break
+    sleep 0.25
+  done
+  if ! tmux has-session -t "=$tmux_session" 2>/dev/null; then
+    echo "tmux セッションが起動しませんでした: $tmux_session" >&2
+    exit 1
+  fi
+fi
+
+if [ -n "${TMUX:-}" ]; then
+  tmux switch-client -t "=$tmux_session"
+else
+  tmux attach -t "=$tmux_session"
+fi


### PR DESCRIPTION
## Why

cmux の各ワークスペースから agent-deck のセッションを開きたいが、agent-deck の TUI は 1 プロファイル 1 インスタンス制限があり、また `agent-deck session attach` は独自の端末制御（raw mode / スクロールバック消去）が cmux 上で不安定でターミナルごと落ちることがある。

## What

- `script/agent/agent-deck-attach.sh`: peco でセッションを選び、素の `tmux attach` でアタッチするスクリプトを追加
- `nix/home/agent-commands.nix`: 上記を `~/.local/bin/ada` として配布するエントリを追加

## How

- `agent-deck list --json` を jq で整形して peco に渡し、選択したセッションの ID を抽出
- tmux セッションが死んでいる場合は `agent-deck session start` で起動し、tmux に現れるまで最大 5 秒待機してからアタッチ
- tmux 内から実行された場合は `switch-client` を使用（ネスト回避）
- 引数を peco の初期クエリとして渡せる（例: `ada n8n`）

## Risk

- 低。新規コマンド追加のみで既存の配布物への変更なし
- 既存の手置き `~/.bin/ada` と重複するため、マージ後 rebuild したら `rm ~/.bin/ada` で手置き側を削除する（`~/.local/bin/ada` が本体になる）

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an `ada` command for quickly selecting and attaching to active agent-deck sessions.
  * Supports switching between sessions within an existing tmux client or attaching from a new terminal.
  * Automatically starts a selected session when its tmux session is not yet available.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->