### PR TITLE
feat(hooks): 作業着手前のタスク登録を促す UserPromptSubmit フックを追加

### DIFF
--- a/.claude/hooks/README.md
+++ b/.claude/hooks/README.md
@@ -228,6 +228,22 @@ Hooksは、Claude Codeの特定のイベント（ツール実行前後、タス�
 - テストが失敗した場合: 失敗ログの末尾30行を `additionalContext` で返し修正を促す
 - タイムアウト: 5分
 
+### 13. `prompt_task_reminder.py`
+
+**目的**: 依頼を受けた直後にタスクを登録させ、着手前に作業計画を可視化する
+
+**トリガー**: `UserPromptSubmit`（プロンプト送信時）
+
+**動作**:
+
+- 「着手前に `TaskCreate` でタスクを作成し、`TaskUpdate` で `in_progress` / `completed` へ更新する」指示を `additionalContext` として注入
+- 質問だけで完結する依頼・3ステップ未満の些末な作業は対象外である旨も併せて指示（過剰なタスク作成の防止）
+- 空プロンプト、および stdin が壊れている場合は何も出力しない（フェイルオープン）
+- ブロックはしない。`UserPromptSubmit` で `exit 2` するとプロンプト自体が破棄され依頼が失われるため
+
+**注意**: このフックは `stdout` がそのままコンテキストへ注入される。スクリプト未配置のリポジトリでは
+フォールバックメッセージを出さず `|| true` で黙る設定にしてある（`.claude/settings.json` 参照）。
+
 ## Hooksの設定方法
 
 ### ステップ1: settings.local.json に設定を追加

--- a/.claude/hooks/prompt_task_reminder.py
+++ b/.claude/hooks/prompt_task_reminder.py
@@ -1,0 +1,49 @@
+#!/usr/bin/env python3
+"""UserPromptSubmit Hook: 作業着手前のタスク登録を促す
+
+依頼を受けた直後に TaskCreate でタスクを作成させ、進行状況を TaskUpdate で
+可視化させる。タスク登録はモデルの裁量に任せると抜けるため、プロンプト受信時に
+毎回 additionalContext として指示を注入して既定動作にする。
+
+ブロックはしない（UserPromptSubmit で exit 2 するとプロンプト自体が破棄され、
+依頼が失われる）。純粋な質問への回答だけで完結する場合は不要である旨も
+指示文に含め、過剰なタスク作成を防ぐ。
+"""
+import json
+import sys
+
+from common import load_hook_input
+
+INSTRUCTION = (
+    "【タスク管理】作業を伴う依頼の場合は、着手前に TaskCreate でタスクを作成してから実装を始めること。"
+    "着手時に TaskUpdate で in_progress、完了時に completed へ更新する。"
+    "質問への回答や確認だけで完結する依頼、および3ステップ未満の些末な作業では作成しなくてよい。"
+)
+
+
+def main() -> int:
+    try:
+        data = load_hook_input()
+    except ValueError:
+        # stdin が壊れていてもプロンプトの処理を止めない
+        return 0
+
+    if not (data.get("prompt") or "").strip():
+        return 0
+
+    print(
+        json.dumps(
+            {
+                "hookSpecificOutput": {
+                    "hookEventName": "UserPromptSubmit",
+                    "additionalContext": INSTRUCTION,
+                }
+            },
+            ensure_ascii=False,
+        )
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -340,6 +340,17 @@
           }
         ]
       }
+    ],
+    "UserPromptSubmit": [
+      {
+        "matcher": "",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "bash -c 'cd \"$(git rev-parse --show-toplevel 2>/dev/null || echo .)\" && { [ -f .claude/hooks/prompt_task_reminder.py ] && python3 .claude/hooks/prompt_task_reminder.py || true; }'"
+          }
+        ]
+      }
     ]
   },
   "enabledPlugins": {

--- a/.devcontainer/claude-settings.json
+++ b/.devcontainer/claude-settings.json
@@ -395,6 +395,17 @@
           }
         ]
       }
+    ],
+    "UserPromptSubmit": [
+      {
+        "matcher": "",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "python3 /home/vscode/.claude/hooks/prompt_task_reminder.py"
+          }
+        ]
+      }
     ]
   }
 }

--- a/.trivyignore
+++ b/.trivyignore
@@ -140,6 +140,18 @@ CVE-2026-45988
 CVE-2026-46043
 CVE-2026-46135
 
+# CVE-2026-53215: kernel: net: mvpp2: refill RX buffers before XDP or skb use
+# Severity: CRITICAL
+# Affected: linux-libc-dev 6.8.0-136.136 (Ubuntu 24.04 base image)
+# Fixed in: no fix available yet
+# Reason: Kernel header package from base image
+#   (mcr.microsoft.com/devcontainers/base:2.0-ubuntu-24.04) pulled in as a
+#   transitive dependency of build-essential; cannot remove or update independently
+# Expected resolution: Wait for Ubuntu to release patched linux-libc-dev package
+# Tracking: https://ubuntu.com/security/CVE-2026-53215
+# Review date: 2026-08-28
+CVE-2026-53215
+
 # CVE-2026-33186: gRPC-Go authorization bypass via missing leading slash in :path
 # Severity: CRITICAL
 # Affected: google.golang.org/grpc v1.79.2 (usr/bin/gh), v1.75.1 (usr/local/bin/op)

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -174,6 +174,7 @@ The following scripts are auto-detected and run before git commit/push:
 | `post_pr_ci_watch.py`         | Post PR creation    | Monitor PR CI status                                                         |
 | `pre_exit_plan_ai_review.py`  | Pre ExitPlanMode    | AI review before plan exit                                                   |
 | `pre_git_quality_gates.py`    | Pre git commit/push | Auto-detect and run quality gates                                            |
+| `prompt_task_reminder.py`     | UserPromptSubmit    | Require task registration (TaskCreate) before starting work                  |
 | `stop_test_verification.py`   | Stop                | Verify test results on session end                                           |
 
 ## Development Standards

--- a/script/lib/agents-md-data.sh
+++ b/script/lib/agents-md-data.sh
@@ -70,5 +70,6 @@ HOOK_TABLE=(
   "post_pr_ci_watch.py|Post PR creation|Monitor PR CI status"
   "post_commit_adr_reminder.py|Post git commit|Remind ADR for architectural changes"
   "pre_exit_plan_ai_review.py|Pre ExitPlanMode|AI review before plan exit"
+  "prompt_task_reminder.py|UserPromptSubmit|Require task registration (TaskCreate) before starting work"
   "stop_test_verification.py|Stop|Verify test results on session end"
 )

--- a/script/setup-claude.sh
+++ b/script/setup-claude.sh
@@ -80,6 +80,9 @@ list_extra_config_dirs() {
     local dir
     for dir in "${HOME}"/.claude-*; do
         [[ -d "$dir" ]] || continue
+        # 初期化済みの実 config_dir のみ対象にする（settings.json か .claude.json を持つ）。
+        # hook 置き場等（例: ~/.claude-worklog）に無用な settings.json を生成しないため。
+        [[ -f "$dir/settings.json" || -f "$dir/.claude.json" ]] || continue
         printf '%s\n' "$dir"
     done
 }

--- a/test/hooks-integrity.test.js
+++ b/test/hooks-integrity.test.js
@@ -20,6 +20,7 @@ describe('Claude Code Hooks integrity', () => {
     'post_pr_ci_watch.py',
     'pre_exit_plan_ai_review.py',
     'pre_git_quality_gates.py',
+    'prompt_task_reminder.py',
     'stop_test_verification.py',
   ];
 

--- a/test/hooks-prompt-task-reminder.test.js
+++ b/test/hooks-prompt-task-reminder.test.js
@@ -1,0 +1,99 @@
+'use strict';
+
+/**
+ * prompt_task_reminder.py の挙動テスト。
+ *
+ * UserPromptSubmit の出力は Claude のコンテキストへ直接注入されるため、
+ * 「JSON として妥当か」「壊れた入力でセッションを止めないか」を実起動で検証する。
+ */
+
+const fs = require('fs');
+const path = require('path');
+const { spawnSync } = require('child_process');
+
+const hookPath = path.join(__dirname, '../.claude/hooks/prompt_task_reminder.py');
+
+/** フックに UserPromptSubmit の入力を流し込み、終了コードと stdout を返す */
+function runHook(payload) {
+  const result = spawnSync('python3', [hookPath], {
+    input: typeof payload === 'string' ? payload : JSON.stringify(payload),
+    encoding: 'utf8',
+    cwd: path.dirname(hookPath), // common.py を import できるようにする
+  });
+
+  return { status: result.status, stdout: result.stdout || '' };
+}
+
+function runWithPrompt(prompt) {
+  return runHook({
+    hook_event_name: 'UserPromptSubmit',
+    session_id: 'test-session',
+    prompt,
+  });
+}
+
+describe('prompt_task_reminder.py', () => {
+  test('should have shebang line', () => {
+    const content = fs.readFileSync(hookPath, 'utf8');
+    expect(content.startsWith('#!/usr/bin/env python3')).toBe(true);
+  });
+
+  describe('タスク登録の指示注入', () => {
+    test('exit 0 で UserPromptSubmit の additionalContext を返す', () => {
+      const { status, stdout } = runWithPrompt('ログイン画面のバグを直して');
+
+      expect(status).toBe(0);
+      const output = JSON.parse(stdout);
+      expect(output.hookSpecificOutput.hookEventName).toBe('UserPromptSubmit');
+      expect(typeof output.hookSpecificOutput.additionalContext).toBe('string');
+    });
+
+    test('着手前の TaskCreate と TaskUpdate による状態更新を指示する', () => {
+      const { stdout } = runWithPrompt('ログイン画面のバグを直して');
+      const context = JSON.parse(stdout).hookSpecificOutput.additionalContext;
+
+      expect(context).toContain('TaskCreate');
+      expect(context).toContain('TaskUpdate');
+      expect(context).toContain('in_progress');
+      expect(context).toContain('completed');
+    });
+
+    test('日本語をエスケープせず出力する（コンテキストの可読性のため）', () => {
+      const { stdout } = runWithPrompt('ログイン画面のバグを直して');
+
+      expect(stdout).not.toContain('\\u');
+    });
+  });
+
+  describe('注入しないケース', () => {
+    test.each([
+      ['空文字', ''],
+      ['空白のみ', '   \n  '],
+    ])('%s のプロンプトでは何も出力しない', (_label, prompt) => {
+      const { status, stdout } = runWithPrompt(prompt);
+
+      expect(status).toBe(0);
+      expect(stdout.trim()).toBe('');
+    });
+
+    test('prompt フィールドが無い入力でも落ちない', () => {
+      const { status, stdout } = runHook({ hook_event_name: 'UserPromptSubmit' });
+
+      expect(status).toBe(0);
+      expect(stdout.trim()).toBe('');
+    });
+  });
+
+  describe('フェイルオープン', () => {
+    // 壊れた stdin でフックが exit != 0 になると、プロンプト自体が処理されず作業が止まる。
+    test.each([
+      ['不正な JSON', 'not json at all'],
+      ['空の stdin', ''],
+    ])('%s でも exit 0 で終了する', (_label, payload) => {
+      const { status, stdout } = runHook(payload);
+
+      expect(status).toBe(0);
+      expect(stdout.trim()).toBe('');
+    });
+  });
+});

--- a/test/integration/setup_claude.bats
+++ b/test/integration/setup_claude.bats
@@ -114,9 +114,18 @@ STUB
     run bash "${REPO_ROOT}/script/setup-claude.sh"
 }
 
+# 追加 config dir は settings.json / .claude.json を持つものだけが対象になる。
+# フィクスチャも初期化済みにしないと list_extra_config_dirs から除外される。
+init_extra_config_dir() {
+  local dir="$1"
+  mkdir -p "$dir"
+  echo '{}' > "${dir}/settings.json"
+}
+
 @test "setup-claude.sh links commands/agents/skills into extra config dirs" {
   local fake_home="${TEST_TEMP_DIR}/home"
-  mkdir -p "${fake_home}/.claude"/{commands,agents,skills} "${fake_home}/.claude-private"
+  mkdir -p "${fake_home}/.claude"/{commands,agents,skills}
+  init_extra_config_dir "${fake_home}/.claude-private"
   echo "canonical" > "${fake_home}/.claude/commands/session-close.md"
 
   run_setup_in_fake_home "$fake_home"
@@ -133,7 +142,9 @@ STUB
 
 @test "setup-claude.sh links content into every extra config dir" {
   local fake_home="${TEST_TEMP_DIR}/home"
-  mkdir -p "${fake_home}/.claude/commands" "${fake_home}/.claude-private" "${fake_home}/.claude-elu"
+  mkdir -p "${fake_home}/.claude/commands"
+  init_extra_config_dir "${fake_home}/.claude-private"
+  init_extra_config_dir "${fake_home}/.claude-elu"
 
   run_setup_in_fake_home "$fake_home"
 
@@ -143,7 +154,8 @@ STUB
 
 @test "setup-claude.sh content linking is idempotent" {
   local fake_home="${TEST_TEMP_DIR}/home"
-  mkdir -p "${fake_home}/.claude/commands" "${fake_home}/.claude-private"
+  mkdir -p "${fake_home}/.claude/commands"
+  init_extra_config_dir "${fake_home}/.claude-private"
 
   run_setup_in_fake_home "$fake_home"
   [ -L "${fake_home}/.claude-private/commands" ]
@@ -156,7 +168,9 @@ STUB
 
 @test "setup-claude.sh does not clobber an existing real directory" {
   local fake_home="${TEST_TEMP_DIR}/home"
-  mkdir -p "${fake_home}/.claude/commands" "${fake_home}/.claude-private/commands"
+  mkdir -p "${fake_home}/.claude/commands"
+  init_extra_config_dir "${fake_home}/.claude-private"
+  mkdir -p "${fake_home}/.claude-private/commands"
   echo "dir-specific" > "${fake_home}/.claude-private/commands/local-only.md"
 
   run_setup_in_fake_home "$fake_home"
@@ -168,7 +182,8 @@ STUB
 
 @test "setup-claude.sh replaces a symlink that points elsewhere" {
   local fake_home="${TEST_TEMP_DIR}/home"
-  mkdir -p "${fake_home}/.claude/commands" "${fake_home}/.claude-private" "${fake_home}/stale"
+  mkdir -p "${fake_home}/.claude/commands" "${fake_home}/stale"
+  init_extra_config_dir "${fake_home}/.claude-private"
   ln -s "${fake_home}/stale" "${fake_home}/.claude-private/commands"
 
   run_setup_in_fake_home "$fake_home"
@@ -178,13 +193,31 @@ STUB
 
 @test "setup-claude.sh skips content missing from the canonical dir" {
   local fake_home="${TEST_TEMP_DIR}/home"
-  mkdir -p "${fake_home}/.claude/commands" "${fake_home}/.claude-private"
+  mkdir -p "${fake_home}/.claude/commands"
+  init_extra_config_dir "${fake_home}/.claude-private"
 
   run_setup_in_fake_home "$fake_home"
 
   # ~/.claude に skills が無いなら壊れたリンクを作らない
   [ ! -e "${fake_home}/.claude-private/skills" ]
   [ ! -L "${fake_home}/.claude-private/skills" ]
+}
+
+@test "setup-claude.sh ignores ~/.claude-* dirs that are not config dirs" {
+  local fake_home="${TEST_TEMP_DIR}/home"
+  mkdir -p "${fake_home}/.claude/commands" "${fake_home}/.claude-worklog"
+  echo '{"permissions":{"allow":[]}}' > "${fake_home}/.claude/settings.json"
+  init_extra_config_dir "${fake_home}/.claude-private"
+
+  run_setup_in_fake_home "$fake_home"
+
+  # 初期化済みの config dir には従来どおり同期される（この判定が空振りしないことの担保）
+  [ -L "${fake_home}/.claude-private/commands" ]
+  grep -q "permissions" "${fake_home}/.claude-private/settings.json"
+
+  # hook 置き場のような ~/.claude-* を config dir と誤認して汚さない
+  [ ! -e "${fake_home}/.claude-worklog/settings.json" ]
+  [ ! -e "${fake_home}/.claude-worklog/commands" ]
 }
 
 # ---------------------------------------------------------------------------

--- a/test/settings-hooks.test.js
+++ b/test/settings-hooks.test.js
@@ -49,6 +49,12 @@ describe('.claude/settings.json — hooks configuration', () => {
       expect(Array.isArray(settings.hooks.Stop)).toBe(true);
       expect(settings.hooks.Stop.length).toBeGreaterThan(0);
     });
+
+    test('should define UserPromptSubmit hooks', () => {
+      expect(settings.hooks).toHaveProperty('UserPromptSubmit');
+      expect(Array.isArray(settings.hooks.UserPromptSubmit)).toBe(true);
+      expect(settings.hooks.UserPromptSubmit.length).toBeGreaterThan(0);
+    });
   });
 
   describe('Hook entry structure', () => {
@@ -173,6 +179,24 @@ describe('.claude/settings.json — hooks configuration', () => {
     });
   });
 
+  describe('UserPromptSubmit hooks', () => {
+    // 依頼を受けた時点でタスクを登録させる導線。設定から外れると登録がモデル任せに戻る。
+    test('should reference prompt_task_reminder.py', () => {
+      const allCommands = settings.hooks.UserPromptSubmit.flatMap((e) => e.hooks.map((h) => h.command));
+      expect(allCommands.some((cmd) => cmd.includes('prompt_task_reminder.py'))).toBe(true);
+    });
+
+    // UserPromptSubmit は stdout がそのままコンテキストへ注入されるため、
+    // 未配置リポジトリでフォールバックメッセージを出さない（|| true で黙る）必要がある。
+    test('should stay silent when the hook script is absent', () => {
+      const entry = settings.hooks.UserPromptSubmit.flatMap((e) => e.hooks).find((h) =>
+        h.command.includes('prompt_task_reminder.py'),
+      );
+      expect(entry.command).toContain('|| true');
+      expect(entry.command).not.toContain('echo "[hooks]');
+    });
+  });
+
   describe('DevContainer settings parity', () => {
     // .claude/settings.json（相対パス）と .devcontainer/claude-settings.json（絶対パス）は
     // 同じ hooks を二重管理している。片方だけへの hook 追加＝ドリフトを検出する。
@@ -221,6 +245,7 @@ describe('.claude/settings.json — hooks configuration', () => {
         ...(settings.hooks.PreToolUse || []),
         ...(settings.hooks.PostToolUse || []),
         ...(settings.hooks.Stop || []),
+        ...(settings.hooks.UserPromptSubmit || []),
       ].flatMap((e) => e.hooks.map((h) => h.command));
 
       const scriptNames = extractScriptNames(allCommands);


### PR DESCRIPTION
## Why

新しい作業依頼を受けたときにタスクを作成してから着手する導線が Hooks 側に存在せず、タスク登録がモデルの裁量任せで抜けていた。既存 Hooks は「動いた後のガード」（危険コマンド、Quality Gates、PR 後の CI 監視）に偏り、「動く前の登録」を担うものが無かった。

あわせて `script/setup-claude.sh` の未初期化 `~/.claude-*` 判定（未コミットだった変更）に対応するテストが無く、`setup_claude.bats` が4件失敗していた状態を解消する。

## What

- `.claude/hooks/prompt_task_reminder.py`（新規）: `UserPromptSubmit` で「着手前に `TaskCreate`、`TaskUpdate` で `in_progress` / `completed`」の運用指示を `additionalContext` として注入
- `.claude/settings.json` / `.devcontainer/claude-settings.json`: 上記 hook を `UserPromptSubmit` に登録
- `script/setup-claude.sh`: `settings.json` か `.claude.json` を持つ dir のみを追加 config dir と見なす（hook 置き場に無用な `settings.json` を生成しない）
- テスト: hook の挙動テスト9件（実起動）、settings 登録の検証、`setup_claude.bats` のフィクスチャ修正 + 未初期化 dir を汚さない回帰テスト
- ドキュメント: `.claude/hooks/README.md` §13、`script/lib/agents-md-data.sh` 経由で `AGENTS.md` / `CLAUDE.md` の Hooks 表

## How

`UserPromptSubmit` はブロックに使わない。`exit 2` するとプロンプト自体が破棄され依頼が失われるため、注入のみで誘導する設計にした。

- 空プロンプト・壊れた stdin では何も出さず `exit 0`（フェイルオープン）
- 未配置リポジトリでは `|| true` で沈黙。このイベントは stdout がそのままコンテキストへ入るため、他 hook のような `echo "[hooks] ... not found"` フォールバックは使えない（テストで担保）

## Risk

- **低**。注入のみでツール実行をブロックしないため、失敗しても作業は止まらない
- `.claude/settings.json` は sync-downstream の配布対象。下流には hook スクリプトも同時配布されるため、未配置による事故は `|| true` で無害化済み
- 過剰なタスク作成を防ぐため、指示文に「質問だけで完結する依頼・3ステップ未満の些末な作業は不要」を明記
- Linked Issue なし（既存の運用ルールでは必須。必要なら起票します）

## Test

- Jest: 792 passed / 36 suites（新規9件を含む）
- BATS: 260 passed（`setup_claude.bats` の失敗4件を解消、回帰テスト1件追加）
- `format:check` / `lint` / `shellcheck` すべて緑

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a prompt-submission reminder that encourages task tracking for multi-step work.
  * Automatically skips simple questions, short requests, and blank or invalid input.
  * Added support for the reminder in local and development environments.

* **Bug Fixes**
  * Prevented setup from modifying uninitialized configuration directories.
  * Added an exception for a documented security vulnerability.

* **Tests**
  * Added coverage for task reminders, hook configuration, and configuration-directory handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->