### PR TITLE
fix(macos): kanary helper が activation の PATH でツールを解決できない問題を修正

### DIFF
--- a/script/macos/kanary-enforce-caps-control.sh
+++ b/script/macos/kanary-enforce-caps-control.sh
@@ -23,6 +23,15 @@ set -euo pipefail
 DOMAIN="download.kanary.settings"
 PLIST="${HOME}/Library/Preferences/${DOMAIN}.plist"
 
+# `darwin-rebuild switch` の home-manager activation は PATH を nix store だけに
+# 差し替えて実行する (/usr/bin も /bin も含まれない)。そのままだと
+# plutil / defaults / pgrep / osascript / open / python3 がすべて名前解決できず、
+# read_caps が unknown を返してこの helper が毎回サイレントにスキップされる。
+# さらに base64 が GNU coreutils 側に解決されると macOS 固有の -D が使えない。
+# このスクリプトは macOS 専用なので、標準パスを先頭に置いて system 版を使わせる。
+PATH="/usr/bin:/bin:/usr/sbin:/sbin:$PATH"
+export PATH
+
 log() { printf 'kanary: %s\n' "$*"; }
 
 # Kanary never launched yet -> nothing to enforce.

--- a/test/integration/kanary_enforce_caps_control.bats
+++ b/test/integration/kanary_enforce_caps_control.bats
@@ -1,0 +1,78 @@
+#!/usr/bin/env bats
+# kanary-enforce-caps-control.sh の振る舞いテスト
+#
+# 回帰の対象: darwin-rebuild の home-manager activation は PATH を nix store だけに
+# 差し替えるため、/usr/bin にしか無い plutil / defaults / python3 等が解決できず、
+# この helper が毎回サイレントにスキップされていた（エラーで落ちないので気付けない）。
+
+load ../test_helper/test_helper
+
+SCRIPT() { echo "$REPO_ROOT/script/macos/kanary-enforce-caps-control.sh"; }
+
+# macOS 専用スクリプトなので、それ以外では丸ごとスキップする
+require_macos() {
+    [ "$(uname -s)" = "Darwin" ] || skip "macOS only (plutil/defaults required)"
+}
+
+# 偽 HOME に Kanary の設定 plist を作る。$1 = true|false
+write_settings() {
+    local caps="$1"
+    mkdir -p "$TEST_TEMP_DIR/Library/Preferences"
+    local plist="$TEST_TEMP_DIR/Library/Preferences/download.kanary.settings.plist"
+    local json="{\"settings\":{\"windowMoveResize\":{\"capsLockRemappedToControl\":$caps}}}"
+    /usr/bin/plutil -create binary1 "$plist"
+    /usr/bin/plutil -insert app_settings -data "$(printf '%s' "$json" | /usr/bin/base64)" "$plist"
+}
+
+# /usr/bin を含まない PATH を作る（bash だけは shebang 解決のために置く）。
+# activation 時の「nix store だけの PATH」を再現する。
+restricted_path() {
+    mkdir -p "$TEST_TEMP_DIR/bin"
+    ln -sf "$(command -v bash)" "$TEST_TEMP_DIR/bin/bash"
+    echo "$TEST_TEMP_DIR/bin"
+}
+
+@test "kanary-enforce-caps-control.sh exists and is executable" {
+    assert_file_exists "$REPO_ROOT/script/macos/kanary-enforce-caps-control.sh"
+    [ -x "$REPO_ROOT/script/macos/kanary-enforce-caps-control.sh" ]
+}
+
+@test "prepends the macOS system paths so activation can resolve its tools" {
+    # PATH に /usr/bin が無い状態でも動く必要があるため、標準パスを先頭に足している。
+    grep -q 'PATH="/usr/bin:/bin:/usr/sbin:/sbin:\$PATH"' "$(SCRIPT)"
+}
+
+@test "reads the setting even when PATH lacks /usr/bin" {
+    require_macos
+    write_settings true
+
+    run env HOME="$TEST_TEMP_DIR" PATH="$(restricted_path)" "$(SCRIPT)"
+    assert_success
+    # 読めなかったときだけ出るメッセージ。出ていたら PATH 解決に失敗している。
+    ! printf '%s\n' "$output" | grep -q 'could not read'
+    ! printf '%s\n' "$output" | grep -q 'command not found'
+}
+
+@test "is a silent no-op when the setting is already true" {
+    require_macos
+    write_settings true
+
+    run env HOME="$TEST_TEMP_DIR" PATH="$(restricted_path)" "$(SCRIPT)"
+    assert_success
+    [ -z "$output" ]
+}
+
+# NOTE: 「設定が false のときに有効化する」書き込み経路はテストしない。
+# `defaults write` は HOME ではなく cfprefsd 経由でユーザーの実ドメインに書くため、
+# 偽 HOME を渡しても本物の Kanary 設定を上書きしてしまう（実際に事故を起こした）。
+# さらに実行中の Kanary を quit する副作用もある。PATH 解決の回帰は上の
+# 「reads the setting even when PATH lacks /usr/bin」で十分に押さえられている。
+
+@test "skips quietly when Kanary has never been launched" {
+    require_macos
+    # plist を作らない
+
+    run env HOME="$TEST_TEMP_DIR" PATH="$(restricted_path)" "$(SCRIPT)"
+    assert_success
+    printf '%s\n' "$output" | grep -q 'settings not found'
+}


### PR DESCRIPTION
Closes #1034

## Why

`darwin-rebuild switch` のたびに `python3: command not found` が出て、Kanary の
CapsLock→Control 強制が**毎回スキップされていた**。`|| true` で握りつぶしているため
activation は成功扱いになり、失敗が表に出ない。

調べると python3 だけの問題ではなかった。home-manager の activation は PATH を
**nix store のパスだけ**に差し替えるため、このスクリプトが使う macOS 標準ツールが
軒並み解決できない。

| コマンド | activation PATH での解決 |
| --- | --- |
| `python3` / `plutil` / `defaults` / `pgrep` / `osascript` / `open` | ❌ 未解決 |
| `base64` | ⚠️ GNU coreutils 側に解決される（macOS 固有の `-D` が使えない） |

エラーとして表に出たのが `python3` だけだったのは、`read_caps` のパイプラインで
`plutil` と `base64` の stderr を `2>/dev/null` で捨てており、最後段の `python3` だけが
素通しだったため。

## What

`script/macos/` 配下の macOS 専用スクリプトなので、**標準パスを PATH の先頭に置いて
system 版を使わせる**（2行）。個別に絶対パス化するより変更が小さく、`base64` が GNU 版に
解決される問題も同時に解消する。

## Test

実 activation と同じ「`/usr/bin` を含まない PATH」を偽 HOME 上で再現する BATS を追加（5件）。
bash だけを置いた一時 bin を PATH にすることで、shebang は解決しつつ macOS ツールだけが
見えない状態を作っている。macOS 以外では `skip`。

**ネガティブコントロール実施済み**: PATH 追加の2行を外すと3件が赤になる。

修正前後を実際の activation PATH で流して確認した。

```console
# 修正前
$ env -i HOME=<fixture> PATH="$ACT_PATH" ./script/macos/kanary-enforce-caps-control.sh
...: 行 37: python3: command not found
kanary: could not read capsLockRemappedToControl (schema changed?); skipping

# 修正後
$ env -i HOME=<fixture> PATH="$ACT_PATH" ./script/macos/kanary-enforce-caps-control.sh
（無出力・exit 0 ＝ true と読めて正常終了）
```

Quality Gates は prettier / eslint / shellcheck / jest 807 件いずれも緑。

## Risk

**設定が false のときの書き込み経路はテストしていない。** `defaults write` は HOME ではなく
cfprefsd 経由でユーザーの実ドメインに書くため、偽 HOME を渡しても本物の Kanary 設定を
上書きしてしまう（テスト作成中に実際に事故を起こし、バックアップから復旧した）。実行中の
Kanary を quit する副作用もある。この経緯はテストファイルにコメントとして残した。

PATH 解決の回帰は「`/usr/bin` を含まない PATH で設定を読めること」で十分に押さえられている。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved macOS activation reliability by ensuring required system utilities remain available in restricted environments.
  * Kanary settings are now handled gracefully when the application has not been launched or the setting is already enabled.

* **Tests**
  * Added integration coverage for restricted PATH environments, missing settings, existing enabled settings, script execution, and expected output.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->