### PR TITLE
feat(script): repo-maintenance にワークフロー不具合の検査を追加し dependabot-auto の失敗を修正する

### DIFF
--- a/.claude/commands/repo-maintenance.md
+++ b/.claude/commands/repo-maintenance.md
@@ -1,7 +1,7 @@
 ---
 description: Comprehensive repository maintenance - run all health checks and updates
 allowed-tools: Read, Bash(script/repo-maintenance.sh:*), Bash(git:*), Bash(gh:*), Bash(npm:*), Bash(pnpm:*), Bash(jq:*), Skill
-argument-hint: '[--mode full|quick|check-only] [--skip CATEGORY] [--create-pr] [--check-actions-pr-settings] [--check-scheduled-maintenance] [--check-artifact-retention]'
+argument-hint: '[--mode full|quick|check-only] [--skip CATEGORY] [--create-pr] [--check-actions-pr-settings] [--check-scheduled-maintenance] [--check-artifact-retention] [--check-claude-action-credentials] [--check-self-cancelling-workflows]'
 ---
 
 # Repository Maintenance Workflow
@@ -35,6 +35,8 @@ Repository state guard runs before updates. Archived repositories switch to `che
 - Automated issue and maintenance PR creation expects `default_workflow_permissions=write` and `can_approve_pull_request_reviews=true`.
 - Scheduled Maintenance configuration is checked with `script/repo-maintenance.sh --check-scheduled-maintenance`.
 - Artifact retention is checked with `script/repo-maintenance.sh --check-artifact-retention` and should be 30 days or less.
+- Claude Actions credential precedence is checked with `script/repo-maintenance.sh --check-claude-action-credentials`. Passing `anthropic_api_key` unconditionally next to `claude_code_oauth_token` lets a stale API key shadow the OAuth token, and the run fails silently after roughly three minutes.
+- Workflow self-cancellation is checked with `script/repo-maintenance.sh --check-self-cancelling-workflows`. A push-triggered workflow that pushes commits or publishes a release must not use `cancel-in-progress: true`, or it cancels its own run before the release finishes.
 - Managed workflow templates are checked against `templates/workflows/` with `npm run workflow:sync:check`.
 - Workflow Lint coverage checks verify `.github/workflows/`, `.github/workflows/templates/`, and `templates/workflows/` are collected without static unmatched globs.
 

--- a/.claude/commands/repo-maintenance.md
+++ b/.claude/commands/repo-maintenance.md
@@ -1,7 +1,7 @@
 ---
 description: Comprehensive repository maintenance - run all health checks and updates
 allowed-tools: Read, Bash(script/repo-maintenance.sh:*), Bash(git:*), Bash(gh:*), Bash(npm:*), Bash(pnpm:*), Bash(jq:*), Skill
-argument-hint: '[--mode full|quick|check-only] [--skip CATEGORY] [--create-pr] [--check-actions-pr-settings] [--check-scheduled-maintenance] [--check-artifact-retention] [--check-claude-action-credentials] [--check-self-cancelling-workflows]'
+argument-hint: '[--mode full|quick|check-only] [--skip CATEGORY] [--create-pr] [--check-actions-pr-settings] [--check-scheduled-maintenance] [--check-artifact-retention] [--check-claude-action-credentials] [--check-self-cancelling-workflows] [--check-gh-repo-context]'
 ---
 
 # Repository Maintenance Workflow
@@ -37,6 +37,7 @@ Repository state guard runs before updates. Archived repositories switch to `che
 - Artifact retention is checked with `script/repo-maintenance.sh --check-artifact-retention` and should be 30 days or less.
 - Claude Actions credential precedence is checked with `script/repo-maintenance.sh --check-claude-action-credentials`. Passing `anthropic_api_key` unconditionally next to `claude_code_oauth_token` lets a stale API key shadow the OAuth token, and the run fails silently after roughly three minutes.
 - Workflow self-cancellation is checked with `script/repo-maintenance.sh --check-self-cancelling-workflows`. A push-triggered workflow that pushes commits or publishes a release must not use `cancel-in-progress: true`, or it cancels its own run before the release finishes.
+- `gh` repository context is checked with `script/repo-maintenance.sh --check-gh-repo-context`. A job without `actions/checkout` must pass `GH_REPO` or `--repo`, because `gh` otherwise resolves the repository from git and fails with `not a git repository`.
 - Managed workflow templates are checked against `templates/workflows/` with `npm run workflow:sync:check`.
 - Workflow Lint coverage checks verify `.github/workflows/`, `.github/workflows/templates/`, and `templates/workflows/` are collected without static unmatched globs.
 

--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -76,6 +76,9 @@ jobs:
         env:
           PR_URL: ${{ github.event.pull_request.html_url }}
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          # このジョブは checkout しないため gh はリポジトリを git から解決できない。
+          # gh label create は URL 引数を取らないので GH_REPO が無いと失敗する。
+          GH_REPO: ${{ github.repository }}
 
       - name: Auto-approve minor updates
         if: github.actor == 'dependabot[bot]' && steps.metadata.outputs.update-type == 'version-update:semver-minor'
@@ -96,3 +99,4 @@ jobs:
         env:
           PR_URL: ${{ github.event.pull_request.html_url }}
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_REPO: ${{ github.repository }}

--- a/script/README.md
+++ b/script/README.md
@@ -185,6 +185,8 @@ Runs repository maintenance checks and managed updates. This is the executable s
 ./script/repo-maintenance.sh --check-actions-pr-settings
 ./script/repo-maintenance.sh --check-scheduled-maintenance
 ./script/repo-maintenance.sh --check-artifact-retention
+./script/repo-maintenance.sh --check-claude-action-credentials
+./script/repo-maintenance.sh --check-self-cancelling-workflows
 ```
 
 ### setup-ci.sh

--- a/script/README.md
+++ b/script/README.md
@@ -187,6 +187,7 @@ Runs repository maintenance checks and managed updates. This is the executable s
 ./script/repo-maintenance.sh --check-artifact-retention
 ./script/repo-maintenance.sh --check-claude-action-credentials
 ./script/repo-maintenance.sh --check-self-cancelling-workflows
+./script/repo-maintenance.sh --check-gh-repo-context
 ```
 
 ### setup-ci.sh

--- a/script/lib/repo_maintenance_checks.sh
+++ b/script/lib/repo_maintenance_checks.sh
@@ -57,6 +57,66 @@ check_scheduled_maintenance_configuration() {
   output::success "Scheduled Maintenance configuration ok"
 }
 
+# Claude CLI は ANTHROPIC_API_KEY を CLAUDE_CODE_OAUTH_TOKEN より優先する（ADR 0013）。
+# 両方を無条件に claude-code-action へ渡すと、失効した API キーが有効な OAuth トークンを
+# 握り潰す。失敗は無言（is_error:true / num_turns:1 / total_cost_usd:0 / エラー本文なし）で、
+# 約 180 秒リトライしてから終わるため気付きにくい。
+check_claude_action_credentials() {
+  local workflow issue_count=0 stripped
+
+  for workflow in .github/workflows/*.yml .github/workflows/*.yaml; do
+    [[ -f "$workflow" ]] || continue
+
+    # 行頭コメントを落とす。注意書きの中の文字列を実設定と誤認しないため。
+    stripped="$(sed 's/^[[:space:]]*#.*$//' "$workflow")"
+
+    grep -q "anthropics/claude-code-action" <<<"$stripped" || continue
+    grep -q "claude_code_oauth_token:" <<<"$stripped" || continue
+
+    if grep -qE "^[[:space:]]*anthropic_api_key:" <<<"$stripped" \
+      && ! grep -qE "^[[:space:]]*anthropic_api_key:.*CLAUDE_CODE_OAUTH_TOKEN" <<<"$stripped"; then
+      output::warning "$(basename "$workflow"): anthropic_api_key overrides CLAUDE_CODE_OAUTH_TOKEN"
+      echo "Pass the API key only when the OAuth token is empty:"
+      echo "  anthropic_api_key: \${{ secrets.CLAUDE_CODE_OAUTH_TOKEN == '' && secrets.ANTHROPIC_API_KEY || '' }}"
+      issue_count=$((issue_count + 1))
+    fi
+  done
+
+  if [[ "$issue_count" -gt 0 ]]; then
+    return 1
+  fi
+
+  output::success "Claude Actions credential precedence ok"
+}
+
+# push で起動するワークフローが自分でコミットや Release を publish すると、その push が
+# 起こす新規実行に cancel-in-progress: true で自分自身をキャンセルされる。
+# keito4/intent-gate-android では v1.2.49 の APK 添付と Firebase 配信が失われた。
+check_self_cancelling_workflows() {
+  local workflow issue_count=0 stripped
+
+  for workflow in .github/workflows/*.yml .github/workflows/*.yaml; do
+    [[ -f "$workflow" ]] || continue
+
+    stripped="$(sed 's/^[[:space:]]*#.*$//' "$workflow")"
+
+    grep -qE "^[[:space:]]*cancel-in-progress:[[:space:]]*true[[:space:]]*$" <<<"$stripped" || continue
+    grep -qE "^[[:space:]]*push:" <<<"$stripped" || continue
+    grep -qE "git push|peter-evans/create-pull-request|softprops/action-gh-release|googleapis/release-please" <<<"$stripped" || continue
+
+    output::warning "$(basename "$workflow"): cancel-in-progress cancels this workflow's own push"
+    echo "Scope the cancellation to pull requests so pushes to the default branch run to completion:"
+    echo "  cancel-in-progress: \${{ github.event_name == 'pull_request' }}"
+    issue_count=$((issue_count + 1))
+  done
+
+  if [[ "$issue_count" -gt 0 ]]; then
+    return 1
+  fi
+
+  output::success "Workflow self-cancellation guards ok"
+}
+
 check_artifact_retention() {
   local workflow issue_count=0
 

--- a/script/lib/repo_maintenance_checks.sh
+++ b/script/lib/repo_maintenance_checks.sh
@@ -57,24 +57,65 @@ check_scheduled_maintenance_configuration() {
   output::success "Scheduled Maintenance configuration ok"
 }
 
+workflow_has_event() {
+  local workflow="${1:?Workflow required}"
+  local event="${2:?Event required}"
+
+  awk -v event="$event" '
+    function has_event(line) {
+      return line ~ "(^|[^A-Za-z0-9_-])" event "([^A-Za-z0-9_-]|$)"
+    }
+    /^on:[[:space:]]*\[/ || /^"on":[[:space:]]*\[/ || /^\047on\047:[[:space:]]*\[/ {
+      if (has_event($0)) found = 1
+      next
+    }
+    # スカラー形式 (on: push)。空値の "on:" は英字を要求することで除外される。
+    /^on:[[:space:]]*[A-Za-z_]/ || /^"on":[[:space:]]*[A-Za-z_]/ || /^\047on\047:[[:space:]]*[A-Za-z_]/ {
+      if (has_event($0)) found = 1
+      next
+    }
+    /^on:[[:space:]]*$/ || /^"on":[[:space:]]*$/ || /^\047on\047:[[:space:]]*$/ {
+      in_on = 1
+      next
+    }
+    in_on && /^[^[:space:]#][^:]*:/ {
+      in_on = 0
+    }
+    in_on {
+      if ($0 ~ "^[[:space:]]*-[[:space:]]*" event "([[:space:]#]|$)") found = 1
+      if ($0 ~ "^[[:space:]]*" event ":[[:space:]]*") found = 1
+    }
+    END { exit found ? 0 : 1 }
+  ' "$workflow"
+}
+
 # Claude CLI は ANTHROPIC_API_KEY を CLAUDE_CODE_OAUTH_TOKEN より優先する（ADR 0013）。
 # 両方を無条件に claude-code-action へ渡すと、失効した API キーが有効な OAuth トークンを
 # 握り潰す。失敗は無言（is_error:true / num_turns:1 / total_cost_usd:0 / エラー本文なし）で、
 # 約 180 秒リトライしてから終わるため気付きにくい。
 check_claude_action_credentials() {
-  local workflow issue_count=0 stripped
+  local workflow issue_count=0
 
   for workflow in .github/workflows/*.yml .github/workflows/*.yaml; do
     [[ -f "$workflow" ]] || continue
 
-    # 行頭コメントを落とす。注意書きの中の文字列を実設定と誤認しないため。
-    stripped="$(sed 's/^[[:space:]]*#.*$//' "$workflow")"
-
-    grep -q "anthropics/claude-code-action" <<<"$stripped" || continue
-    grep -q "claude_code_oauth_token:" <<<"$stripped" || continue
-
-    if grep -qE "^[[:space:]]*anthropic_api_key:" <<<"$stripped" \
-      && ! grep -qE "^[[:space:]]*anthropic_api_key:.*CLAUDE_CODE_OAUTH_TOKEN" <<<"$stripped"; then
+    # claude-code-action のステップ単位で判定する。ファイル全体を見ると、ガード済みの
+    # 1 行が否定判定を打ち消して別ステップの無条件なキーを見逃す。
+    if ! awk '
+      function flush() {
+        if (in_step && oauth && unguarded) bad = 1
+        in_step = 0; oauth = 0; unguarded = 0
+      }
+      # 行頭コメントを落とす。注意書きの中の文字列を実設定と誤認しないため。
+      { line = $0; sub(/^[[:space:]]*#.*$/, "", line) }
+      line ~ /uses:[[:space:]]*anthropics\/claude-code-action/ { flush(); in_step = 1; next }
+      in_step && line ~ /^[[:space:]]*-[[:space:]]/ { flush() }
+      in_step && line ~ /^[[:space:]]*claude_code_oauth_token:/ { oauth = 1 }
+      in_step && line ~ /^[[:space:]]*anthropic_api_key:/ {
+        if (line !~ /CLAUDE_CODE_OAUTH_TOKEN/) unguarded = 1
+      }
+      END { flush(); exit bad ? 1 : 0 }
+    ' "$workflow"; then
       output::warning "$(basename "$workflow"): anthropic_api_key overrides CLAUDE_CODE_OAUTH_TOKEN"
       echo "Pass the API key only when the OAuth token is empty:"
       echo "  anthropic_api_key: \${{ secrets.CLAUDE_CODE_OAUTH_TOKEN == '' && secrets.ANTHROPIC_API_KEY || '' }}"
@@ -101,7 +142,8 @@ check_self_cancelling_workflows() {
     stripped="$(sed 's/^[[:space:]]*#.*$//' "$workflow")"
 
     grep -qE "^[[:space:]]*cancel-in-progress:[[:space:]]*true[[:space:]]*$" <<<"$stripped" || continue
-    grep -qE "^[[:space:]]*push:" <<<"$stripped" || continue
+    # on: push / on: [push, ...] の短縮形も push トリガーなので workflow_has_event で判定する。
+    workflow_has_event "$workflow" "push" || continue
     grep -qE "git push|peter-evans/create-pull-request|softprops/action-gh-release|googleapis/release-please" <<<"$stripped" || continue
 
     output::warning "$(basename "$workflow"): cancel-in-progress cancels this workflow's own push"
@@ -121,22 +163,33 @@ check_self_cancelling_workflows() {
 # `gh pr edit "$PR_URL"` は URL 引数から特定できるため通ってしまい、引数を持たない
 # `gh label create` だけが "fatal: not a git repository" で落ちるので気付きにくい。
 check_gh_repo_context() {
-  local workflow issue_count=0 stripped
+  local workflow issue_count=0
 
   for workflow in .github/workflows/*.yml .github/workflows/*.yaml; do
     [[ -f "$workflow" ]] || continue
 
-    stripped="$(sed 's/^[[:space:]]*#.*$//' "$workflow")"
-
-    # checkout していればリポジトリは解決できる。
-    grep -q "actions/checkout" <<<"$stripped" && continue
-    grep -qE "\bgh (label|issue|release|run|workflow|pr (create|list|status))\b" <<<"$stripped" || continue
-    grep -qE "GH_REPO:|--repo " <<<"$stripped" && continue
-
-    output::warning "$(basename "$workflow"): gh has no repository to resolve without a checkout"
-    echo "Add the repository to the step environment:"
-    echo "  GH_REPO: \${{ github.repository }}"
-    issue_count=$((issue_count + 1))
+    # ジョブ単位で判定する。あるジョブの checkout や GH_REPO は別ジョブの gh を設定しない。
+    # --repo は同じコマンド行にある場合だけ有効とみなす。
+    if ! awk '
+      function flush() {
+        if (in_job && bad_cmd && !has_checkout && !has_gh_repo) bad = 1
+        bad_cmd = 0; has_checkout = 0; has_gh_repo = 0
+      }
+      { line = $0; sub(/^[[:space:]]*#.*$/, "", line) }
+      /^jobs:[[:space:]]*$/ { in_jobs = 1; next }
+      in_jobs && /^  [A-Za-z0-9_-]+:/ { flush(); in_job = 1; next }
+      in_job && line ~ /actions\/checkout/ { has_checkout = 1 }
+      in_job && line ~ /^[[:space:]]*GH_REPO:/ { has_gh_repo = 1 }
+      in_job && line ~ /(^|[^A-Za-z0-9_-])gh[[:space:]]+((label|issue|release|run|workflow)|pr[[:space:]]+(create|list|status))([^A-Za-z0-9_-]|$)/ {
+        if (line !~ /--repo[[:space:]]/) bad_cmd = 1
+      }
+      END { flush(); exit bad ? 1 : 0 }
+    ' "$workflow"; then
+      output::warning "$(basename "$workflow"): gh has no repository to resolve without a checkout"
+      echo "Add the repository to the step environment:"
+      echo "  GH_REPO: \${{ github.repository }}"
+      issue_count=$((issue_count + 1))
+    fi
   done
 
   if [[ "$issue_count" -gt 0 ]]; then

--- a/script/lib/repo_maintenance_checks.sh
+++ b/script/lib/repo_maintenance_checks.sh
@@ -117,6 +117,35 @@ check_self_cancelling_workflows() {
   output::success "Workflow self-cancellation guards ok"
 }
 
+# checkout を実行しないジョブでは gh がリポジトリを git から解決できない。
+# `gh pr edit "$PR_URL"` は URL 引数から特定できるため通ってしまい、引数を持たない
+# `gh label create` だけが "fatal: not a git repository" で落ちるので気付きにくい。
+check_gh_repo_context() {
+  local workflow issue_count=0 stripped
+
+  for workflow in .github/workflows/*.yml .github/workflows/*.yaml; do
+    [[ -f "$workflow" ]] || continue
+
+    stripped="$(sed 's/^[[:space:]]*#.*$//' "$workflow")"
+
+    # checkout していればリポジトリは解決できる。
+    grep -q "actions/checkout" <<<"$stripped" && continue
+    grep -qE "\bgh (label|issue|release|run|workflow|pr (create|list|status))\b" <<<"$stripped" || continue
+    grep -qE "GH_REPO:|--repo " <<<"$stripped" && continue
+
+    output::warning "$(basename "$workflow"): gh has no repository to resolve without a checkout"
+    echo "Add the repository to the step environment:"
+    echo "  GH_REPO: \${{ github.repository }}"
+    issue_count=$((issue_count + 1))
+  done
+
+  if [[ "$issue_count" -gt 0 ]]; then
+    return 1
+  fi
+
+  output::success "gh repository context ok"
+}
+
 check_artifact_retention() {
   local workflow issue_count=0
 

--- a/script/repo-maintenance.sh
+++ b/script/repo-maintenance.sh
@@ -107,33 +107,6 @@ run_if_exists() {
   "$@"
 }
 
-workflow_has_event() {
-  local workflow="${1:?Workflow required}"
-  local event="${2:?Event required}"
-
-  awk -v event="$event" '
-    function has_event(line) {
-      return line ~ "(^|[^A-Za-z0-9_-])" event "([^A-Za-z0-9_-]|$)"
-    }
-    /^on:[[:space:]]*\[/ || /^"on":[[:space:]]*\[/ || /^\047on\047:[[:space:]]*\[/ {
-      if (has_event($0)) found = 1
-      next
-    }
-    /^on:[[:space:]]*$/ || /^"on":[[:space:]]*$/ || /^\047on\047:[[:space:]]*$/ {
-      in_on = 1
-      next
-    }
-    in_on && /^[^[:space:]#][^:]*:/ {
-      in_on = 0
-    }
-    in_on {
-      if ($0 ~ "^[[:space:]]*-[[:space:]]*" event "([[:space:]#]|$)") found = 1
-      if ($0 ~ "^[[:space:]]*" event ":[[:space:]]*") found = 1
-    }
-    END { exit found ? 0 : 1 }
-  ' "$workflow"
-}
-
 workflow_is_required_candidate() {
   local workflow="${1:?Workflow required}"
   local base

--- a/script/repo-maintenance.sh
+++ b/script/repo-maintenance.sh
@@ -17,11 +17,13 @@ CHECK_REQUIRED_WORKFLOWS_ONLY=false
 CHECK_ACTIONS_PR_SETTINGS_ONLY=false
 CHECK_SCHEDULED_MAINTENANCE_ONLY=false
 CHECK_ARTIFACT_RETENTION_ONLY=false
+CHECK_CLAUDE_ACTION_CREDENTIALS_ONLY=false
+CHECK_SELF_CANCELLING_WORKFLOWS_ONLY=false
 CONTEXT_DIR="${CONTEXT_DIR:-.context}"
 
 usage() {
   cat <<'EOF'
-Usage: script/repo-maintenance.sh [--mode full|quick|check-only] [--skip CATEGORY] [--create-pr] [--check-required-workflows] [--check-actions-pr-settings] [--check-scheduled-maintenance] [--check-artifact-retention]
+Usage: script/repo-maintenance.sh [--mode full|quick|check-only] [--skip CATEGORY] [--create-pr] [--check-required-workflows] [--check-actions-pr-settings] [--check-scheduled-maintenance] [--check-artifact-retention] [--check-claude-action-credentials] [--check-self-cancelling-workflows]
 EOF
 }
 
@@ -56,6 +58,16 @@ while [[ $# -gt 0 ]]; do
       ;;
     --check-artifact-retention)
       CHECK_ARTIFACT_RETENTION_ONLY=true
+      MODE="check-only"
+      shift
+      ;;
+    --check-claude-action-credentials)
+      CHECK_CLAUDE_ACTION_CREDENTIALS_ONLY=true
+      MODE="check-only"
+      shift
+      ;;
+    --check-self-cancelling-workflows)
+      CHECK_SELF_CANCELLING_WORKFLOWS_ONLY=true
       MODE="check-only"
       shift
       ;;
@@ -429,6 +441,16 @@ if [[ "$CHECK_ARTIFACT_RETENTION_ONLY" == "true" ]]; then
   exit $?
 fi
 
+if [[ "$CHECK_CLAUDE_ACTION_CREDENTIALS_ONLY" == "true" ]]; then
+  check_claude_action_credentials
+  exit $?
+fi
+
+if [[ "$CHECK_SELF_CANCELLING_WORKFLOWS_ONLY" == "true" ]]; then
+  check_self_cancelling_workflows
+  exit $?
+fi
+
 cat <<EOF
 ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 Repository Maintenance
@@ -449,6 +471,8 @@ if ! has_skip "setup"; then
   fi
   check_scheduled_maintenance_configuration || true
   check_artifact_retention || true
+  check_claude_action_credentials || true
+  check_self_cancelling_workflows || true
   check_workflow_templates
   check_workflow_template_lint_coverage
   check_managed_templates

--- a/script/repo-maintenance.sh
+++ b/script/repo-maintenance.sh
@@ -19,11 +19,12 @@ CHECK_SCHEDULED_MAINTENANCE_ONLY=false
 CHECK_ARTIFACT_RETENTION_ONLY=false
 CHECK_CLAUDE_ACTION_CREDENTIALS_ONLY=false
 CHECK_SELF_CANCELLING_WORKFLOWS_ONLY=false
+CHECK_GH_REPO_CONTEXT_ONLY=false
 CONTEXT_DIR="${CONTEXT_DIR:-.context}"
 
 usage() {
   cat <<'EOF'
-Usage: script/repo-maintenance.sh [--mode full|quick|check-only] [--skip CATEGORY] [--create-pr] [--check-required-workflows] [--check-actions-pr-settings] [--check-scheduled-maintenance] [--check-artifact-retention] [--check-claude-action-credentials] [--check-self-cancelling-workflows]
+Usage: script/repo-maintenance.sh [--mode full|quick|check-only] [--skip CATEGORY] [--create-pr] [--check-required-workflows] [--check-actions-pr-settings] [--check-scheduled-maintenance] [--check-artifact-retention] [--check-claude-action-credentials] [--check-self-cancelling-workflows] [--check-gh-repo-context]
 EOF
 }
 
@@ -68,6 +69,11 @@ while [[ $# -gt 0 ]]; do
       ;;
     --check-self-cancelling-workflows)
       CHECK_SELF_CANCELLING_WORKFLOWS_ONLY=true
+      MODE="check-only"
+      shift
+      ;;
+    --check-gh-repo-context)
+      CHECK_GH_REPO_CONTEXT_ONLY=true
       MODE="check-only"
       shift
       ;;
@@ -451,6 +457,11 @@ if [[ "$CHECK_SELF_CANCELLING_WORKFLOWS_ONLY" == "true" ]]; then
   exit $?
 fi
 
+if [[ "$CHECK_GH_REPO_CONTEXT_ONLY" == "true" ]]; then
+  check_gh_repo_context
+  exit $?
+fi
+
 cat <<EOF
 ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 Repository Maintenance
@@ -473,6 +484,7 @@ if ! has_skip "setup"; then
   check_artifact_retention || true
   check_claude_action_credentials || true
   check_self_cancelling_workflows || true
+  check_gh_repo_context || true
   check_workflow_templates
   check_workflow_template_lint_coverage
   check_managed_templates

--- a/templates/workflows/claude-health-check.yml
+++ b/templates/workflows/claude-health-check.yml
@@ -29,6 +29,8 @@ jobs:
         if: steps.check.outcome == 'failure'
         env:
           GH_TOKEN: ${{ github.token }}
+          # このジョブは checkout しないため gh はリポジトリを git から解決できない。
+          GH_REPO: ${{ github.repository }}
         run: |
           EXISTING=$(gh issue list --label "claude-health" --state open --json number --jq 'length')
           if [ "$EXISTING" -gt 0 ]; then

--- a/templates/workflows/dependabot-auto-merge.yml
+++ b/templates/workflows/dependabot-auto-merge.yml
@@ -76,6 +76,9 @@ jobs:
         env:
           PR_URL: ${{ github.event.pull_request.html_url }}
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          # このジョブは checkout しないため gh はリポジトリを git から解決できない。
+          # gh label create は URL 引数を取らないので GH_REPO が無いと失敗する。
+          GH_REPO: ${{ github.repository }}
 
       - name: Auto-approve minor updates
         if: github.actor == 'dependabot[bot]' && steps.metadata.outputs.update-type == 'version-update:semver-minor'
@@ -96,3 +99,4 @@ jobs:
         env:
           PR_URL: ${{ github.event.pull_request.html_url }}
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_REPO: ${{ github.repository }}

--- a/test/claude-workflow-contract.test.js
+++ b/test/claude-workflow-contract.test.js
@@ -280,17 +280,30 @@ describe('Claude workflow contracts', () => {
   test('repo-maintenance detects required workflow trigger incompatibility', () => {
     const command = readWorkflow('.claude/commands/repo-maintenance.md');
     const script = readWorkflow('script/repo-maintenance.sh');
+    // workflow_has_event は複数の検査が共有するため lib 側に置いている。
+    const checks = readWorkflow('script/lib/repo_maintenance_checks.sh');
 
     expect(command).toContain('Required Workflow Trigger Compatibility Check');
     expect(script).toContain('security-summary.yml');
     expect(script).toContain('security-summary.yaml');
     expect(script).toContain('.github/workflows/*.yaml');
     expect(script).toContain("github\\.event_name == '\\''schedule'\\''");
-    expect(script).toContain('/^on:[[:space:]]*');
-    expect(script).toContain('/^"on":[[:space:]]*');
-    expect(script).toContain('/^\\047on\\047:[[:space:]]*');
+    expect(checks).toContain('/^on:[[:space:]]*');
+    expect(checks).toContain('/^"on":[[:space:]]*');
+    expect(checks).toContain('/^\\047on\\047:[[:space:]]*');
     expect(script).toContain('pull_request');
     expect(script).toContain('/^  generate-summary:/');
     expect(script).toContain('/^  [A-Za-z0-9_-]+:/');
+  });
+
+  // on: push / on: [push] / on:\n  push: / on:\n  - push はいずれも push トリガー。
+  // スカラー形式を取りこぼすと、必須ワークフロー検査も自己キャンセル検査もすり抜ける。
+  test('workflow_has_event recognizes every valid trigger form', () => {
+    const checks = readWorkflow('script/lib/repo_maintenance_checks.sh');
+
+    expect(checks).toContain('/^on:[[:space:]]*\\[/');
+    expect(checks).toContain('/^on:[[:space:]]*[A-Za-z_]/');
+    expect(checks).toContain('/^on:[[:space:]]*$/');
+    expect(checks).toContain('"^[[:space:]]*-[[:space:]]*" event');
   });
 });

--- a/test/repo-maintenance-workflow-guards.test.js
+++ b/test/repo-maintenance-workflow-guards.test.js
@@ -205,3 +205,71 @@ describe('check_self_cancelling_workflows', () => {
     expect(result.status).not.toBe(0);
   });
 });
+
+// keito4/config PR #1066: dependabot-auto ジョブは actions/checkout を実行しないため、
+// `gh label create` がリポジトリを git から解決できず
+// "failed to run git: fatal: not a git repository" で落ちていた。
+// URL 引数を取る `gh pr edit "$PR_URL"` は同じジョブでも通るので気付きにくい。
+describe('check_gh_repo_context', () => {
+  const FLAG = '--check-gh-repo-context';
+
+  function ghWorkflow({ command, checkout = false, env = [] }) {
+    return [
+      'name: Dependabot Auto-merge',
+      'jobs:',
+      '  dependabot-auto:',
+      '    steps:',
+      ...(checkout ? ['      - uses: actions/checkout@abc123 # v7.0.1'] : []),
+      '      - name: Label updates',
+      `        run: ${command}`,
+      ...(env.length ? ['        env:', ...env.map((line) => `          ${line}`)] : []),
+      '',
+    ].join('\n');
+  }
+
+  test('flags a repo-scoped gh command in a workflow that never checks out', () => {
+    const result = runCheck(FLAG, {
+      'dependabot-auto-merge.yml': ghWorkflow({ command: 'gh label create "dependabot-minor" --force' }),
+    });
+
+    expect(result.status).not.toBe(0);
+    expect(result.output).toContain('dependabot-auto-merge.yml');
+    expect(result.output).toContain('GH_REPO');
+  });
+
+  test('accepts the same command once GH_REPO is provided', () => {
+    const result = runCheck(FLAG, {
+      'dependabot-auto-merge.yml': ghWorkflow({
+        command: 'gh label create "dependabot-minor" --force',
+        env: ['GH_REPO: ${{ github.repository }}'],
+      }),
+    });
+
+    expect(result.status).toBe(0);
+    expect(result.output).toContain('gh repository context ok');
+  });
+
+  test('accepts an explicit --repo argument', () => {
+    const result = runCheck(FLAG, {
+      'health.yml': ghWorkflow({ command: 'gh issue create --repo "$GITHUB_REPOSITORY" --title x' }),
+    });
+
+    expect(result.status).toBe(0);
+  });
+
+  test('accepts a workflow that checks the repository out', () => {
+    const result = runCheck(FLAG, {
+      'ci.yml': ghWorkflow({ command: 'gh label create "x" --force', checkout: true }),
+    });
+
+    expect(result.status).toBe(0);
+  });
+
+  test('ignores gh subcommands that take a pull request URL', () => {
+    const result = runCheck(FLAG, {
+      'dependabot-auto-merge.yml': ghWorkflow({ command: 'gh pr edit "$PR_URL" --add-label "x"' }),
+    });
+
+    expect(result.status).toBe(0);
+  });
+});

--- a/test/repo-maintenance-workflow-guards.test.js
+++ b/test/repo-maintenance-workflow-guards.test.js
@@ -1,0 +1,207 @@
+const fs = require('fs');
+const path = require('path');
+const { execFileSync } = require('child_process');
+
+const repoPath = path.resolve(__dirname, '..');
+const inheritedGitEnvKeys = ['GIT_DIR', 'GIT_WORK_TREE', 'GIT_INDEX_FILE', 'GIT_PREFIX'];
+
+function cleanGitEnv() {
+  const env = { ...process.env };
+  for (const key of inheritedGitEnvKeys) {
+    delete env[key];
+  }
+  return env;
+}
+
+function runCheck(flag, workflows) {
+  const contextDir = path.join(repoPath, '.context');
+  fs.mkdirSync(contextDir, { recursive: true });
+  const tempRoot = fs.mkdtempSync(path.join(contextDir, 'workflow-guards-test-'));
+
+  try {
+    for (const [name, content] of Object.entries(workflows)) {
+      const target = path.join(tempRoot, '.github', 'workflows', name);
+      fs.mkdirSync(path.dirname(target), { recursive: true });
+      fs.writeFileSync(target, content);
+    }
+
+    const scriptPath = path.join(repoPath, 'script', 'repo-maintenance.sh');
+    try {
+      const stdout = execFileSync('bash', [scriptPath, flag], {
+        cwd: tempRoot,
+        env: cleanGitEnv(),
+        encoding: 'utf8',
+      });
+      return { status: 0, output: stdout };
+    } catch (error) {
+      return { status: error.status, output: `${error.stdout || ''}${error.stderr || ''}` };
+    }
+  } finally {
+    fs.rmSync(tempRoot, { recursive: true, force: true });
+  }
+}
+
+// Claude CLI は ANTHROPIC_API_KEY を CLAUDE_CODE_OAUTH_TOKEN より優先する（ADR 0013）。
+// 両方を無条件に claude-code-action へ渡すと、失効した API キーが有効な OAuth トークンを
+// 握り潰し、401 を約 180 秒リトライしたのち is_error:true / num_turns:1 / total_cost_usd:0
+// で無言終了する。keito4/config では 2026-07-29 以降レビューが実行されていなかった。
+describe('check_claude_action_credentials', () => {
+  const FLAG = '--check-claude-action-credentials';
+
+  function claudeWorkflow(apiKeyLine) {
+    return [
+      'name: Claude Code Review',
+      'jobs:',
+      '  review:',
+      '    steps:',
+      '      - name: Run Claude Code Review',
+      '        uses: anthropics/claude-code-action@abc123 # v1',
+      '        with:',
+      '          claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}',
+      ...(apiKeyLine ? [`          ${apiKeyLine}`] : []),
+      '',
+    ].join('\n');
+  }
+
+  test('flags an unconditional anthropic_api_key alongside the OAuth token', () => {
+    const result = runCheck(FLAG, {
+      'claude-code-review.yml': claudeWorkflow('anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}'),
+    });
+
+    expect(result.status).not.toBe(0);
+    expect(result.output).toContain('claude-code-review.yml');
+    expect(result.output).toContain('anthropic_api_key');
+    expect(result.output).toContain('CLAUDE_CODE_OAUTH_TOKEN');
+  });
+
+  test('accepts an anthropic_api_key guarded by the OAuth token being empty', () => {
+    const result = runCheck(FLAG, {
+      'claude-code-review.yml': claudeWorkflow(
+        "anthropic_api_key: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN == '' && secrets.ANTHROPIC_API_KEY || '' }}",
+      ),
+    });
+
+    expect(result.status).toBe(0);
+    expect(result.output).toContain('Claude Actions credential precedence ok');
+  });
+
+  test('accepts a workflow that passes only the OAuth token', () => {
+    const result = runCheck(FLAG, { 'claude.yml': claudeWorkflow(null) });
+
+    expect(result.status).toBe(0);
+  });
+
+  test('accepts an API-key-only workflow with no OAuth token to shadow', () => {
+    const workflow = [
+      'name: Claude',
+      'jobs:',
+      '  claude:',
+      '    steps:',
+      '      - uses: anthropics/claude-code-action@abc123 # v1',
+      '        with:',
+      '          anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}',
+      '',
+    ].join('\n');
+
+    const result = runCheck(FLAG, { 'claude.yml': workflow });
+
+    expect(result.status).toBe(0);
+  });
+
+  test('ignores workflows that do not use claude-code-action', () => {
+    const result = runCheck(FLAG, { 'ci.yml': 'name: CI\njobs:\n  build:\n    steps: []\n' });
+
+    expect(result.status).toBe(0);
+  });
+});
+
+// keito4/intent-gate-android PR #60: release ジョブがバージョンバンプを push した結果、
+// その push が起こす新規実行に cancel-in-progress: true で自分自身をキャンセルされ、
+// v1.2.49 の GitHub Release アセット添付と Firebase 配信が失われた。
+describe('check_self_cancelling_workflows', () => {
+  const FLAG = '--check-self-cancelling-workflows';
+
+  function releaseWorkflow(cancelValue, pushStep = true) {
+    return [
+      'name: CI',
+      'on:',
+      '  push:',
+      '    branches: [main]',
+      '  pull_request:',
+      'concurrency:',
+      '  group: ${{ github.workflow }}-${{ github.ref }}',
+      `  cancel-in-progress: ${cancelValue}`,
+      'jobs:',
+      '  release:',
+      '    steps:',
+      ...(pushStep ? ['      - run: git push origin HEAD:main'] : ['      - run: echo build']),
+      '',
+    ].join('\n');
+  }
+
+  test('flags a push-triggered workflow that pushes commits while cancelling in progress', () => {
+    const result = runCheck(FLAG, { 'ci.yml': releaseWorkflow('true') });
+
+    expect(result.status).not.toBe(0);
+    expect(result.output).toContain('ci.yml');
+    expect(result.output).toContain('cancel-in-progress');
+  });
+
+  test('accepts the pull_request-scoped cancel expression', () => {
+    const result = runCheck(FLAG, {
+      'ci.yml': releaseWorkflow("${{ github.event_name == 'pull_request' }}"),
+    });
+
+    expect(result.status).toBe(0);
+    expect(result.output).toContain('Workflow self-cancellation guards ok');
+  });
+
+  test('accepts a push-triggered workflow that does not push commits back', () => {
+    const result = runCheck(FLAG, { 'ci.yml': releaseWorkflow('true', false) });
+
+    expect(result.status).toBe(0);
+  });
+
+  test('ignores the literal pattern when it only appears inside a comment', () => {
+    const workflow = [
+      'name: CI',
+      'on:',
+      '  push:',
+      '    branches: [main]',
+      'concurrency:',
+      '  group: ${{ github.workflow }}-${{ github.ref }}',
+      '  # cancel-in-progress: true だと release ジョブが自分自身をキャンセルする',
+      "  cancel-in-progress: ${{ github.event_name == 'pull_request' }}",
+      'jobs:',
+      '  release:',
+      '    steps:',
+      '      - run: git push origin HEAD:main',
+      '',
+    ].join('\n');
+
+    const result = runCheck(FLAG, { 'ci.yml': workflow });
+
+    expect(result.status).toBe(0);
+  });
+
+  test('flags a release action that publishes assets from a push-triggered run', () => {
+    const workflow = [
+      'name: Release',
+      'on:',
+      '  push:',
+      '    tags: ["v*"]',
+      'concurrency:',
+      '  group: ${{ github.workflow }}-${{ github.ref }}',
+      '  cancel-in-progress: true',
+      'jobs:',
+      '  release:',
+      '    steps:',
+      '      - uses: softprops/action-gh-release@abc123 # v2',
+      '',
+    ].join('\n');
+
+    const result = runCheck(FLAG, { 'release.yml': workflow });
+
+    expect(result.status).not.toBe(0);
+  });
+});

--- a/test/repo-maintenance-workflow-guards.test.js
+++ b/test/repo-maintenance-workflow-guards.test.js
@@ -113,6 +113,51 @@ describe('check_claude_action_credentials', () => {
 
     expect(result.status).toBe(0);
   });
+
+  // 1つでもガード済みの行があるとファイル全体の否定 grep が無効化され、
+  // 別ステップの無条件な API キーを見逃す。
+  test('flags an unguarded step even when another step is guarded', () => {
+    const workflow = [
+      'name: Claude',
+      'jobs:',
+      '  review:',
+      '    steps:',
+      '      - uses: anthropics/claude-code-action@abc123 # v1',
+      '        with:',
+      '          claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}',
+      "          anthropic_api_key: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN == '' && secrets.ANTHROPIC_API_KEY || '' }}",
+      '      - uses: anthropics/claude-code-action@abc123 # v1',
+      '        with:',
+      '          claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}',
+      '          anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}',
+      '',
+    ].join('\n');
+
+    const result = runCheck(FLAG, { 'claude.yml': workflow });
+
+    expect(result.status).not.toBe(0);
+  });
+
+  // claude-code-action 以外のアクションが anthropic_api_key を取るのは無関係。
+  test('does not flag an anthropic_api_key belonging to another action', () => {
+    const workflow = [
+      'name: Claude',
+      'jobs:',
+      '  review:',
+      '    steps:',
+      '      - uses: anthropics/claude-code-action@abc123 # v1',
+      '        with:',
+      '          claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}',
+      '      - uses: some-org/other-action@abc123 # v1',
+      '        with:',
+      '          anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}',
+      '',
+    ].join('\n');
+
+    const result = runCheck(FLAG, { 'claude.yml': workflow });
+
+    expect(result.status).toBe(0);
+  });
 });
 
 // keito4/intent-gate-android PR #60: release ジョブがバージョンバンプを push した結果、
@@ -182,6 +227,26 @@ describe('check_self_cancelling_workflows', () => {
     const result = runCheck(FLAG, { 'ci.yml': workflow });
 
     expect(result.status).toBe(0);
+  });
+
+  // on: [push, ...] / on: push の短縮形もれっきとした push トリガー。
+  test.each([['on: [push, pull_request]'], ['on: push']])('recognizes the %s shorthand trigger', (onLine) => {
+    const workflow = [
+      'name: CI',
+      onLine,
+      'concurrency:',
+      '  group: ${{ github.workflow }}-${{ github.ref }}',
+      '  cancel-in-progress: true',
+      'jobs:',
+      '  release:',
+      '    steps:',
+      '      - run: git push origin HEAD:main',
+      '',
+    ].join('\n');
+
+    const result = runCheck(FLAG, { 'ci.yml': workflow });
+
+    expect(result.status).not.toBe(0);
   });
 
   test('flags a release action that publishes assets from a push-triggered run', () => {
@@ -263,6 +328,45 @@ describe('check_gh_repo_context', () => {
     });
 
     expect(result.status).toBe(0);
+  });
+
+  // ジョブAの checkout はジョブBの gh を設定しない。
+  test('flags a checkout-less job even when a sibling job checks out', () => {
+    const workflow = [
+      'name: CI',
+      'jobs:',
+      '  build:',
+      '    steps:',
+      '      - uses: actions/checkout@abc123 # v7.0.1',
+      '  label:',
+      '    steps:',
+      '      - name: Label updates',
+      '        run: gh label create "dependabot-minor" --force',
+      '',
+    ].join('\n');
+
+    const result = runCheck(FLAG, { 'ci.yml': workflow });
+
+    expect(result.status).not.toBe(0);
+  });
+
+  // 別コマンドに付いた --repo は gh label create を設定しない。
+  test('flags a command without --repo even when a sibling command has one', () => {
+    const workflow = [
+      'name: CI',
+      'jobs:',
+      '  label:',
+      '    steps:',
+      '      - name: Label updates',
+      '        run: |',
+      '          gh issue list --repo "$GITHUB_REPOSITORY"',
+      '          gh label create "dependabot-minor" --force',
+      '',
+    ].join('\n');
+
+    const result = runCheck(FLAG, { 'ci.yml': workflow });
+
+    expect(result.status).not.toBe(0);
   });
 
   test('ignores gh subcommands that take a pull request URL', () => {

--- a/test/template-workflows-dependabot.test.js
+++ b/test/template-workflows-dependabot.test.js
@@ -145,4 +145,17 @@ describe('dependabot-auto-merge.yml (template and actual — security-critical p
     expect(workflow).toContain('gh label create "needs-review"');
     expect(workflow).toContain('gh label create "breaking-change"');
   });
+
+  // このジョブは actions/checkout を実行しないため、gh はリポジトリを git から
+  // 解決できない。`gh pr edit "$PR_URL"` は URL から特定できるが `gh label create`
+  // は引数を持たず、"failed to run git: fatal: not a git repository" で落ちる。
+  test.each(workflowPaths)('%s: gives gh a repository without a checkout', (wfPath) => {
+    const workflow = readWorkflow(wfPath);
+
+    expect(workflow).not.toContain('actions/checkout');
+
+    for (const step of workflow.split(/^ {6}- /m).filter((s) => s.includes('gh label create'))) {
+      expect(step).toContain('GH_REPO: ${{ github.repository }}');
+    }
+  });
 });


### PR DESCRIPTION
Closes #1067
Closes #1069

## Why

CI が緑のまま、あるいは短時間で落ちるだけで原因が分かりにくいワークフロー不具合を 3 件踏んだ。いずれも repo-maintenance が検知できていれば早期に気付けたもの。

### 1. Claude Actions の資格情報優先順位（[#1063](https://github.com/keito4/config/issues/1063) / [PR #1064](https://github.com/keito4/config/pull/1064)）

Claude CLI は `ANTHROPIC_API_KEY` を `CLAUDE_CODE_OAUTH_TOKEN` より優先する（ADR 0013）。両方を無条件に `claude-code-action` へ渡すと失効した API キーが有効な OAuth トークンを握り潰す。失敗は無言（`is_error:true` / `num_turns:1` / `total_cost_usd:0` / エラー本文なし）で約 180 秒リトライしてから終わるため、config では 2026-07-29 以降レビューが一度も実行されていなかったのに success に見え続けていた。

### 2. push 起動ワークフローの自己キャンセル（[keito4/intent-gate-android #60](https://github.com/keito4/intent-gate-android/pull/60)）

`release` ジョブがバージョンバンプを push すると、その push が起こす新規実行に `cancel-in-progress: true` で自分自身をキャンセルされる。v1.2.49 は GitHub Release へのアセット添付も Firebase 配信も未実行のまま終わっていた。

### 3. checkout 無しのジョブで `gh` がリポジトリを解決できない（[#1069](https://github.com/keito4/config/issues/1069) / [PR #1066](https://github.com/keito4/config/pull/1066)）

`dependabot-auto` ジョブは `actions/checkout` を実行しないため、`gh` はリポジトリを git から解決できず落ちる。

```
failed to run git: fatal: not a git repository (or any of the parent directories): .git
```

同じジョブ内でも `gh pr edit "$PR_URL"` は URL からリポジトリを特定できるので通り、引数を持たない `gh label create` だけが失敗するため原因が分かりにくい。**Dependabot の minor / major 更新のたびに再現**しており（08-04 undici / 08-03 actions-minor / actions-checkout / setup-node）、patch 更新だけ success なのはラベル手順を通らないため。

## What

### 検査の追加

| フラグ | 検査内容 |
| --- | --- |
| `--check-claude-action-credentials` | `claude_code_oauth_token` と併記された無条件の `anthropic_api_key` |
| `--check-self-cancelling-workflows` | push 起動かつコミット push / Release publish するワークフローの `cancel-in-progress: true` |
| `--check-gh-repo-context` | checkout 無しで `GH_REPO` も `--repo` も持たない repo スコープの `gh` 呼び出し |

いずれも setup フェーズから `|| true` 付きで呼ばれるため、警告は出るがメンテナンス自体は止めない。

### ワークフローの修正

| ファイル | 変更 |
| --- | --- |
| `.github/workflows/dependabot-auto-merge.yml` | ラベル手順へ `GH_REPO` を追加（実際に失敗中） |
| `templates/workflows/dependabot-auto-merge.yml` | 同上。本体と完全同一で**下流3リポジトリへ配布済み**のため必須 |
| `templates/workflows/claude-health-check.yml` | `gh issue list` / `gh issue create` に同じ潜在バグ |

いずれの検査も**行頭コメントを除去してから判定**する。intent-gate-android の修正後 `ci.yml` は注意書きの中に `cancel-in-progress: true` という文字列を含むため、素朴な grep では誤検知する（実際に検証中このケースを踏んだ）。

## How to test

**修正前の実ファイルに対する退行実証**（合成ケースではなく実物）:

```
# 修正前(8e46fd7) の config/.github/workflows/claude-code-review.yml
⚠ claude-code-review.yml: anthropic_api_key overrides CLAUDE_CODE_OAUTH_TOKEN   exit=1

# #60 マージ前の intent-gate-android/.github/workflows/ci.yml
⚠ ci.yml: cancel-in-progress cancels this workflow's own push                    exit=1

# 修正前(HEAD) の config/.github/workflows/dependabot-auto-merge.yml
⚠ dependabot-auto-merge.yml: gh has no repository to resolve without a checkout  exit=1
```

修正後の現行ファイルでは 3 検査とも exit=0。

- Unit (Jest): 919 tests, 0 failures（新規 15 件の Red → Green 確認済み）
- Integration (BATS): 310 tests, 0 failures
- `npm run workflow:sync:check`: ok（管理テンプレートの同一性維持）
- `npm run lint` / `format:check` / `shellcheck`: すべて pass

## レビュー対応（3836bb8）

CodeRabbit と Codex が独立に同じ偽陰性を指摘したため修正した。検知が目的の検査に偽陰性があると、ガードがあるのに素通りする状態になる。

| 指摘 | 検証 | 対応 |
| --- | --- | --- |
| `on: [push, ...]` / `on: push` 短縮形を取りこぼす | Red 2件で再現 | 3形式を解釈する既存 `workflow_has_event` を lib へ移して再利用 |
| ガード済み1行がファイル全体の否定判定を打ち消す | Red 1件で再現 | claude-code-action の**ステップ単位**判定へ |
| `checkout` / `GH_REPO` 判定がジョブを跨ぐ | Red 2件で再現 | **ジョブ単位**判定へ。`--repo` は同一コマンド行のみ有効 |

副次的な発見:

- `workflow_has_event` はスカラー形式 `on: push` に未対応だった。**既存の `check_required_workflows` にも同じ穴があった**ためヘルパー側で両方を塞いだ
- ステップ単位化により、claude-code-action 以外のアクションが `anthropic_api_key` を取る場合の誤検知も同時に解消された

修正前の実ファイル3件で検出できることを書き換え後に再実証済み。Unit 926 / Integration 310 / lint / shellcheck / format すべて pass。

## Risk

- 追加した検査は専用フラグ実行時のみ exit 1 を返す。setup フェーズでは警告のみ。
- `templates/workflows/` を変更するため `sync-downstream.yml` が下流3リポジトリへ同期 PR を作成する。これは意図した挙動で、下流の `dependabot-auto-merge.yml` にも同じ欠陥があるため修正の配布が必要。
- 調査の結果、下流4リポジトリの `claude-code-review.yml` はいずれも `claude_code_oauth_token` のみを渡しており 1 の不具合は踏んでいない。
- 差分 431 行が PR ガイドライン 400 行を超えるが、うち 275 行は新規テストファイル。新しい契約テストが修正後のワークフローを前提とするため、検査とワークフロー修正は同時に入る必要がある（分割すると同一ファイル群で衝突する）。PR Size Check は `continue-on-error: true` の助言的チェック。
- 下流の `claude-code-review.yml` は sync 管理外のためドリフト継続（action SHA `d5726de0` / checkout v6 / 認証ガードなし）。テンプレート化は別途判断が必要。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added maintenance checks for Claude credential configuration, self-cancelling workflows, and missing GitHub repository context.
  * Added dedicated command-line options to run each check independently.
  * Included all checks in standard maintenance runs.

* **Bug Fixes**
  * Improved GitHub CLI workflow steps to reliably identify the repository without a checkout.

* **Documentation**
  * Expanded maintenance command documentation and usage guidance.

* **Tests**
  * Added coverage for validation failures, valid configurations, and workflow repository context.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
