### PR TITLE
fix(script): gh 検査が行継続の先にある --repo を見落とす誤検知を修正する

### DIFF
--- a/script/lib/repo_maintenance_checks.sh
+++ b/script/lib/repo_maintenance_checks.sh
@@ -183,22 +183,39 @@ check_gh_repo_context() {
     [[ -n "$workflow" ]] || continue
 
     # ジョブ単位で判定する。あるジョブの checkout や GH_REPO は別ジョブの gh を設定しない。
-    # --repo は同じコマンド行にある場合だけ有効とみなす。
+    # 行継続は 1 つの論理行に結合してから見る。--repo が継続行にある書き方は普通で、
+    # 同一行しか見ないと正常動作しているワークフローを誤検知する。
     if ! awk '
       function flush() {
         if (in_job && bad_cmd && !has_checkout && !has_gh_repo) bad = 1
         bad_cmd = 0; has_checkout = 0; has_gh_repo = 0
       }
-      { line = $0; sub(/^[[:space:]]*#.*$/, "", line) }
-      /^jobs:[[:space:]]*$/ { in_jobs = 1; next }
-      in_jobs && /^  [A-Za-z0-9_-]+:/ { flush(); in_job = 1; next }
-      in_job && line ~ /actions\/checkout/ { has_checkout = 1 }
-      in_job && line ~ /^[[:space:]]*GH_REPO:/ { has_gh_repo = 1 }
-      in_job && line ~ /(^|[^A-Za-z0-9_-])gh[[:space:]]+((label|issue|release|run|workflow)|pr[[:space:]]+(create|list|status))([^A-Za-z0-9_-]|$)/ {
-        # gh は -R / --repo= も受け付ける。落とすと正当なワークフローを止める。
-        if (line !~ /(--repo[[:space:]=]|-R[[:space:]])/) bad_cmd = 1
+      function eval_line(l) {
+        if (!in_job) return
+        if (l ~ /actions\/checkout/) has_checkout = 1
+        if (l ~ /^[[:space:]]*GH_REPO:/) has_gh_repo = 1
+        if (l ~ /(^|[^A-Za-z0-9_-])gh[[:space:]]+((label|issue|release|run|workflow)|pr[[:space:]]+(create|list|status))([^A-Za-z0-9_-]|$)/) {
+          # gh は -R / --repo= も受け付ける。落とすと正当なワークフローを止める。
+          if (l !~ /(--repo[[:space:]=]|-R[[:space:]])/) bad_cmd = 1
+        }
       }
-      END { flush(); exit bad ? 1 : 0 }
+      { line = $0; sub(/^[[:space:]]*#.*$/, "", line) }
+      pending == "" && /^jobs:[[:space:]]*$/ { in_jobs = 1; next }
+      pending == "" && in_jobs && /^  [A-Za-z0-9_-]+:/ { flush(); in_job = 1; next }
+      {
+        if (pending != "") { line = pending " " line; pending = "" }
+        if (line ~ /\\[[:space:]]*$/) {
+          sub(/\\[[:space:]]*$/, "", line)
+          pending = line
+          next
+        }
+        eval_line(line)
+      }
+      END {
+        if (pending != "") eval_line(pending)
+        flush()
+        exit bad ? 1 : 0
+      }
     ' "$workflow"; then
       output::warning "$(basename "$workflow"): gh has no repository to resolve without a checkout"
       echo "Add the repository to the step environment:"

--- a/test/repo-maintenance-gh-guards.test.js
+++ b/test/repo-maintenance-gh-guards.test.js
@@ -111,6 +111,47 @@ describe('check_gh_repo_context', () => {
     },
   );
 
+  // シェルの行継続の先にある --repo も同じコマンドの一部。
+  // keito4/calendar_alerm の release-please.yml が実際にこの書き方で、
+  // 誤検知すると正常動作しているワークフローを CI が拒否する。
+  test('accepts a repository flag on a shell line continuation', () => {
+    const workflow = [
+      'name: Release Please',
+      'jobs:',
+      '  trigger-cd:',
+      '    steps:',
+      '      - name: Trigger CD workflow',
+      '        run: |',
+      '          gh workflow run cd.yml \\',
+      '            --repo "$GITHUB_REPOSITORY" \\',
+      '            --field "tag=$TAG_NAME"',
+      '',
+    ].join('\n');
+
+    const result = runCheck(FLAG, { 'release-please.yml': workflow });
+
+    expect(result.status).toBe(0);
+  });
+
+  // 継続行があっても、リポジトリ指定が無ければ検出する。
+  test('still flags a continued command that never names a repository', () => {
+    const workflow = [
+      'name: Release Please',
+      'jobs:',
+      '  trigger-cd:',
+      '    steps:',
+      '      - name: Trigger CD workflow',
+      '        run: |',
+      '          gh workflow run cd.yml \\',
+      '            --field "tag=$TAG_NAME"',
+      '',
+    ].join('\n');
+
+    const result = runCheck(FLAG, { 'release-please.yml': workflow });
+
+    expect(result.status).not.toBe(0);
+  });
+
   test('ignores gh subcommands that take a pull request URL', () => {
     const result = runCheck(FLAG, {
       'dependabot-auto-merge.yml': ghWorkflow({ command: 'gh pr edit "$PR_URL" --add-label "x"' }),


### PR DESCRIPTION
Closes #1072

## Why

`check_gh_repo_context` は `gh` コマンドと同じ**行**にある `--repo` しか見ていなかったため、シェルの行継続で書かれた正常なワークフローを誤検知する。

keito4/calendar_alerm の `release-please.yml` が実際にこの書き方:

```yaml
run: |
  gh workflow run cd.yml \
    --repo "$GITHUB_REPOSITORY" \
    --field "tag=$TAG_NAME"
```

当該ワークフローの直近6実行はすべて success で動作に問題はない。

[PR #1071](https://github.com/keito4/config/pull/1071) でこの検査は `ci.yml` の Workflow Lint から実行され **CI をブロックする**ようになったため、この誤検知は正常動作しているリポジトリの PR を止める。

**複数リポジトリの実ワークフローに対して検査を走らせて発見した。** config 内だけでは見つからなかった。

## What

行継続（末尾の `\`）を 1 つの論理行へ結合してから判定する。

## How to test

**実リポジトリ4件**（calendar_alerm / effectuation / intent-gate-android / ohana）の全ワークフローに対して4検査を実行:

```
修正前: ⚠ release-please.yml: gh has no repository to resolve without a checkout
修正後: 4リポジトリとも違反なし
```

**真陽性の維持**（修正前の実ファイル4件、いずれも exit=1）:

| 対象 | 検査 |
| --- | --- |
| config `claude-code-review.yml` (8e46fd7) | 資格情報 |
| intent-gate-android `ci.yml` (#60 マージ前) | 自己キャンセル |
| config `dependabot-auto-merge.yml` (546573b) | gh context |
| config `templates/workflows/claude-health-check.yml` (546573b) | gh context（配布テンプレート） |

- Unit (Jest): 937 tests, 0 failures（新規 2 件の Red → Green 確認済み）
- lint / format / shellcheck: すべて pass

## Risk

- 判定が緩む方向の変更のため、既存の検出が失われないことを上表で確認している。
- 継続行の結合は `check_gh_repo_context` のみ。他の3検査は YAML キーや `on:` ブロックを見ており行継続の影響を受けない。

🤖 Generated with [Claude Code](https://claude.com/claude-code)