### PR TITLE
fix(ci): claude.yml テンプレートに認証ガードを追加し未設定時のCI失敗を防止

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -98,8 +98,7 @@ jobs:
 
       - name: Run Claude Code
         id: claude
-        if: steps.claude-auth.outputs.available == 'true'
-        if: steps.pr_draft.outputs.is_draft != 'true'
+        if: steps.pr_draft.outputs.is_draft != 'true' && steps.claude-auth.outputs.available == 'true'
         uses: anthropics/claude-code-action@a92e7c70a4da9793dc164451d829089dc057a464 # v1
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -79,8 +79,26 @@ jobs:
         with:
           fetch-depth: 1
 
+      - name: Check Claude authentication
+        id: claude-auth
+        env:
+          CLAUDE_CODE_OAUTH_TOKEN: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+          ANTHROPIC_FEDERATION_RULE_ID: ${{ secrets.ANTHROPIC_FEDERATION_RULE_ID }}
+          ANTHROPIC_ORGANIZATION_ID: ${{ secrets.ANTHROPIC_ORGANIZATION_ID }}
+        run: |
+          if [ -n "$CLAUDE_CODE_OAUTH_TOKEN" ] ||
+             [ -n "$ANTHROPIC_API_KEY" ] ||
+             { [ -n "$ANTHROPIC_FEDERATION_RULE_ID" ] && [ -n "$ANTHROPIC_ORGANIZATION_ID" ]; }; then
+            echo "available=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "available=false" >> "$GITHUB_OUTPUT"
+            echo "::notice::Skipping Claude Code because no Claude authentication secret is configured."
+          fi
+
       - name: Run Claude Code
         id: claude
+        if: steps.claude-auth.outputs.available == 'true'
         if: steps.pr_draft.outputs.is_draft != 'true'
         uses: anthropics/claude-code-action@a92e7c70a4da9793dc164451d829089dc057a464 # v1
         with:

--- a/templates/workflows/claude.yml
+++ b/templates/workflows/claude.yml
@@ -94,9 +94,26 @@ jobs:
         with:
           fetch-depth: 1
 
+      - name: Check Claude authentication
+        id: claude-auth
+        env:
+          CLAUDE_CODE_OAUTH_TOKEN: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+          ANTHROPIC_FEDERATION_RULE_ID: ${{ secrets.ANTHROPIC_FEDERATION_RULE_ID }}
+          ANTHROPIC_ORGANIZATION_ID: ${{ secrets.ANTHROPIC_ORGANIZATION_ID }}
+        run: |
+          if [ -n "$CLAUDE_CODE_OAUTH_TOKEN" ] ||
+             [ -n "$ANTHROPIC_API_KEY" ] ||
+             { [ -n "$ANTHROPIC_FEDERATION_RULE_ID" ] && [ -n "$ANTHROPIC_ORGANIZATION_ID" ]; }; then
+            echo "available=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "available=false" >> "$GITHUB_OUTPUT"
+            echo "::notice::Skipping Claude Code because no Claude authentication secret is configured."
+          fi
+
       - name: Run Claude Code
         id: claude
-        if: steps.pr_draft.outputs.is_draft != 'true'
+        if: steps.pr_draft.outputs.is_draft != 'true' && steps.claude-auth.outputs.available == 'true'
         uses: anthropics/claude-code-action@a92e7c70a4da9793dc164451d829089dc057a464 # v1
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}


### PR DESCRIPTION
## Why
認証シークレット (`CLAUDE_CODE_OAUTH_TOKEN` / `ANTHROPIC_API_KEY` / federation) が未設定のリポジトリで、`@claude` トリガーのたびに `anthropics/claude-code-action` が `Environment variable validation failed` で失敗し、GitHub Actions が赤くなっていた。OYKOT-jp 組織横断で多発。

## What
テンプレート `claude.yml` に `claude-code-review.yml` と同じ `Check Claude authentication` ステップを追加し、`Run Claude Code` を `if: steps.claude-auth.outputs.available == 'true'` でガード。未設定時は skip（job成功=緑）になる。

## How
downstream-template-auto-sync（ADR 0019）で各リポに伝播。既にOYKOT-jpの36リポには同等のガードを個別適用済みで、本PRはテンプレート正本を追従させ新規リポでの再発を防ぐもの。

## Risk
低。トークン設定済みリポは従来どおり稼働、未設定リポは fail→skip に変わるのみ。YAML構文検証済み。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for detecting multiple Claude authentication methods.
  * Claude execution now runs only when valid credentials are available.
  * Added a notice when no Claude credentials are configured.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->