### PR TITLE
fix(ci): ワークフロー検査を配布テンプレートまで広げ PR で強制する

### DIFF
--- a/.claude/commands/repo-maintenance.md
+++ b/.claude/commands/repo-maintenance.md
@@ -38,6 +38,8 @@ Repository state guard runs before updates. Archived repositories switch to `che
 - Claude Actions credential precedence is checked with `script/repo-maintenance.sh --check-claude-action-credentials`. Passing `anthropic_api_key` unconditionally next to `claude_code_oauth_token` lets a stale API key shadow the OAuth token, and the run fails silently after roughly three minutes.
 - Workflow self-cancellation is checked with `script/repo-maintenance.sh --check-self-cancelling-workflows`. A push-triggered workflow that pushes commits or publishes a release must not use `cancel-in-progress: true`, or it cancels its own run before the release finishes.
 - `gh` repository context is checked with `script/repo-maintenance.sh --check-gh-repo-context`. A job without `actions/checkout` must pass `GH_REPO` or `--repo`, because `gh` otherwise resolves the repository from git and fails with `not a git repository`.
+- The four workflow guards above scan `.github/workflows/`, `.github/workflows/templates/`, and `templates/workflows/`. Templates are in scope because this repository distributes them to downstream repositories.
+- `ci.yml` runs the same guards in its Workflow Lint job, so a pull request that reintroduces one of these defects fails instead of only warning at the next scheduled maintenance run.
 - Managed workflow templates are checked against `templates/workflows/` with `npm run workflow:sync:check`.
 - Workflow Lint coverage checks verify `.github/workflows/`, `.github/workflows/templates/`, and `templates/workflows/` are collected without static unmatched globs.
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -247,6 +247,20 @@ jobs:
           fail_level: error
           actionlint_flags: ${{ steps.workflow-files.outputs.files }}
 
+      # actionlint が拾わない、CI が緑のまま実害だけが出る不具合を PR で止める。
+      # 週次メンテナンスの警告だけでは退行を含む PR がマージできてしまう。
+      - name: Run workflow guards
+        run: |
+          guard_status=0
+          for check in \
+            --check-claude-action-credentials \
+            --check-self-cancelling-workflows \
+            --check-gh-repo-context \
+            --check-artifact-retention; do
+            script/repo-maintenance.sh "$check" || guard_status=1
+          done
+          exit "$guard_status"
+
   workflow-template-sync:
     name: Workflow Template Sync
     runs-on: ubuntu-latest

--- a/script/README.md
+++ b/script/README.md
@@ -190,6 +190,11 @@ Runs repository maintenance checks and managed updates. This is the executable s
 ./script/repo-maintenance.sh --check-gh-repo-context
 ```
 
+The workflow guards (`--check-claude-action-credentials`, `--check-self-cancelling-workflows`,
+`--check-gh-repo-context`, `--check-artifact-retention`) scan `.github/workflows/`,
+`.github/workflows/templates/`, and `templates/workflows/`. `ci.yml` runs all four in its
+Workflow Lint job so regressions fail the pull request.
+
 ### setup-ci.sh
 
 Detects project type and package manager, then writes CI/CD workflow defaults.

--- a/script/lib/repo_maintenance_checks.sh
+++ b/script/lib/repo_maintenance_checks.sh
@@ -57,6 +57,17 @@ check_scheduled_maintenance_configuration() {
   output::success "Scheduled Maintenance configuration ok"
 }
 
+# 検査対象のワークフロー一覧。actionlint の収集範囲と同じ3ディレクトリを見る。
+# config は templates/workflows/ を下流リポジトリへ配布するため、ここを外すと
+# 配布物に入った不具合を検出できない。
+workflow_files() {
+  {
+    find .github/workflows -maxdepth 1 -type f \( -name '*.yml' -o -name '*.yaml' \) 2>/dev/null || true
+    find .github/workflows/templates -type f \( -name '*.yml' -o -name '*.yaml' \) 2>/dev/null || true
+    find templates/workflows -type f \( -name '*.yml' -o -name '*.yaml' \) 2>/dev/null || true
+  } | sort
+}
+
 workflow_has_event() {
   local workflow="${1:?Workflow required}"
   local event="${2:?Event required}"
@@ -96,8 +107,8 @@ workflow_has_event() {
 check_claude_action_credentials() {
   local workflow issue_count=0
 
-  for workflow in .github/workflows/*.yml .github/workflows/*.yaml; do
-    [[ -f "$workflow" ]] || continue
+  while IFS= read -r workflow; do
+    [[ -n "$workflow" ]] || continue
 
     # claude-code-action のステップ単位で判定する。ファイル全体を見ると、ガード済みの
     # 1 行が否定判定を打ち消して別ステップの無条件なキーを見逃す。
@@ -121,7 +132,7 @@ check_claude_action_credentials() {
       echo "  anthropic_api_key: \${{ secrets.CLAUDE_CODE_OAUTH_TOKEN == '' && secrets.ANTHROPIC_API_KEY || '' }}"
       issue_count=$((issue_count + 1))
     fi
-  done
+  done < <(workflow_files)
 
   if [[ "$issue_count" -gt 0 ]]; then
     return 1
@@ -136,8 +147,8 @@ check_claude_action_credentials() {
 check_self_cancelling_workflows() {
   local workflow issue_count=0 stripped
 
-  for workflow in .github/workflows/*.yml .github/workflows/*.yaml; do
-    [[ -f "$workflow" ]] || continue
+  while IFS= read -r workflow; do
+    [[ -n "$workflow" ]] || continue
 
     stripped="$(sed 's/^[[:space:]]*#.*$//' "$workflow")"
 
@@ -150,7 +161,7 @@ check_self_cancelling_workflows() {
     echo "Scope the cancellation to pull requests so pushes to the default branch run to completion:"
     echo "  cancel-in-progress: \${{ github.event_name == 'pull_request' }}"
     issue_count=$((issue_count + 1))
-  done
+  done < <(workflow_files)
 
   if [[ "$issue_count" -gt 0 ]]; then
     return 1
@@ -165,8 +176,8 @@ check_self_cancelling_workflows() {
 check_gh_repo_context() {
   local workflow issue_count=0
 
-  for workflow in .github/workflows/*.yml .github/workflows/*.yaml; do
-    [[ -f "$workflow" ]] || continue
+  while IFS= read -r workflow; do
+    [[ -n "$workflow" ]] || continue
 
     # ジョブ単位で判定する。あるジョブの checkout や GH_REPO は別ジョブの gh を設定しない。
     # --repo は同じコマンド行にある場合だけ有効とみなす。
@@ -190,7 +201,7 @@ check_gh_repo_context() {
       echo "  GH_REPO: \${{ github.repository }}"
       issue_count=$((issue_count + 1))
     fi
-  done
+  done < <(workflow_files)
 
   if [[ "$issue_count" -gt 0 ]]; then
     return 1
@@ -202,8 +213,8 @@ check_gh_repo_context() {
 check_artifact_retention() {
   local workflow issue_count=0
 
-  for workflow in .github/workflows/*.yml .github/workflows/*.yaml; do
-    [[ -f "$workflow" ]] || continue
+  while IFS= read -r workflow; do
+    [[ -n "$workflow" ]] || continue
     if ! awk -v file="$(basename "$workflow")" '
       /^[[:space:]]*(-[[:space:]]*)?uses:[[:space:]]*actions\/upload-artifact@/ {
         in_upload = 1
@@ -239,7 +250,7 @@ check_artifact_retention() {
     ' "$workflow"; then
       issue_count=$((issue_count + 1))
     fi
-  done
+  done < <(workflow_files)
 
   if [[ "$issue_count" -gt 0 ]]; then
     return 1

--- a/script/lib/repo_maintenance_checks.sh
+++ b/script/lib/repo_maintenance_checks.sh
@@ -153,6 +153,9 @@ check_self_cancelling_workflows() {
     stripped="$(sed 's/^[[:space:]]*#.*$//' "$workflow")"
 
     grep -qE "^[[:space:]]*cancel-in-progress:[[:space:]]*true[[:space:]]*$" <<<"$stripped" || continue
+    # group が sha / run_id を含むなら、自分が起こす push は別グループに属するため
+    # 自分自身をキャンセルできない。
+    grep -qE "^[[:space:]]*group:.*(github\.sha|github\.run_id)" <<<"$stripped" && continue
     # on: push / on: [push, ...] の短縮形も push トリガーなので workflow_has_event で判定する。
     workflow_has_event "$workflow" "push" || continue
     grep -qE "git push|peter-evans/create-pull-request|softprops/action-gh-release|googleapis/release-please" <<<"$stripped" || continue
@@ -192,7 +195,8 @@ check_gh_repo_context() {
       in_job && line ~ /actions\/checkout/ { has_checkout = 1 }
       in_job && line ~ /^[[:space:]]*GH_REPO:/ { has_gh_repo = 1 }
       in_job && line ~ /(^|[^A-Za-z0-9_-])gh[[:space:]]+((label|issue|release|run|workflow)|pr[[:space:]]+(create|list|status))([^A-Za-z0-9_-]|$)/ {
-        if (line !~ /--repo[[:space:]]/) bad_cmd = 1
+        # gh は -R / --repo= も受け付ける。落とすと正当なワークフローを止める。
+        if (line !~ /(--repo[[:space:]=]|-R[[:space:]])/) bad_cmd = 1
       }
       END { flush(); exit bad ? 1 : 0 }
     ' "$workflow"; then

--- a/test/claude-workflow-contract.test.js
+++ b/test/claude-workflow-contract.test.js
@@ -296,6 +296,27 @@ describe('Claude workflow contracts', () => {
     expect(script).toContain('/^  [A-Za-z0-9_-]+:/');
   });
 
+  // 検査は週次メンテナンスの警告だけでは退行を止められない。PR の CI で強制する。
+  test('CI enforces the workflow guards on pull requests', () => {
+    const workflow = readWorkflow('.github/workflows/ci.yml');
+
+    expect(workflow).toContain('name: Run workflow guards');
+    expect(workflow).toContain('script/repo-maintenance.sh "$check"');
+    for (const flag of [
+      '--check-claude-action-credentials',
+      '--check-self-cancelling-workflows',
+      '--check-gh-repo-context',
+      '--check-artifact-retention',
+    ]) {
+      expect(workflow).toContain(flag);
+    }
+    // 最初の失敗で打ち切らず、全違反を報告してから落ちる。
+    expect(workflow).toContain('|| guard_status=1');
+    expect(workflow).toContain('exit "$guard_status"');
+    // Workflow Lint は quality-gate の needs に含まれるため、失敗がマージを止める。
+    expect(workflow).toContain('needs: [changes, lint, test, integration-test, actionlint, workflow-template-sync]');
+  });
+
   // on: push / on: [push] / on:\n  push: / on:\n  - push はいずれも push トリガー。
   // スカラー形式を取りこぼすと、必須ワークフロー検査も自己キャンセル検査もすり抜ける。
   test('workflow_has_event recognizes every valid trigger form', () => {

--- a/test/helpers/workflow-guards.js
+++ b/test/helpers/workflow-guards.js
@@ -1,0 +1,51 @@
+const fs = require('fs');
+const path = require('path');
+const { execFileSync } = require('child_process');
+
+const repoPath = path.resolve(__dirname, '..', '..');
+const inheritedGitEnvKeys = ['GIT_DIR', 'GIT_WORK_TREE', 'GIT_INDEX_FILE', 'GIT_PREFIX'];
+
+function cleanGitEnv() {
+  const env = { ...process.env };
+  for (const key of inheritedGitEnvKeys) {
+    delete env[key];
+  }
+  return env;
+}
+
+/**
+ * repo-maintenance のワークフロー検査を、一時リポジトリに対して実行する。
+ * workflows のキーがパス区切りを含めばそのまま、含まなければ .github/workflows/ に置く。
+ * @param {string} flag - 実行する検査フラグ。
+ * @param {Record<string, string>} workflows - 配置するワークフローの内容。
+ * @returns {{status: number, output: string}} 終了コードと標準出力。
+ */
+function runCheck(flag, workflows) {
+  const contextDir = path.join(repoPath, '.context');
+  fs.mkdirSync(contextDir, { recursive: true });
+  const tempRoot = fs.mkdtempSync(path.join(contextDir, 'workflow-guards-test-'));
+
+  try {
+    for (const [name, content] of Object.entries(workflows)) {
+      const target = name.includes('/') ? path.join(tempRoot, name) : path.join(tempRoot, '.github', 'workflows', name);
+      fs.mkdirSync(path.dirname(target), { recursive: true });
+      fs.writeFileSync(target, content);
+    }
+
+    const scriptPath = path.join(repoPath, 'script', 'repo-maintenance.sh');
+    try {
+      const stdout = execFileSync('bash', [scriptPath, flag], {
+        cwd: tempRoot,
+        env: cleanGitEnv(),
+        encoding: 'utf8',
+      });
+      return { status: 0, output: stdout };
+    } catch (error) {
+      return { status: error.status, output: `${error.stdout || ''}${error.stderr || ''}` };
+    }
+  } finally {
+    fs.rmSync(tempRoot, { recursive: true, force: true });
+  }
+}
+
+module.exports = { runCheck };

--- a/test/repo-maintenance-gh-guards.test.js
+++ b/test/repo-maintenance-gh-guards.test.js
@@ -1,0 +1,205 @@
+const { runCheck } = require('./helpers/workflow-guards');
+
+// keito4/config PR #1066: dependabot-auto ジョブは actions/checkout を実行しないため、
+// `gh label create` がリポジトリを git から解決できず
+// "failed to run git: fatal: not a git repository" で落ちていた。
+// URL 引数を取る `gh pr edit "$PR_URL"` は同じジョブでも通るので気付きにくい。
+describe('check_gh_repo_context', () => {
+  const FLAG = '--check-gh-repo-context';
+
+  function ghWorkflow({ command, checkout = false, env = [] }) {
+    return [
+      'name: Dependabot Auto-merge',
+      'jobs:',
+      '  dependabot-auto:',
+      '    steps:',
+      ...(checkout ? ['      - uses: actions/checkout@abc123 # v7.0.1'] : []),
+      '      - name: Label updates',
+      `        run: ${command}`,
+      ...(env.length ? ['        env:', ...env.map((line) => `          ${line}`)] : []),
+      '',
+    ].join('\n');
+  }
+
+  test('flags a repo-scoped gh command in a workflow that never checks out', () => {
+    const result = runCheck(FLAG, {
+      'dependabot-auto-merge.yml': ghWorkflow({ command: 'gh label create "dependabot-minor" --force' }),
+    });
+
+    expect(result.status).not.toBe(0);
+    expect(result.output).toContain('dependabot-auto-merge.yml');
+    expect(result.output).toContain('GH_REPO');
+  });
+
+  test('accepts the same command once GH_REPO is provided', () => {
+    const result = runCheck(FLAG, {
+      'dependabot-auto-merge.yml': ghWorkflow({
+        command: 'gh label create "dependabot-minor" --force',
+        env: ['GH_REPO: ${{ github.repository }}'],
+      }),
+    });
+
+    expect(result.status).toBe(0);
+    expect(result.output).toContain('gh repository context ok');
+  });
+
+  test('accepts an explicit --repo argument', () => {
+    const result = runCheck(FLAG, {
+      'health.yml': ghWorkflow({ command: 'gh issue create --repo "$GITHUB_REPOSITORY" --title x' }),
+    });
+
+    expect(result.status).toBe(0);
+  });
+
+  test('accepts a workflow that checks the repository out', () => {
+    const result = runCheck(FLAG, {
+      'ci.yml': ghWorkflow({ command: 'gh label create "x" --force', checkout: true }),
+    });
+
+    expect(result.status).toBe(0);
+  });
+
+  // ジョブAの checkout はジョブBの gh を設定しない。
+  test('flags a checkout-less job even when a sibling job checks out', () => {
+    const workflow = [
+      'name: CI',
+      'jobs:',
+      '  build:',
+      '    steps:',
+      '      - uses: actions/checkout@abc123 # v7.0.1',
+      '  label:',
+      '    steps:',
+      '      - name: Label updates',
+      '        run: gh label create "dependabot-minor" --force',
+      '',
+    ].join('\n');
+
+    const result = runCheck(FLAG, { 'ci.yml': workflow });
+
+    expect(result.status).not.toBe(0);
+  });
+
+  // 別コマンドに付いた --repo は gh label create を設定しない。
+  test('flags a command without --repo even when a sibling command has one', () => {
+    const workflow = [
+      'name: CI',
+      'jobs:',
+      '  label:',
+      '    steps:',
+      '      - name: Label updates',
+      '        run: |',
+      '          gh issue list --repo "$GITHUB_REPOSITORY"',
+      '          gh label create "dependabot-minor" --force',
+      '',
+    ].join('\n');
+
+    const result = runCheck(FLAG, { 'ci.yml': workflow });
+
+    expect(result.status).not.toBe(0);
+  });
+
+  // gh は -R / --repo= も受け付ける。検査が CI をブロックする以上、
+  // 正しい書き方を落とすと正当な PR が止まる。
+  test.each([['-R "$GITHUB_REPOSITORY"'], ['--repo="$GITHUB_REPOSITORY"']])(
+    'accepts the %s form of the repository flag',
+    (flag) => {
+      const result = runCheck(FLAG, {
+        'health.yml': ghWorkflow({ command: `gh issue create ${flag} --title x` }),
+      });
+
+      expect(result.status).toBe(0);
+    },
+  );
+
+  test('ignores gh subcommands that take a pull request URL', () => {
+    const result = runCheck(FLAG, {
+      'dependabot-auto-merge.yml': ghWorkflow({ command: 'gh pr edit "$PR_URL" --add-label "x"' }),
+    });
+
+    expect(result.status).toBe(0);
+  });
+});
+
+// config は templates/workflows/ を下流リポジトリへ配布する。ここを走査しないと、
+// 配布物に入った不具合を config 側の検査が検出できない（実際 claude-health-check.yml の
+// gh バグは .github/workflows/ しか見ていなかったため検査をすり抜けていた）。
+describe('workflow guards cover distributed templates', () => {
+  test('--check-gh-repo-context flags a template that never checks out', () => {
+    const workflow = [
+      'name: Claude Code Health Check',
+      'jobs:',
+      '  health-check:',
+      '    steps:',
+      '      - name: Create issue on failure',
+      '        env:',
+      '          GH_TOKEN: ${{ github.token }}',
+      '        run: gh issue create --title x',
+      '',
+    ].join('\n');
+
+    const result = runCheck('--check-gh-repo-context', {
+      'templates/workflows/claude-health-check.yml': workflow,
+    });
+
+    expect(result.status).not.toBe(0);
+    expect(result.output).toContain('claude-health-check.yml');
+  });
+
+  test('--check-claude-action-credentials flags a template that shadows the OAuth token', () => {
+    const workflow = [
+      'name: Claude',
+      'jobs:',
+      '  claude:',
+      '    steps:',
+      '      - uses: anthropics/claude-code-action@abc123 # v1',
+      '        with:',
+      '          claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}',
+      '          anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}',
+      '',
+    ].join('\n');
+
+    const result = runCheck('--check-claude-action-credentials', {
+      'templates/workflows/claude.yml': workflow,
+    });
+
+    expect(result.status).not.toBe(0);
+  });
+
+  test('--check-self-cancelling-workflows flags a template that cancels its own push', () => {
+    const workflow = [
+      'name: Release',
+      'on: [push]',
+      'concurrency:',
+      '  group: ${{ github.workflow }}',
+      '  cancel-in-progress: true',
+      'jobs:',
+      '  release:',
+      '    steps:',
+      '      - run: git push origin HEAD:main',
+      '',
+    ].join('\n');
+
+    const result = runCheck('--check-self-cancelling-workflows', {
+      'templates/workflows/release.yml': workflow,
+    });
+
+    expect(result.status).not.toBe(0);
+  });
+
+  test('also covers reusable workflow templates under .github/workflows/templates', () => {
+    const workflow = [
+      'name: Reusable',
+      'jobs:',
+      '  label:',
+      '    steps:',
+      '      - run: gh label create "x" --force',
+      '',
+    ].join('\n');
+
+    const result = runCheck('--check-gh-repo-context', {
+      '.github/workflows/templates/reusable.yml': workflow,
+    });
+
+    expect(result.status).not.toBe(0);
+  });
+});

--- a/test/repo-maintenance-workflow-guards.test.js
+++ b/test/repo-maintenance-workflow-guards.test.js
@@ -20,7 +20,8 @@ function runCheck(flag, workflows) {
 
   try {
     for (const [name, content] of Object.entries(workflows)) {
-      const target = path.join(tempRoot, '.github', 'workflows', name);
+      // パス区切りを含むキーはそのまま使う。含まなければ .github/workflows/ に置く。
+      const target = name.includes('/') ? path.join(tempRoot, name) : path.join(tempRoot, '.github', 'workflows', name);
       fs.mkdirSync(path.dirname(target), { recursive: true });
       fs.writeFileSync(target, content);
     }
@@ -375,5 +376,89 @@ describe('check_gh_repo_context', () => {
     });
 
     expect(result.status).toBe(0);
+  });
+});
+
+// config は templates/workflows/ を下流リポジトリへ配布する。ここを走査しないと、
+// 配布物に入った不具合を config 側の検査が検出できない（実際 claude-health-check.yml の
+// gh バグは .github/workflows/ しか見ていなかったため検査をすり抜けていた）。
+describe('workflow guards cover distributed templates', () => {
+  test('--check-gh-repo-context flags a template that never checks out', () => {
+    const workflow = [
+      'name: Claude Code Health Check',
+      'jobs:',
+      '  health-check:',
+      '    steps:',
+      '      - name: Create issue on failure',
+      '        env:',
+      '          GH_TOKEN: ${{ github.token }}',
+      '        run: gh issue create --title x',
+      '',
+    ].join('\n');
+
+    const result = runCheck('--check-gh-repo-context', {
+      'templates/workflows/claude-health-check.yml': workflow,
+    });
+
+    expect(result.status).not.toBe(0);
+    expect(result.output).toContain('claude-health-check.yml');
+  });
+
+  test('--check-claude-action-credentials flags a template that shadows the OAuth token', () => {
+    const workflow = [
+      'name: Claude',
+      'jobs:',
+      '  claude:',
+      '    steps:',
+      '      - uses: anthropics/claude-code-action@abc123 # v1',
+      '        with:',
+      '          claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}',
+      '          anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}',
+      '',
+    ].join('\n');
+
+    const result = runCheck('--check-claude-action-credentials', {
+      'templates/workflows/claude.yml': workflow,
+    });
+
+    expect(result.status).not.toBe(0);
+  });
+
+  test('--check-self-cancelling-workflows flags a template that cancels its own push', () => {
+    const workflow = [
+      'name: Release',
+      'on: [push]',
+      'concurrency:',
+      '  group: ${{ github.workflow }}',
+      '  cancel-in-progress: true',
+      'jobs:',
+      '  release:',
+      '    steps:',
+      '      - run: git push origin HEAD:main',
+      '',
+    ].join('\n');
+
+    const result = runCheck('--check-self-cancelling-workflows', {
+      'templates/workflows/release.yml': workflow,
+    });
+
+    expect(result.status).not.toBe(0);
+  });
+
+  test('also covers reusable workflow templates under .github/workflows/templates', () => {
+    const workflow = [
+      'name: Reusable',
+      'jobs:',
+      '  label:',
+      '    steps:',
+      '      - run: gh label create "x" --force',
+      '',
+    ].join('\n');
+
+    const result = runCheck('--check-gh-repo-context', {
+      '.github/workflows/templates/reusable.yml': workflow,
+    });
+
+    expect(result.status).not.toBe(0);
   });
 });

--- a/test/repo-maintenance-workflow-guards.test.js
+++ b/test/repo-maintenance-workflow-guards.test.js
@@ -1,46 +1,4 @@
-const fs = require('fs');
-const path = require('path');
-const { execFileSync } = require('child_process');
-
-const repoPath = path.resolve(__dirname, '..');
-const inheritedGitEnvKeys = ['GIT_DIR', 'GIT_WORK_TREE', 'GIT_INDEX_FILE', 'GIT_PREFIX'];
-
-function cleanGitEnv() {
-  const env = { ...process.env };
-  for (const key of inheritedGitEnvKeys) {
-    delete env[key];
-  }
-  return env;
-}
-
-function runCheck(flag, workflows) {
-  const contextDir = path.join(repoPath, '.context');
-  fs.mkdirSync(contextDir, { recursive: true });
-  const tempRoot = fs.mkdtempSync(path.join(contextDir, 'workflow-guards-test-'));
-
-  try {
-    for (const [name, content] of Object.entries(workflows)) {
-      // パス区切りを含むキーはそのまま使う。含まなければ .github/workflows/ に置く。
-      const target = name.includes('/') ? path.join(tempRoot, name) : path.join(tempRoot, '.github', 'workflows', name);
-      fs.mkdirSync(path.dirname(target), { recursive: true });
-      fs.writeFileSync(target, content);
-    }
-
-    const scriptPath = path.join(repoPath, 'script', 'repo-maintenance.sh');
-    try {
-      const stdout = execFileSync('bash', [scriptPath, flag], {
-        cwd: tempRoot,
-        env: cleanGitEnv(),
-        encoding: 'utf8',
-      });
-      return { status: 0, output: stdout };
-    } catch (error) {
-      return { status: error.status, output: `${error.stdout || ''}${error.stderr || ''}` };
-    }
-  } finally {
-    fs.rmSync(tempRoot, { recursive: true, force: true });
-  }
-}
+const { runCheck } = require('./helpers/workflow-guards');
 
 // Claude CLI は ANTHROPIC_API_KEY を CLAUDE_CODE_OAUTH_TOKEN より優先する（ADR 0013）。
 // 両方を無条件に claude-code-action へ渡すと、失効した API キーが有効な OAuth トークンを
@@ -250,6 +208,29 @@ describe('check_self_cancelling_workflows', () => {
     expect(result.status).not.toBe(0);
   });
 
+  // concurrency group が sha / run_id を含むなら、自分が起こす push は別グループに
+  // 属するため自分自身をキャンセルできない。
+  test.each([['${{ github.sha }}'], ['${{ github.run_id }}']])('accepts a concurrency group keyed by %s', (suffix) => {
+    const workflow = [
+      'name: Release',
+      'on:',
+      '  push:',
+      '    branches: [main]',
+      'concurrency:',
+      `  group: \${{ github.workflow }}-${suffix}`,
+      '  cancel-in-progress: true',
+      'jobs:',
+      '  release:',
+      '    steps:',
+      '      - run: git push origin HEAD:main',
+      '',
+    ].join('\n');
+
+    const result = runCheck(FLAG, { 'release.yml': workflow });
+
+    expect(result.status).toBe(0);
+  });
+
   test('flags a release action that publishes assets from a push-triggered run', () => {
     const workflow = [
       'name: Release',
@@ -267,197 +248,6 @@ describe('check_self_cancelling_workflows', () => {
     ].join('\n');
 
     const result = runCheck(FLAG, { 'release.yml': workflow });
-
-    expect(result.status).not.toBe(0);
-  });
-});
-
-// keito4/config PR #1066: dependabot-auto ジョブは actions/checkout を実行しないため、
-// `gh label create` がリポジトリを git から解決できず
-// "failed to run git: fatal: not a git repository" で落ちていた。
-// URL 引数を取る `gh pr edit "$PR_URL"` は同じジョブでも通るので気付きにくい。
-describe('check_gh_repo_context', () => {
-  const FLAG = '--check-gh-repo-context';
-
-  function ghWorkflow({ command, checkout = false, env = [] }) {
-    return [
-      'name: Dependabot Auto-merge',
-      'jobs:',
-      '  dependabot-auto:',
-      '    steps:',
-      ...(checkout ? ['      - uses: actions/checkout@abc123 # v7.0.1'] : []),
-      '      - name: Label updates',
-      `        run: ${command}`,
-      ...(env.length ? ['        env:', ...env.map((line) => `          ${line}`)] : []),
-      '',
-    ].join('\n');
-  }
-
-  test('flags a repo-scoped gh command in a workflow that never checks out', () => {
-    const result = runCheck(FLAG, {
-      'dependabot-auto-merge.yml': ghWorkflow({ command: 'gh label create "dependabot-minor" --force' }),
-    });
-
-    expect(result.status).not.toBe(0);
-    expect(result.output).toContain('dependabot-auto-merge.yml');
-    expect(result.output).toContain('GH_REPO');
-  });
-
-  test('accepts the same command once GH_REPO is provided', () => {
-    const result = runCheck(FLAG, {
-      'dependabot-auto-merge.yml': ghWorkflow({
-        command: 'gh label create "dependabot-minor" --force',
-        env: ['GH_REPO: ${{ github.repository }}'],
-      }),
-    });
-
-    expect(result.status).toBe(0);
-    expect(result.output).toContain('gh repository context ok');
-  });
-
-  test('accepts an explicit --repo argument', () => {
-    const result = runCheck(FLAG, {
-      'health.yml': ghWorkflow({ command: 'gh issue create --repo "$GITHUB_REPOSITORY" --title x' }),
-    });
-
-    expect(result.status).toBe(0);
-  });
-
-  test('accepts a workflow that checks the repository out', () => {
-    const result = runCheck(FLAG, {
-      'ci.yml': ghWorkflow({ command: 'gh label create "x" --force', checkout: true }),
-    });
-
-    expect(result.status).toBe(0);
-  });
-
-  // ジョブAの checkout はジョブBの gh を設定しない。
-  test('flags a checkout-less job even when a sibling job checks out', () => {
-    const workflow = [
-      'name: CI',
-      'jobs:',
-      '  build:',
-      '    steps:',
-      '      - uses: actions/checkout@abc123 # v7.0.1',
-      '  label:',
-      '    steps:',
-      '      - name: Label updates',
-      '        run: gh label create "dependabot-minor" --force',
-      '',
-    ].join('\n');
-
-    const result = runCheck(FLAG, { 'ci.yml': workflow });
-
-    expect(result.status).not.toBe(0);
-  });
-
-  // 別コマンドに付いた --repo は gh label create を設定しない。
-  test('flags a command without --repo even when a sibling command has one', () => {
-    const workflow = [
-      'name: CI',
-      'jobs:',
-      '  label:',
-      '    steps:',
-      '      - name: Label updates',
-      '        run: |',
-      '          gh issue list --repo "$GITHUB_REPOSITORY"',
-      '          gh label create "dependabot-minor" --force',
-      '',
-    ].join('\n');
-
-    const result = runCheck(FLAG, { 'ci.yml': workflow });
-
-    expect(result.status).not.toBe(0);
-  });
-
-  test('ignores gh subcommands that take a pull request URL', () => {
-    const result = runCheck(FLAG, {
-      'dependabot-auto-merge.yml': ghWorkflow({ command: 'gh pr edit "$PR_URL" --add-label "x"' }),
-    });
-
-    expect(result.status).toBe(0);
-  });
-});
-
-// config は templates/workflows/ を下流リポジトリへ配布する。ここを走査しないと、
-// 配布物に入った不具合を config 側の検査が検出できない（実際 claude-health-check.yml の
-// gh バグは .github/workflows/ しか見ていなかったため検査をすり抜けていた）。
-describe('workflow guards cover distributed templates', () => {
-  test('--check-gh-repo-context flags a template that never checks out', () => {
-    const workflow = [
-      'name: Claude Code Health Check',
-      'jobs:',
-      '  health-check:',
-      '    steps:',
-      '      - name: Create issue on failure',
-      '        env:',
-      '          GH_TOKEN: ${{ github.token }}',
-      '        run: gh issue create --title x',
-      '',
-    ].join('\n');
-
-    const result = runCheck('--check-gh-repo-context', {
-      'templates/workflows/claude-health-check.yml': workflow,
-    });
-
-    expect(result.status).not.toBe(0);
-    expect(result.output).toContain('claude-health-check.yml');
-  });
-
-  test('--check-claude-action-credentials flags a template that shadows the OAuth token', () => {
-    const workflow = [
-      'name: Claude',
-      'jobs:',
-      '  claude:',
-      '    steps:',
-      '      - uses: anthropics/claude-code-action@abc123 # v1',
-      '        with:',
-      '          claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}',
-      '          anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}',
-      '',
-    ].join('\n');
-
-    const result = runCheck('--check-claude-action-credentials', {
-      'templates/workflows/claude.yml': workflow,
-    });
-
-    expect(result.status).not.toBe(0);
-  });
-
-  test('--check-self-cancelling-workflows flags a template that cancels its own push', () => {
-    const workflow = [
-      'name: Release',
-      'on: [push]',
-      'concurrency:',
-      '  group: ${{ github.workflow }}',
-      '  cancel-in-progress: true',
-      'jobs:',
-      '  release:',
-      '    steps:',
-      '      - run: git push origin HEAD:main',
-      '',
-    ].join('\n');
-
-    const result = runCheck('--check-self-cancelling-workflows', {
-      'templates/workflows/release.yml': workflow,
-    });
-
-    expect(result.status).not.toBe(0);
-  });
-
-  test('also covers reusable workflow templates under .github/workflows/templates', () => {
-    const workflow = [
-      'name: Reusable',
-      'jobs:',
-      '  label:',
-      '    steps:',
-      '      - run: gh label create "x" --force',
-      '',
-    ].join('\n');
-
-    const result = runCheck('--check-gh-repo-context', {
-      '.github/workflows/templates/reusable.yml': workflow,
-    });
 
     expect(result.status).not.toBe(0);
   });


### PR DESCRIPTION
Closes #1070

## Why

[PR #1068](https://github.com/keito4/config/pull/1068) で4つのワークフロー検査を追加したが、「今後も起きない」と言い切れない穴が2つ残っていた。

### 1. 走査対象が `.github/workflows/` だけだった

config は `templates/workflows/` を下流リポジトリへ配布するが、検査はそこを見ていなかった。

**PR #1068 で修正した `templates/workflows/claude-health-check.yml` の `gh` バグを、同じ PR で追加した検査が検出できない**状態だった。修正前のテンプレートを置いた実測:

```
--- templates/workflows/claude-health-check.yml（GH_REPO なし）---
✓ gh repository context ok
exit=0
```

### 2. CI で強制されていなかった

検査は `scheduled-maintenance.yml`（週次 TAKT 実行）からしか呼ばれず、退行を含む PR は緑のままマージできた。今回の `dependabot-auto` が繰り返し失敗し続けていたのと同じ構図。

## What

| 対応 | 内容 |
| --- | --- |
| 走査範囲 | actionlint と同じ3ディレクトリを走査する `workflow_files()` を共有し、4検査すべてを揃える |
| CI 強制 | `ci.yml` の Workflow Lint ジョブで4検査を実行 |

`paths-filter` の `workflows` は既に `templates/workflows/**` を含むため、テンプレートのみの変更でも検査が起動する。Workflow Lint は `quality-gate` の `needs` に含まれるため、失敗がマージを止める。

最初の失敗で打ち切らず**全違反を報告してから落ちる**形にした（1件直すたびに次が出る往復を避けるため）。

## How to test

**走査範囲の拡大**（修正前のテンプレートを検出できるか）:

```
# 変更前
✓ gh repository context ok                                                    exit=0
# 変更後
⚠ claude-health-check.yml: gh has no repository to resolve without a checkout  exit=1
```

**CI 強制**（退行を注入して CI ステップを再現）:

```
✓ Claude Actions credential precedence ok
✓ Workflow self-cancellation guards ok
⚠ claude-health-check.yml: gh has no repository to resolve without a checkout
✓ Artifact retention settings ok
guard exit=1
```

**既存テンプレートへの影響**: 現行の `templates/workflows/` 9ファイルに対して4検査とも exit=0。範囲拡大で新たな違反は出ない。

- Unit (Jest): 931 tests, 0 failures（新規 5 件の Red → Green 確認済み）
- Integration (BATS): 310 tests, 0 failures
- `npm run workflow:sync:check` / `actionlint` / lint / format / shellcheck: すべて pass

## レビュー対応（54132bd）

Codex が偽陽性を2件指摘した。**検査が CI をブロックするようになった以上、偽陽性は正当な PR を止める**ため修正した。

| 指摘 | 内容 |
| --- | --- |
| `gh` の `-R` / `--repo=` 形式を拒否 | `gh` は `-R, --repo [HOST/]OWNER/REPO` を受け付ける。`--repo` + 空白しか認めておらず、正しく書かれた checkout 無しジョブが Workflow Lint を落としていた |
| `concurrency group` が `sha` / `run_id` を含む場合も自己キャンセル扱い | group に `github.sha` / `github.run_id` が入ると、自分が起こす push は別グループに属するため自分自身をキャンセルできない。この構成を拒否すると正当な publish ワークフローが通らない |

偽陽性を消したうえで、**実バグ4件を引き続き検出できることを再実証**した（config の資格情報・gh context・配布テンプレート、intent-gate-android の自己キャンセル、いずれも修正前の実ファイルで exit=1）。

あわせてテストが file-length ゲート(500行)に達したため、共有ヘルパーを `test/helpers/workflow-guards.js` へ切り出し、`gh` 関連の検査を `test/repo-maintenance-gh-guards.test.js` へ分けた。ゲートの回避（`.filelengthignore` への追加）はしていない。

## Risk

- 検査が CI をブロックするようになる。現行のワークフローとテンプレートはすべて pass 済みなので、既存の PR を止めることはない。
- Workflow Lint ジョブは `needs.changes.outputs.workflows == 'true'` が条件。検査スクリプト自体（`script/lib/repo_maintenance_checks.sh`）のみを変更する PR ではこのジョブは走らないが、検査の挙動は Jest 側の 30 件で固定されており常時実行される。
- `workflow_files()` は `find` ベースのため、ワークフローが存在しないリポジトリでも空を返して正常終了する（下流リポジトリでの `repo-maintenance` 実行を壊さない）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added contract and integration tests verifying workflow guard validation in CI.

* **Chores**
  * Integrated repository maintenance checks into CI workflow validation.
  * Extended workflow scanning to include reusable and distributed template directories.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
