### PR TITLE
fix(ci): Claude生成PRをリポジトリ担当者へ自動アサイン

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -126,6 +126,7 @@ jobs:
           DEFAULT_BRANCH: ${{ github.event.repository.default_branch }}
           ISSUE_NUMBER: ${{ github.event.issue.number }}
           ISSUE_TITLE: ${{ github.event.issue.title }}
+          PR_ASSIGNEE: ${{ vars.CLAUDE_PR_ASSIGNEE }}
         run: |
           if [ -z "$CLAUDE_BRANCH" ]; then
             echo "Claude did not create a branch. Skipping PR creation."
@@ -150,8 +151,14 @@ jobs:
 
           BODY=$(printf "Closes #%s\n\nCreated automatically from Claude Code branch \`%s\`." "$ISSUE_NUMBER" "$CLAUDE_BRANCH")
 
+          ASSIGNEE_ARGS=()
+          if [ -n "$PR_ASSIGNEE" ]; then
+            ASSIGNEE_ARGS=(--assignee "$PR_ASSIGNEE")
+          fi
+
           gh pr create \
             --head "$CLAUDE_BRANCH" \
             --base "$DEFAULT_BRANCH" \
             --title "$TITLE" \
-            --body "$BODY"
+            --body "$BODY" \
+            "${ASSIGNEE_ARGS[@]}"

--- a/templates/workflows/claude.yml
+++ b/templates/workflows/claude.yml
@@ -141,6 +141,7 @@ jobs:
           DEFAULT_BRANCH: ${{ github.event.repository.default_branch }}
           ISSUE_NUMBER: ${{ github.event.issue.number }}
           ISSUE_TITLE: ${{ github.event.issue.title }}
+          PR_ASSIGNEE: ${{ vars.CLAUDE_PR_ASSIGNEE }}
         run: |
           if [ -z "$CLAUDE_BRANCH" ]; then
             echo "Claude did not create a branch. Skipping PR creation."
@@ -165,8 +166,14 @@ jobs:
 
           BODY=$(printf "Closes #%s\n\nCreated automatically from Claude Code branch \`%s\`." "$ISSUE_NUMBER" "$CLAUDE_BRANCH")
 
+          ASSIGNEE_ARGS=()
+          if [ -n "$PR_ASSIGNEE" ]; then
+            ASSIGNEE_ARGS=(--assignee "$PR_ASSIGNEE")
+          fi
+
           gh pr create \
             --head "$CLAUDE_BRANCH" \
             --base "$DEFAULT_BRANCH" \
             --title "$TITLE" \
-            --body "$BODY"
+            --body "$BODY" \
+            "${ASSIGNEE_ARGS[@]}"

--- a/test/claude-workflow-contract.test.js
+++ b/test/claude-workflow-contract.test.js
@@ -63,6 +63,9 @@ describe('Claude workflow contracts', () => {
     expect(workflow).toContain('name: Create pull request from Claude branch');
     expect(workflow).toContain('GH_TOKEN: ${{ secrets.CLAUDE_PR_GITHUB_TOKEN || github.token }}');
     expect(workflow).toContain('gh pr create');
+    expect(workflow).toContain('PR_ASSIGNEE: ${{ vars.CLAUDE_PR_ASSIGNEE }}');
+    expect(workflow).toContain('ASSIGNEE_ARGS=(--assignee "$PR_ASSIGNEE")');
+    expect(workflow).toContain('"${ASSIGNEE_ARGS[@]}"');
     expect(workflow).toContain('git ls-remote --exit-code --heads origin "$CLAUDE_BRANCH"');
     // 変更なしタスク（ブランチ未push）は正常終了として扱う（false failure 防止）
     expect(workflow).toContain('Claude branch $CLAUDE_BRANCH was not pushed (no code changes). Skipping PR creation.');


### PR DESCRIPTION
## 変更内容

- `CLAUDE_PR_ASSIGNEE` リポジトリ変数をClaude生成PRへ自動設定
- 未設定時は従来どおりassigneeなしで作成
- 実ワークフローと配布テンプレートを同期
- 契約テストを追加

## 背景

OYKOT-jp配下でClaude生成PRがassigneeなしのまま滞留していました。リポジトリごとの担当者は変数で管理し、担当変更時にワークフローを書き換えず差し替えられるようにします。

## 確認

- OYKOT-jpの対象15リポジトリへ `CLAUDE_PR_ASSIGNEE` を設定済み
- 既存の同種open PR 62件へ担当者をアサイン済み
- OYKOT-jpの14リポジトリは更新済み、ルールセット対象の1リポジトリはPR #220で反映中

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added optional pull-request assignee configuration for automated pull requests.
  * Pull requests can now be automatically assigned when an assignee is configured; otherwise, behavior remains unchanged.

* **Tests**
  * Added coverage to verify the assignee configuration and pull-request creation behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->