### PR TITLE
fix(nix): skhd を固定 identity で署名し TCC 許可が更新で失効しないようにする

### DIFF
--- a/nix/hosts/darwin/default.nix
+++ b/nix/hosts/darwin/default.nix
@@ -200,16 +200,44 @@
   # skhd 更新のたびに TCC (アクセシビリティ) 許可の再付与が必要になる。
   # activation で /usr/local/bin/skhd に実体コピーした安定パスから起動することで、
   # 許可対象のパスを固定する。
+  #
+  # ただしパスの固定だけでは足りない。nixpkgs の skhd は ad-hoc (linker-signed)
+  # なので TCC は cdhash で許可を紐付けており、コピーの中身が変わると許可が失効する。
+  # しかも ad-hoc バイナリは同定が不安定で、システム設定で許可を付け直しても
+  # launchd が直接起動したプロセスには適用されない (ターミナルから手動起動した
+  # ときだけ親の許可を継承して動く)。
+  # そこでコピー後に固定の自己署名 identity で署名し、TCC が designated
+  # requirement で紐付けるようにする。identity の作成は管理者認証を伴うため
+  # script/macos/setup-skhd-signing.sh を本人が一度実行する。未作成のうちは
+  # 署名を飛ばすだけで、従来どおりの動作を壊さない。
   environment.etc."skhdrc".text = ''
     ctrl + shift - j    : /Users/${username}/.local/bin/send-ime-key kana
     ctrl + shift - 0x29 : /Users/${username}/.local/bin/send-ime-key eisuu
   '';
 
   system.activationScripts.postActivation.text = ''
-    if ! cmp -s "${pkgs.skhd}/bin/skhd" /usr/local/bin/skhd; then
+    skhdSigningIdentity=skhd-local-signing
+
+    # 署名済みのコピーは中身が元バイナリと一致しないため、cmp ではなく
+    # 「元バイナリと同じ内容から作られた署名か」を cdhash 相当で判定できない。
+    # ここでは元バイナリのハッシュを控えておき、それが変わったときだけ入れ替える。
+    skhdStampFile=/usr/local/bin/.skhd.nix-source-hash
+    skhdWant=$(/usr/bin/shasum -a 256 "${pkgs.skhd}/bin/skhd" | cut -d' ' -f1)
+    skhdHave=$(cat "$skhdStampFile" 2>/dev/null || echo none)
+
+    if [ "$skhdWant" != "$skhdHave" ] || [ ! -x /usr/local/bin/skhd ]; then
       mkdir -p /usr/local/bin
       install -m 755 "${pkgs.skhd}/bin/skhd" /usr/local/bin/skhd
       echo "installed skhd to /usr/local/bin/skhd"
+
+      if /usr/bin/security find-identity -v -p codesigning /Library/Keychains/System.keychain 2>/dev/null | grep -q "$skhdSigningIdentity"; then
+        /usr/bin/codesign --force --sign "$skhdSigningIdentity" --identifier org.nixos.skhd --timestamp=none /usr/local/bin/skhd
+        echo "signed skhd with $skhdSigningIdentity"
+      else
+        echo "skhd: signing identity '$skhdSigningIdentity' not found; run script/macos/setup-skhd-signing.sh to keep the accessibility grant across updates"
+      fi
+
+      printf '%s\n' "$skhdWant" > "$skhdStampFile"
     fi
   '';
 

--- a/script/macos/setup-skhd-signing.sh
+++ b/script/macos/setup-skhd-signing.sh
@@ -1,0 +1,98 @@
+#!/usr/bin/env bash
+#
+# skhd を安定した identity で自己署名できるようにする一度きりのセットアップ。
+#
+# Why this exists:
+#   nix-darwin は skhd を /usr/local/bin/skhd に実体コピーして launchd から起動する。
+#   このバイナリは ad-hoc (linker-signed) のため、macOS の TCC は cdhash で
+#   アクセシビリティ許可を紐付ける。nixpkgs の skhd が更新されてコピーの中身が
+#   変わると cdhash も変わり、許可が無効化される。
+#
+#   さらに厄介なことに、ad-hoc バイナリは同定が不安定なため、システム設定で
+#   許可を付け直しても **launchd が直接起動したプロセスには適用されない**
+#   (ターミナルから手動起動した場合だけ親プロセスの許可を継承して動く)。
+#
+#   固定の自己署名証明書で署名すると TCC は cdhash ではなく designated
+#   requirement で紐付けるようになり、skhd を更新しても許可が保持される。
+#
+# Why this is not run automatically:
+#   キーチェーンへの証明書取り込みと信頼設定は管理者認証を伴うため、
+#   本人が対話的に実行する必要がある。
+#
+# Usage: sudo ./script/macos/setup-skhd-signing.sh
+#
+# 実行後は `darwin-rebuild switch` (make nix-switch) を一度流すと、activation が
+# /usr/local/bin/skhd をこの identity で署名する。その後システム設定 >
+# プライバシーとセキュリティ > アクセシビリティ で skhd を一度削除して追加し直すと、
+# 以後は skhd を更新しても許可が維持される。
+
+set -euo pipefail
+
+IDENTITY="skhd-local-signing"
+KEYCHAIN="/Library/Keychains/System.keychain"
+WORKDIR="$(mktemp -d)"
+trap 'rm -rf "$WORKDIR"' EXIT
+
+if [ "$(id -u)" -ne 0 ]; then
+    echo "エラー: root で実行してください (sudo $0)" >&2
+    exit 1
+fi
+
+if security find-identity -v -p codesigning "$KEYCHAIN" 2>/dev/null | grep -q "$IDENTITY"; then
+    echo "identity '$IDENTITY' は既に存在します。何もしません。"
+    exit 0
+fi
+
+echo "[1/4] 自己署名の code signing 証明書を作成します"
+# extendedKeyUsage=codeSigning と basicConstraints を明示しないと codesign が受け付けない。
+cat > "$WORKDIR/openssl.cnf" <<'CNF'
+[req]
+distinguished_name = dn
+x509_extensions    = ext
+prompt             = no
+
+[dn]
+CN = skhd-local-signing
+
+[ext]
+basicConstraints       = critical,CA:false
+keyUsage               = critical,digitalSignature
+extendedKeyUsage       = critical,codeSigning
+CNF
+
+openssl req -x509 -newkey rsa:2048 -nodes -days 3650 \
+    -config "$WORKDIR/openssl.cnf" \
+    -keyout "$WORKDIR/key.pem" -out "$WORKDIR/cert.pem" 2>/dev/null
+
+openssl pkcs12 -export -inkey "$WORKDIR/key.pem" -in "$WORKDIR/cert.pem" \
+    -out "$WORKDIR/bundle.p12" -passout pass: 2>/dev/null
+
+echo "[2/4] System キーチェーンに取り込みます"
+# root の activation から codesign が秘密鍵を使えるよう、System キーチェーンに入れる。
+# -A は「どのアプリからも使用可」の意味で、これが無いと codesign 実行時に
+# 対話プロンプトが出て activation が止まる。
+security import "$WORKDIR/bundle.p12" -k "$KEYCHAIN" -P "" -A \
+    -T /usr/bin/codesign -T /usr/bin/security >/dev/null
+
+echo "[3/4] 証明書を code signing 用として信頼します"
+security add-trusted-cert -d -r trustRoot -p codeSign -k "$KEYCHAIN" "$WORKDIR/cert.pem"
+
+echo "[4/4] 確認"
+if security find-identity -v -p codesigning "$KEYCHAIN" | grep -q "$IDENTITY"; then
+    echo "  OK: identity '$IDENTITY' を作成しました"
+else
+    echo "  NG: identity が見つかりません" >&2
+    exit 1
+fi
+
+cat <<MSG
+
+次の手順:
+  1. make nix-switch          (activation が skhd をこの identity で署名する)
+  2. システム設定 > プライバシーとセキュリティ > アクセシビリティ で
+     skhd を「−」で削除してから「＋」で /usr/local/bin/skhd を追加し直す
+     (⌘⇧G でパスを直接指定できる)
+  3. launchctl kickstart -k gui/\$(id -u)/org.nixos.skhd
+
+以後 skhd が更新されても許可は保持される。
+MSG

--- a/test/nix-darwin-config-input-method.test.js
+++ b/test/nix-darwin-config-input-method.test.js
@@ -32,6 +32,33 @@ describe('nix-darwin and home-manager input method configuration', () => {
     expect(darwinHost).toContain('/Users/${username}/.local/bin/send-ime-key eisuu');
   });
 
+  test('skhd copy is signed with a stable identity so the accessibility grant survives updates', () => {
+    const darwinHost = readRepoFile('nix/hosts/darwin/default.nix');
+    const setupScript = readRepoFile('script/macos/setup-skhd-signing.sh');
+
+    // nixpkgs の skhd は ad-hoc 署名なので TCC が cdhash で許可を紐付ける。
+    // 更新でコピーの中身が変わると許可が失効し、しかも ad-hoc バイナリは
+    // launchd 起動時に許可が適用されない。固定 identity で署名して回避する。
+    expect(darwinHost).toContain('skhdSigningIdentity=skhd-local-signing');
+    expect(darwinHost).toContain('/usr/bin/codesign --force --sign "$skhdSigningIdentity"');
+    expect(darwinHost).toContain('--identifier org.nixos.skhd');
+
+    // identity が未作成でも activation を壊さないこと (署名を飛ばすだけ)
+    expect(darwinHost).toContain('/usr/bin/security find-identity -v -p codesigning');
+    expect(darwinHost).toContain('run script/macos/setup-skhd-signing.sh');
+
+    // 署名するとコピーは元バイナリと一致しなくなるため、cmp ではなく
+    // 元バイナリのハッシュを控えて入れ替え要否を判定する
+    expect(darwinHost).toContain('skhdStampFile=/usr/local/bin/.skhd.nix-source-hash');
+    expect(darwinHost).not.toContain('cmp -s "${pkgs.skhd}/bin/skhd" /usr/local/bin/skhd');
+
+    // セットアップ側は System キーチェーンに入れる (root の activation から使うため)
+    expect(setupScript).toContain('IDENTITY="skhd-local-signing"');
+    expect(setupScript).toContain('KEYCHAIN="/Library/Keychains/System.keychain"');
+    expect(setupScript).toContain('extendedKeyUsage       = critical,codeSigning');
+    expect(setupScript).toContain('add-trusted-cert');
+  });
+
   test('input source helper exposes macOS input source selection commands', () => {
     const inputSourceModule = readRepoFile('nix/home/input-source.nix');
     const inputSourceWrapper = readRepoFile('script/macos/agent-select-input-source.sh');


### PR DESCRIPTION
Closes #1036

## Why

`make nix-switch` の後に skhd が launchd から起動できなくなり、IME 切替ショートカット
（`Ctrl+Shift+J` / `Ctrl+Shift+;`）が丸ごと効かなくなった。実際に本日発生した。

切り分けた結果、設定・引数・ロックはいずれも原因ではなく、`/usr/local/bin/skhd` が
**ad-hoc (linker-signed)** であることが原因だった。ad-hoc バイナリには安定した
designated requirement が無いため TCC は cdhash で許可を紐付ける。結果として:

1. skhd が更新されてコピーの中身が変わると **cdhash が変わり許可が失効する**
2. 同定が不安定なため、システム設定で許可を付け直しても **launchd が直接起動した
   プロセスには適用されない**（ターミナルから手動起動したときだけ親の許可を継承して動く）

既存の「`/usr/local/bin` へコピーしてパスを固定する」対策はパスしか固定しておらず、
1 も 2 も防げていなかった。

## What

コピー後に固定の自己署名 identity（`skhd-local-signing`）で署名する。

- `script/macos/setup-skhd-signing.sh` を追加。自己署名の code signing 証明書を作り、
  **System キーチェーン**に取り込んで信頼する（root の activation から `codesign` が
  秘密鍵を使えるようにするため）。管理者認証を伴うので本人が一度だけ実行する
- activation はコピー後に `codesign --force --sign` する。**identity が未作成のうちは
  署名を飛ばして案内を出すだけ**で、従来動作を壊さない
- 署名するとコピーは元バイナリと一致しなくなるため、入れ替え判定を `cmp` から
  元バイナリのハッシュ比較（`.skhd.nix-source-hash`）へ変更した

## Test

`make nix-build` で評価・ビルドが通ることを確認し、**生成された activation スクリプトを
実際に読んで** nix の補間（store パス）と shell 変数が意図どおり展開されていることを検証した。

nix 設定とセットアップスクリプトの契約を Jest で固定（既存の input-method テストに追加）。
identity 未作成時に署名を飛ばすガードと、`cmp` 判定が残っていないことも assert している。

Quality Gates は prettier / eslint / shellcheck / jest 808 件いずれも緑。

## Risk

- **署名の効果自体は本番適用でしか検証できない。** 証明書のキーチェーン取り込みは
  管理者認証が要るため CI でも手元でも自動検証できない。同じ手法で ad-hoc 署名由来の
  TCC リセットを解決した実績が `health-mac` にある（2026-07-28）
- 適用手順は次のとおり:
  1. `sudo ./script/macos/setup-skhd-signing.sh`
  2. `make nix-switch`
  3. システム設定 > アクセシビリティ で skhd を削除して再追加
  4. `launchctl kickstart -k gui/$(id -u)/org.nixos.skhd`
- 3 が最後に一度だけ必要なのは、署名によって identity が変わるため。以後の skhd 更新では不要になる

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved macOS `skhd` updates to preserve Accessibility permissions across changes.
  * Added a setup script for creating and configuring a stable local signing identity.
  * Added guidance for restoring permissions and restarting `skhd` when initial setup is required.

* **Bug Fixes**
  * `skhd` is now automatically reinstalled and signed only when its source binary changes.
  * Added warnings when the required signing identity is unavailable.

* **Tests**
  * Added coverage for signing, activation, keychain configuration, and update detection.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->