### PR TITLE
fix(ci): claude-review を OAuth 優先にし失効 API キーによる無言失敗を解消する

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -106,7 +106,10 @@ jobs:
         uses: anthropics/claude-code-action@be7b93b1907a4abad570368f3c74b6fe3807510b # v1
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
-          anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
+          # Claude CLI は ANTHROPIC_API_KEY を OAuth トークンより優先する（ADR 0013）。
+          # OAuth が設定されている限り API キーは渡さない。渡すと失効キーが OAuth を
+          # 握り潰し、401 を約 180 秒リトライしたのちエラー本文なしで失敗する。
+          anthropic_api_key: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN == '' && secrets.ANTHROPIC_API_KEY || '' }}
           anthropic_federation_rule_id: ${{ secrets.ANTHROPIC_FEDERATION_RULE_ID }}
           anthropic_organization_id: ${{ secrets.ANTHROPIC_ORGANIZATION_ID }}
 

--- a/docs/adr/0013-takt-repo-maintenance-orchestration.md
+++ b/docs/adr/0013-takt-repo-maintenance-orchestration.md
@@ -62,6 +62,17 @@ OAuth token reaches the Claude CLI unchanged. Because the CLI prefers
 variables when an OAuth token is present, so the credential that was verified
 is the credential that is used.
 
+The same precedence applies to every workflow that invokes
+`anthropics/claude-code-action`. The action exports whatever credential inputs
+it receives, so passing `anthropic_api_key` unconditionally alongside
+`claude_code_oauth_token` lets a stale API key shadow a working OAuth token.
+`.github/workflows/claude-code-review.yml` therefore forwards
+`anthropic_api_key` only when `CLAUDE_CODE_OAUTH_TOKEN` is empty, and
+`.github/workflows/claude.yml` forwards the OAuth token alone. Without this
+guard the run does not fail loudly: the CLI retries the 401 for roughly three
+minutes and then reports `is_error: true` with `num_turns: 1` and
+`total_cost_usd: 0` and no error text.
+
 `script/validate-takt-auth.sh` probes the resolved credential against the
 Anthropic API before the multi-minute TAKT run. It fails the job only on an
 unambiguous rejection (HTTP 401/403) and warns on any other outcome, so an

--- a/test/claude-workflow-contract.test.js
+++ b/test/claude-workflow-contract.test.js
@@ -116,9 +116,20 @@ describe('Claude workflow contracts', () => {
     expect(workflow).toContain('ANTHROPIC_ORGANIZATION_ID: ${{ secrets.ANTHROPIC_ORGANIZATION_ID }}');
     expect(workflow).toContain('available=false');
     expect(workflow).toContain("if: steps.claude-auth.outputs.available == 'true'");
-    expect(workflow).toContain('anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}');
     expect(workflow).toContain('anthropic_federation_rule_id: ${{ secrets.ANTHROPIC_FEDERATION_RULE_ID }}');
     expect(workflow).toContain('anthropic_organization_id: ${{ secrets.ANTHROPIC_ORGANIZATION_ID }}');
+  });
+
+  // Claude CLI は ANTHROPIC_API_KEY を CLAUDE_CODE_OAUTH_TOKEN より優先する（ADR 0013）。
+  // 失効した API キーを無条件に渡すと OAuth トークンが握り潰され、レビューは 401 を
+  // 約 180 秒リトライしたのち is_error:true / num_turns:1 / cost $0 で無言終了する。
+  test('Claude Code Review prefers the OAuth token over a stale API key', () => {
+    const workflow = readWorkflow('.github/workflows/claude-code-review.yml');
+
+    expect(workflow).toContain(
+      "anthropic_api_key: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN == '' && secrets.ANTHROPIC_API_KEY || '' }}",
+    );
+    expect(workflow).not.toContain('anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}');
   });
 
   test('repo-maintenance reports downstream sync when managed files change', () => {


### PR DESCRIPTION
Closes #1063

## Why

`claude-review` ジョブがエラー本文なしで失敗し続けていた。

```json
{ "type": "result", "subtype": "success", "is_error": true,
  "duration_ms": 182233, "num_turns": 1, "total_cost_usd": 0 }
```

調査の結果、これは #1061 で新たに発生した問題ではなく、**2026-07-29 以降ずっと続いていた無言失敗**だった。旧 action SHA (`a92e7c70`) が `is_error:true` をジョブ失敗として扱わなかったため success に見えていただけで、実際にはレビューが一度も実行されていない。

| Run | 日時 | action SHA | job conclusion |
| --- | --- | --- | --- |
| 30806948161 | 08-03 10:47 | `be7b93b1` | failure |
| 30806071504 | 08-03 10:33 | `be7b93b1` | failure |
| 30794594290 | 08-03 07:41 | `be7b93b1` | failure |
| 30738576626 | 08-02 07:50 | `a92e7c70` | success（偽グリーン） |
| 30509563507 | 07-30 02:51 | `a92e7c70` | success（偽グリーン） |
| 30445646478 | 07-29 10:57 | `a92e7c70` | success（偽グリーン） |

### 原因

同日・同一シークレットで `claude.yml` は成功している。差分は資格情報の渡し方だけだった。

| | claude-code-review.yml | claude.yml |
| --- | --- | --- |
| `anthropic_api_key` の受け渡し | あり | なし |
| action ステップの `ANTHROPIC_API_KEY` | セット済み | 空 |
| 解決モデル | `claude-opus-5[1m]` | `claude-sonnet-5` |
| 結果 | `is_error:true` / 1 turn / \$0 | `is_error:false` / 22 turns / \$0.89 |

Claude CLI は `ANTHROPIC_API_KEY` を `CLAUDE_CODE_OAUTH_TOKEN` より優先する（ADR 0013 に既出）。レビューワークフローだけが失効済み API キーを無条件に action へ渡していたため、初回 API 呼び出しが 401 になり、約 180 秒リトライしたのちエラー本文なしで終了していた。PR #1061 が scheduled-maintenance で特定した「無効キーで 3 分走ってから落ちる」現象と同一。

## What

| 変更 | 内容 |
| --- | --- |
| `.github/workflows/claude-code-review.yml` | `CLAUDE_CODE_OAUTH_TOKEN` が空のときだけ `anthropic_api_key` を渡す |
| `test/claude-workflow-contract.test.js` | OAuth 優先の受け渡しを検証する契約テストを追加 |
| `docs/adr/0013-...md` | 資格情報優先順位が Claude Actions 全体に適用されることと、違反時の失敗シグネチャを明記 |

`Check Claude authentication` ガードは変更していないため、OAuth 未設定・API キーのみの下流リポジトリは従来どおり API キーで動作する。

## How to test

- Unit (Jest): 902 tests, 0 failures
- Integration (BATS): 310 tests, 0 failures
- `actionlint .github/workflows/claude-code-review.yml`: pass
- 新規テストの Red → Green を確認済み（修正前は `toContain` が失敗）

## Risk

- 挙動変更は「OAuth があるとき API キーを渡さない」の一点のみ。OAuth のみ・API キーのみいずれの構成も引き続き動作する。
- 失効していた `ANTHROPIC_API_KEY` シークレットは 08-03 12:00〜08-04 03:02 の間に既に削除済みで、現在のリポジトリシークレットは `CLAUDE_CODE_OAUTH_TOKEN` / `CLAUDE_PAT` のみ。本 PR はワークフロー側で再発を防ぐもの。
- `claude-review` ジョブは `continue-on-error: true` のままなので、レビュー失敗がマージをブロックすることはない（偽グリーンの主因は旧 action の挙動であり、こちらは意図的な設定として維持）。
- このワークフロー自身を変更する PR は `review_gate_changed` ガードでレビューがスキップされるため、修正の実効性は次回以降の PR で確認する。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved authentication handling for automated code reviews by prioritizing OAuth credentials and using API keys only when OAuth is unavailable.
  * Prevented authentication conflicts that could cause review workflows to fail.

* **Documentation**
  * Documented credential precedence and related authentication failure scenarios.

* **Tests**
  * Added coverage validating OAuth priority, API-key fallback, and existing federation settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->