### PR TITLE
fix(test): gh 不在テストが macOS で bash 3.2 に阻まれる問題を修正

### DIFF
--- a/test/integration/setup_team_protection.bats
+++ b/test/integration/setup_team_protection.bats
@@ -68,7 +68,13 @@ EOF
 }
 
 @test "fails with installation guidance when gh CLI is missing" {
-  local minimal_path="/usr/bin:/bin"
+  # gh だけを取り除いた PATH を作る。/usr/bin:/bin だけにすると macOS では
+  # bash 3.2 が使われ、lib/output.sh の bash 4.0+ チェックで先に落ちてしまい
+  # gh 不在時の分岐まで到達できない。
+  mkdir -p "${TEST_TEMP_DIR}/bin"
+  ln -sf "$(command -v bash)" "${TEST_TEMP_DIR}/bin/bash"
+  local minimal_path="${TEST_TEMP_DIR}/bin:/usr/bin:/bin"
+
   if PATH="$minimal_path" command -v gh >/dev/null 2>&1; then
     skip "gh is available in the minimal PATH"
   fi


### PR DESCRIPTION
Closes #1030

## Why

`setup_team_protection.bats` の「gh 不在時のインストール案内」テストが、macOS ローカルで
恒常的に赤かった。`PATH=/usr/bin:/bin` に絞ると `#!/usr/bin/env bash` が macOS 標準の
**bash 3.2** を拾い、`lib/output.sh` の bash 4.0+ チェックで先に終了してしまうため、
検証したい分岐に到達していなかった。

```console
$ env PATH="/usr/bin:/bin" ./script/setup-team-protection.sh owner/repo --dry-run
エラー: このライブラリは bash 4.0 以降が必要です (現在: 3.2.57(1)-release)
```

CI は Linux（bash 5）で走るため顕在化しない。

## What

bash 4+ への symlink だけを置いた一時 bin を PATH の先頭に足し、**gh のみが不在**の
状態を作る。テストの意図（gh 不在時の挙動の検証）は変えていない。

## Test

修正後、`setup_team_protection.bats` は macOS ローカルで 14/14 緑。
統合テスト全体（283 件）も失敗ゼロを確認した。

修正前は該当テストが `not ok` になり、スクリプトを直接叩くと bash 3.2 のエラーで
止まることを確認済み（上記コンソール出力）。修正後は期待どおり
`GitHub CLI (gh) is not installed` に到達する。

## Risk

テスト側のみの変更で、プロダクションコードには触れていない。
Linux CI では `command -v bash` が bash 5 を返すため、挙動は従来どおり。

🤖 Generated with [Claude Code](https://claude.com/claude-code)