### PR TITLE
fix(ci): 変更なし@claudeタスクでPR作成ステップが失敗する問題を修正

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -133,8 +133,8 @@ jobs:
           fi
 
           if ! git ls-remote --exit-code --heads origin "$CLAUDE_BRANCH" >/dev/null; then
-            echo "Claude branch $CLAUDE_BRANCH was not pushed."
-            exit 1
+            echo "Claude branch $CLAUDE_BRANCH was not pushed (no code changes). Skipping PR creation."
+            exit 0
           fi
 
           EXISTING_PR=$(gh pr list --head "$CLAUDE_BRANCH" --state open --json number --jq '.[0].number // empty')

--- a/templates/workflows/claude.yml
+++ b/templates/workflows/claude.yml
@@ -148,8 +148,8 @@ jobs:
           fi
 
           if ! git ls-remote --exit-code --heads origin "$CLAUDE_BRANCH" >/dev/null; then
-            echo "Claude branch $CLAUDE_BRANCH was not pushed."
-            exit 1
+            echo "Claude branch $CLAUDE_BRANCH was not pushed (no code changes). Skipping PR creation."
+            exit 0
           fi
 
           EXISTING_PR=$(gh pr list --head "$CLAUDE_BRANCH" --state open --json number --jq '.[0].number // empty')

--- a/test/claude-workflow-contract.test.js
+++ b/test/claude-workflow-contract.test.js
@@ -64,8 +64,9 @@ describe('Claude workflow contracts', () => {
     expect(workflow).toContain('GH_TOKEN: ${{ secrets.CLAUDE_PR_GITHUB_TOKEN || github.token }}');
     expect(workflow).toContain('gh pr create');
     expect(workflow).toContain('git ls-remote --exit-code --heads origin "$CLAUDE_BRANCH"');
-    expect(workflow).toContain('Claude branch $CLAUDE_BRANCH was not pushed.');
-    expect(workflow).not.toContain('Claude branch $CLAUDE_BRANCH was not pushed. Skipping PR creation.');
+    // 変更なしタスク（ブランチ未push）は正常終了として扱う（false failure 防止）
+    expect(workflow).toContain('Claude branch $CLAUDE_BRANCH was not pushed (no code changes). Skipping PR creation.');
+    expect(workflow).not.toMatch(/was not pushed\."\n\s*exit 1/);
     expect(workflow).not.toMatch(/Bash\(gh pr create:\*\)/);
     expect(workflow).not.toContain('github_token: ${{ github.token }}');
     expect(workflow).not.toContain('"allowedTools"');


### PR DESCRIPTION
## Why
`@claude` タスクが「コード変更なし」で終わると、`branch_name` は出力されるがブランチは push されないため、PR作成ステップの `git ls-remote` が失敗し `exit 1` → run が赤くなっていた（質問回答・調査のみ・変更不要と判断したケースで発生）。

## What
「ブランチ未push」を異常ではなく正常終了として扱う（`exit 1` → メッセージ出力 + `exit 0`）。`.github/workflows/claude.yml` と `templates/workflows/claude.yml` の両方を修正。

## How
変更なしは Skipping PR creation として終了。OYKOT-jp の36リポには同修正を個別反映済み（当リポの downstream-sync 対象は keito4 個人5リポのみのため）。

## Risk
低。変更を伴うタスクは従来どおり branch push→PR作成。変更なしタスクが false failure にならなくなるのみ。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Automated workflow runs now complete successfully when no code changes are generated.
  * Added clear logging to indicate when no changes were pushed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->