### PR TITLE
feat(ci): ワークフロー検査をリポジトリ横断で実行できるようにする

### DIFF
--- a/.github/workflows/fleet-workflow-guards.yml
+++ b/.github/workflows/fleet-workflow-guards.yml
@@ -1,0 +1,55 @@
+# Fleet Workflow Guards
+#
+# repo-maintenance のワークフロー検査を、直近いじったリポジトリ全体に対して実行する。
+# 検査は bash と awk だけで動き、対象リポジトリのワークフロー YAML を読むだけなので、
+# 各リポジトリへスクリプトを配布せずここから一括で走らせられる。検査を直せば次回の
+# 実行から全リポジトリへ反映される。
+#
+# 走査は読み取りのみ。対象リポジトリへ Issue や PR は作らない。
+name: Fleet Workflow Guards
+
+on:
+  schedule:
+    - cron: '0 22 * * 0' # 毎週月曜 07:00 JST
+  workflow_dispatch:
+    inputs:
+      days:
+        description: '対象とする最終 push からの日数'
+        required: false
+        default: '90'
+      repos:
+        description: '走査するリポジトリ名（空白区切り）。空なら自動検出'
+        required: false
+        default: ''
+
+permissions: {}
+
+concurrency:
+  group: ${{ github.workflow }}
+  cancel-in-progress: false
+
+jobs:
+  scan:
+    name: Scan repositories
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    permissions:
+      contents: read
+    steps:
+      - name: Checkout config
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          fetch-depth: 1
+
+      # 他リポジトリを読むため PAT が要る。GITHUB_TOKEN は自リポジトリしか見えない。
+      - name: Run workflow guards across repositories
+        env:
+          GH_TOKEN: ${{ secrets.CLAUDE_PAT }}
+          FLEET_DAYS: ${{ inputs.days || '90' }}
+          FLEET_REPOS: ${{ inputs.repos || '' }}
+        run: |
+          args=(--days "$FLEET_DAYS")
+          if [ -n "$FLEET_REPOS" ]; then
+            args+=(--repos "$FLEET_REPOS")
+          fi
+          script/fleet-workflow-guards.sh "${args[@]}"

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -39,24 +39,24 @@ Development infrastructure template repository providing DevContainer images, CI
 
 | Directory            | Purpose                                                     |
 | -------------------- | ----------------------------------------------------------- |
+| `.claude-plugin/`    | Claude Code LSP plugin configuration                        |
 | `.claude/agents/`    | Claude Code specialized agents                              |
 | `.claude/commands/`  | Claude Code slash commands                                  |
 | `.claude/hooks/`     | Pre/post hook scripts for quality enforcement               |
 | `.claude/plugins/`   | Claude Code plugin configuration                            |
 | `.claude/rules/`     | Claude Code rules for development standards                 |
 | `.claude/skills/`    | Claude Code skill definitions                               |
-| `.claude-plugin/`    | Claude Code LSP plugin configuration                        |
 | `.codex/`            | Codex AI agent configuration                                |
 | `.context/`          | Shared intermediate artifacts (complexity reports etc.)     |
 | `.cursor/`           | Cursor editor settings                                      |
 | `.devcontainer/`     | DevContainer configuration and Dockerfile                   |
 | `.gemini/`           | Gemini AI agent configuration                               |
-| `.github/workflows/` | GitHub Actions CI/CD workflows (15 workflows)               |
+| `.github/workflows/` | GitHub Actions CI/CD workflows (16 workflows)               |
 | `.husky/`            | Git hooks (pre-commit, commit-msg)                          |
 | `.takt/`             | TAKT workflow automation for scheduled agent tasks          |
 | `.vscode/`           | VS Code workspace settings                                  |
 | `.zsh/`              | Zsh configuration (aliases, completions, functions, prompt) |
-| `automation/`        | Weekly/screenshot ingest adapters and threshold rules       |
+| `automation/`        | Weekly and screenshot ingest adapters and threshold rules   |
 | `brew/`              | Homebrew package management (Linux only)                    |
 | `credentials/`       | Credential templates and filtering documentation            |
 | `docs/`              | Documentation and ADRs                                      |
@@ -141,6 +141,7 @@ Development infrastructure template repository providing DevContainer images, CI
 | `coverage-report.yml`       | Coverage Report                      |
 | `dependabot-auto-merge.yml` | Dependabot Auto-merge                |
 | `docker-image.yml`          | Build and Release DevContainer Image |
+| `fleet-workflow-guards.yml` | Fleet Workflow Guards                |
 | `label-sync.yml`            | Label Sync                           |
 | `manual-release.yml`        | Manual Release                       |
 | `quality-gate-fallback.yml` | CI Fallback                          |

--- a/script/README.md
+++ b/script/README.md
@@ -12,6 +12,7 @@ This directory contains utility scripts for managing configuration, credentials,
 | `version.sh`                     | Semantic versioning                                      | Makefile               |
 | `update-agents-md.sh`            | AGENTS.md 自動生成セクション更新                         | repo-maintenance       |
 | `repo-maintenance.sh`            | Repository maintenance executable workflow               | `/repo-maintenance`    |
+| `fleet-workflow-guards.sh`       | Workflow guards across every recently pushed repository  | fleet-workflow-guards  |
 | `validate-takt-auth.sh`          | Fail fast on rejected Anthropic credentials              | scheduled-maintenance  |
 | `trust-claude-workspace.sh`      | Trust a workspace in `~/.claude.json` for headless runs  | scheduled-maintenance  |
 | `setup-ci.sh`                    | CI/CD workflow setup                                     | `/setup-ci`            |
@@ -194,6 +195,28 @@ The workflow guards (`--check-claude-action-credentials`, `--check-self-cancelli
 `--check-gh-repo-context`, `--check-artifact-retention`) scan `.github/workflows/`,
 `.github/workflows/templates/`, and `templates/workflows/`. `ci.yml` runs all four in its
 Workflow Lint job so regressions fail the pull request.
+
+### fleet-workflow-guards.sh
+
+Runs the repo-maintenance workflow guards across several repositories at once.
+The guards only read workflow YAML, so they run unchanged against any checkout;
+keeping them here means a fix to a guard reaches every repository on the next
+run without distributing this script downstream.
+
+The scan is read-only. It never opens issues or pull requests in the scanned
+repositories.
+
+**Usage**:
+
+```bash
+./script/fleet-workflow-guards.sh                       # 直近90日に push されたリポジトリ
+./script/fleet-workflow-guards.sh --days 30
+./script/fleet-workflow-guards.sh --repos "config ohana"
+```
+
+Requires `gh` authenticated with a token that can read the target repositories.
+`.github/workflows/fleet-workflow-guards.yml` runs it weekly with `CLAUDE_PAT`
+and writes the per-repository result to the job summary.
 
 ### setup-ci.sh
 

--- a/script/fleet-workflow-guards.sh
+++ b/script/fleet-workflow-guards.sh
@@ -59,6 +59,22 @@ while [[ $# -gt 0 ]]; do
   esac
 done
 
+validate_inputs() {
+  local repo
+
+  if [[ ! "$DAYS" =~ ^[1-9][0-9]*$ ]]; then
+    # 検証しないと date が失敗して cutoff が空になり、全リポジトリへ黙って広がる。
+    output::fatal "invalid --days: $DAYS (expected a positive integer)"
+  fi
+
+  for repo in $REPOS; do
+    # rm -rf する先を作るので、作業ディレクトリの外を指す名前は受け付けない。
+    if [[ ! "$repo" =~ ^[A-Za-z0-9._-]+$ || "$repo" == .* ]]; then
+      output::fatal "invalid repository name: $repo"
+    fi
+  done
+}
+
 discover_repos() {
   local cutoff
   # 直近いじったリポジトリだけを対象にする。アーカイブ済みは除外する。
@@ -74,19 +90,31 @@ discover_repos() {
 # チェックアウトへ入れないときは 2 を返す。ここを握り潰すと、走査できていないのに
 # 「違反なし」と報告してしまう。
 scan_repo() {
-  local dest="$1" guard output
+  local dest="$1" guard output guard_status
 
   [[ -d "$dest" ]] || return 2
 
   for guard in "${GUARDS[@]}"; do
-    # 検査は違反があると非ゼロを返す。1 つ落ちても残りを続け、まとめて直せるようにする。
-    output="$(cd "$dest" || exit 1; "$SCRIPT_DIR/repo-maintenance.sh" "$guard" 2>&1)" || true
-    grep -E '^(⚠|.*\[1;33m)' <<<"$output" || true
+    # 終了ステータスを正とする。検査によっては output::warning ではなく素の
+    # "file: message" を出すため、⚠ 行だけを拾うと違反が消える。依存不足などの
+    # 違反以外の失敗も、黙って clean にせずここで拾う。
+    # 1 つ落ちても残りを続け、まとめて直せるようにする。
+    guard_status=0
+    output="$(cd "$dest" || exit 1; "$SCRIPT_DIR/repo-maintenance.sh" "$guard" 2>&1)" || guard_status=$?
+    [[ "$guard_status" -eq 0 ]] && continue
+
+    if [[ -n "$output" ]]; then
+      printf '%s\n' "$output"
+    else
+      printf '%s: failed with no output\n' "$guard"
+    fi
   done
 }
 
 main() {
   local repos repo dest violations=0 summary=""
+
+  validate_inputs
 
   if [[ -n "$REPOS" ]]; then
     read -r -a repos <<<"$REPOS"

--- a/script/fleet-workflow-guards.sh
+++ b/script/fleet-workflow-guards.sh
@@ -1,0 +1,147 @@
+#!/usr/bin/env bash
+# Run the repo-maintenance workflow guards across several repositories.
+#
+# The guards only read workflow YAML, so they run unchanged against any
+# repository checkout. Keeping them here means a fix to a guard reaches every
+# repository at once, without distributing this script downstream.
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=script/lib/output.sh
+source "$SCRIPT_DIR/lib/output.sh"
+
+OWNER="${FLEET_OWNER:-keito4}"
+DAYS="90"
+REPOS=""
+WORK_DIR="${FLEET_WORK_DIR:-${CONTEXT_DIR:-.context}/fleet}"
+
+GUARDS=(
+  --check-claude-action-credentials
+  --check-self-cancelling-workflows
+  --check-gh-repo-context
+  --check-artifact-retention
+)
+
+usage() {
+  cat <<'EOF'
+Usage: script/fleet-workflow-guards.sh [--owner OWNER] [--days N] [--repos "name ..."]
+
+Scans each repository with the repo-maintenance workflow guards and prints a
+markdown summary. Exits non-zero when any repository reports a violation.
+
+  --owner OWNER   GitHub owner to scan (default: keito4)
+  --days N        Only scan repositories pushed within N days (default: 90)
+  --repos "..."   Scan exactly these repository names, skipping discovery
+EOF
+}
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --owner)
+      OWNER="${2:?--owner requires a value}"
+      shift 2
+      ;;
+    --days)
+      DAYS="${2:?--days requires a value}"
+      shift 2
+      ;;
+    --repos)
+      REPOS="${2:?--repos requires a value}"
+      shift 2
+      ;;
+    -h | --help)
+      usage
+      exit 0
+      ;;
+    *)
+      output::fatal "Unknown argument: $1"
+      ;;
+  esac
+done
+
+discover_repos() {
+  local cutoff
+  # 直近いじったリポジトリだけを対象にする。アーカイブ済みは除外する。
+  cutoff="$(date -u -v-"${DAYS}"d +%Y-%m-%d 2>/dev/null || date -u -d "${DAYS} days ago" +%Y-%m-%d)"
+  gh repo list "$OWNER" \
+    --limit 200 \
+    --no-archived \
+    --json name,pushedAt \
+    --jq "[.[] | select(.pushedAt >= \"$cutoff\")] | .[].name"
+}
+
+# 1 リポジトリ分の違反行を stdout へ出す。違反が無ければ何も出さない。
+scan_repo() {
+  local repo="$1" dest="$2" guard findings=""
+
+  for guard in "${GUARDS[@]}"; do
+    # 1 つ落ちても残りの検査を続ける。まとめて直せるようにするため。
+    findings+="$(cd "$dest" && "$SCRIPT_DIR/repo-maintenance.sh" "$guard" 2>&1 | grep -E '^(⚠|.*\[1;33m)' || true)"$'\n'
+  done
+
+  printf '%s' "$findings" | sed '/^[[:space:]]*$/d'
+}
+
+main() {
+  local repos repo dest violations=0 summary=""
+
+  if [[ -n "$REPOS" ]]; then
+    read -r -a repos <<<"$REPOS"
+  else
+    mapfile -t repos < <(discover_repos)
+  fi
+
+  if [[ "${#repos[@]}" -eq 0 ]]; then
+    output::warning "No repositories to scan"
+    return 0
+  fi
+
+  mkdir -p "$WORK_DIR"
+  summary+="## Workflow guard scan"$'\n\n'
+  summary+="| Repository | Result |"$'\n'
+  summary+="| --- | --- |"$'\n'
+
+  for repo in "${repos[@]}"; do
+    [[ -n "$repo" ]] || continue
+    dest="$WORK_DIR/$repo"
+    rm -rf "$dest"
+
+    if ! gh repo clone "$OWNER/$repo" "$dest" -- --depth 1 --no-tags >/dev/null 2>&1; then
+      output::warning "$repo: clone failed; skipped"
+      summary+="| \`$repo\` | ⚠️ clone failed |"$'\n'
+      continue
+    fi
+
+    local findings
+    findings="$(scan_repo "$repo" "$dest")"
+
+    if [[ -n "$findings" ]]; then
+      violations=$((violations + 1))
+      output::warning "$repo"
+      printf '%s\n' "$findings"
+      summary+="| \`$repo\` | ❌ $(printf '%s' "$findings" | grep -c . ) violation(s) |"$'\n'
+      while IFS= read -r line; do
+        [[ -n "$line" ]] || continue
+        summary+="| | $(printf '%s' "$line" | sed 's/\x1b\[[0-9;]*m//g; s/^[[:space:]]*⚠[[:space:]]*//') |"$'\n'
+      done <<<"$findings"
+    else
+      output::success "$repo"
+      summary+="| \`$repo\` | ✅ clean |"$'\n'
+    fi
+  done
+
+  if [[ "$violations" -eq 0 ]]; then
+    summary+=$'\n'"No workflow guard violations across ${#repos[@]} repositories."$'\n'
+    output::success "No workflow guard violations across ${#repos[@]} repositories"
+  else
+    summary+=$'\n'"$violations of ${#repos[@]} repositories reported violations."$'\n'
+  fi
+
+  if [[ -n "${GITHUB_STEP_SUMMARY:-}" ]]; then
+    printf '%s' "$summary" >>"$GITHUB_STEP_SUMMARY"
+  fi
+
+  [[ "$violations" -eq 0 ]]
+}
+
+main

--- a/script/fleet-workflow-guards.sh
+++ b/script/fleet-workflow-guards.sh
@@ -71,15 +71,18 @@ discover_repos() {
 }
 
 # 1 リポジトリ分の違反行を stdout へ出す。違反が無ければ何も出さない。
+# チェックアウトへ入れないときは 2 を返す。ここを握り潰すと、走査できていないのに
+# 「違反なし」と報告してしまう。
 scan_repo() {
-  local repo="$1" dest="$2" guard findings=""
+  local dest="$1" guard output
+
+  [[ -d "$dest" ]] || return 2
 
   for guard in "${GUARDS[@]}"; do
-    # 1 つ落ちても残りの検査を続ける。まとめて直せるようにするため。
-    findings+="$(cd "$dest" && "$SCRIPT_DIR/repo-maintenance.sh" "$guard" 2>&1 | grep -E '^(⚠|.*\[1;33m)' || true)"$'\n'
+    # 検査は違反があると非ゼロを返す。1 つ落ちても残りを続け、まとめて直せるようにする。
+    output="$(cd "$dest" || exit 1; "$SCRIPT_DIR/repo-maintenance.sh" "$guard" 2>&1)" || true
+    grep -E '^(⚠|.*\[1;33m)' <<<"$output" || true
   done
-
-  printf '%s' "$findings" | sed '/^[[:space:]]*$/d'
 }
 
 main() {
@@ -112,8 +115,15 @@ main() {
       continue
     fi
 
-    local findings
-    findings="$(scan_repo "$repo" "$dest")"
+    local findings scan_status=0
+    findings="$(scan_repo "$dest")" || scan_status=$?
+
+    if [[ "$scan_status" -eq 2 ]]; then
+      violations=$((violations + 1))
+      output::warning "$repo: checkout missing; not scanned"
+      summary+="| \`$repo\` | ⚠️ not scanned |"$'\n'
+      continue
+    fi
 
     if [[ -n "$findings" ]]; then
       violations=$((violations + 1))

--- a/script/lib/repo_maintenance_checks.sh
+++ b/script/lib/repo_maintenance_checks.sh
@@ -183,22 +183,39 @@ check_gh_repo_context() {
     [[ -n "$workflow" ]] || continue
 
     # ジョブ単位で判定する。あるジョブの checkout や GH_REPO は別ジョブの gh を設定しない。
-    # --repo は同じコマンド行にある場合だけ有効とみなす。
+    # 行継続は 1 つの論理行に結合してから見る。--repo が継続行にある書き方は普通で、
+    # 同一行しか見ないと正常動作しているワークフローを誤検知する。
     if ! awk '
       function flush() {
         if (in_job && bad_cmd && !has_checkout && !has_gh_repo) bad = 1
         bad_cmd = 0; has_checkout = 0; has_gh_repo = 0
       }
-      { line = $0; sub(/^[[:space:]]*#.*$/, "", line) }
-      /^jobs:[[:space:]]*$/ { in_jobs = 1; next }
-      in_jobs && /^  [A-Za-z0-9_-]+:/ { flush(); in_job = 1; next }
-      in_job && line ~ /actions\/checkout/ { has_checkout = 1 }
-      in_job && line ~ /^[[:space:]]*GH_REPO:/ { has_gh_repo = 1 }
-      in_job && line ~ /(^|[^A-Za-z0-9_-])gh[[:space:]]+((label|issue|release|run|workflow)|pr[[:space:]]+(create|list|status))([^A-Za-z0-9_-]|$)/ {
-        # gh は -R / --repo= も受け付ける。落とすと正当なワークフローを止める。
-        if (line !~ /(--repo[[:space:]=]|-R[[:space:]])/) bad_cmd = 1
+      function eval_line(l) {
+        if (!in_job) return
+        if (l ~ /actions\/checkout/) has_checkout = 1
+        if (l ~ /^[[:space:]]*GH_REPO:/) has_gh_repo = 1
+        if (l ~ /(^|[^A-Za-z0-9_-])gh[[:space:]]+((label|issue|release|run|workflow)|pr[[:space:]]+(create|list|status))([^A-Za-z0-9_-]|$)/) {
+          # gh は -R / --repo= も受け付ける。落とすと正当なワークフローを止める。
+          if (l !~ /(--repo[[:space:]=]|-R[[:space:]])/) bad_cmd = 1
+        }
       }
-      END { flush(); exit bad ? 1 : 0 }
+      { line = $0; sub(/^[[:space:]]*#.*$/, "", line) }
+      pending == "" && /^jobs:[[:space:]]*$/ { in_jobs = 1; next }
+      pending == "" && in_jobs && /^  [A-Za-z0-9_-]+:/ { flush(); in_job = 1; next }
+      {
+        if (pending != "") { line = pending " " line; pending = "" }
+        if (line ~ /\\[[:space:]]*$/) {
+          sub(/\\[[:space:]]*$/, "", line)
+          pending = line
+          next
+        }
+        eval_line(line)
+      }
+      END {
+        if (pending != "") eval_line(pending)
+        flush()
+        exit bad ? 1 : 0
+      }
     ' "$workflow"; then
       output::warning "$(basename "$workflow"): gh has no repository to resolve without a checkout"
       echo "Add the repository to the step environment:"

--- a/test/fleet-workflow-guards.test.js
+++ b/test/fleet-workflow-guards.test.js
@@ -94,7 +94,47 @@ const GH_CONTEXT_VIOLATION = [
   '',
 ].join('\n');
 
+// check_artifact_retention は output::warning ではなく素の "file: message" を出す。
+// ⚠ 行だけを拾う実装だと、非ゼロ終了しているのに違反が消えて clean と報告される。
+const ARTIFACT_RETENTION_VIOLATION = [
+  'name: CI',
+  'jobs:',
+  '  build:',
+  '    steps:',
+  '      - uses: actions/checkout@abc123 # v7.0.1',
+  '      - uses: actions/upload-artifact@abc123 # v4',
+  '        with:',
+  '          name: coverage',
+  '',
+].join('\n');
+
 describe('script/fleet-workflow-guards.sh', () => {
+  test('detects a guard whose diagnostics are not warning-formatted', () => {
+    const result = runFleet(['--repos', 'alpha'], {
+      workflows: { alpha: { '.github/workflows/ci.yml': ARTIFACT_RETENTION_VIOLATION } },
+    });
+
+    expect(result.status).not.toBe(0);
+    expect(result.output).not.toContain('No workflow guard violations');
+    expect(result.output).toContain('alpha');
+  });
+
+  test('rejects a repository name that would escape the work directory', () => {
+    const result = runFleet(['--repos', '../escape'], { workflows: {} });
+
+    expect(result.status).not.toBe(0);
+    expect(result.output).toMatch(/invalid|不正/i);
+  });
+
+  test.each([['0'], ['-5'], ['abc']])('rejects an invalid --days value (%s)', (days) => {
+    const result = runFleet(['--days', days, '--repos', 'alpha'], {
+      workflows: { alpha: { '.github/workflows/ci.yml': CLEAN_WORKFLOW } },
+    });
+
+    expect(result.status).not.toBe(0);
+    expect(result.output).toMatch(/invalid|不正/i);
+  });
+
   test('reports no violations when every repository is clean', () => {
     const result = runFleet(['--repos', 'alpha bravo'], {
       workflows: {

--- a/test/fleet-workflow-guards.test.js
+++ b/test/fleet-workflow-guards.test.js
@@ -27,9 +27,12 @@ function buildGhStub({ discovered = [], workflows = {} }) {
   }
   lines.push('  exit 0', 'fi', 'if [ "$1" = "repo" ] && [ "$2" = "clone" ]; then');
   // gh repo clone <owner/name> <dest> -- <flags...> なので $3=owner/name, $4=dest
-  lines.push('  name="${3##*/}"', '  dest="$4"', '  mkdir -p "$dest"');
+  // 既知のリポジトリのときだけ dest を作る。未知のものは「clone は成功したが
+  // チェックアウトが無い」状況を再現する。
+  lines.push('  name="${3##*/}"', '  dest="$4"');
   for (const [name, files] of Object.entries(workflows)) {
     lines.push(`  if [ "$name" = "${name}" ]; then`);
+    lines.push('    mkdir -p "$dest"');
     for (const [file, content] of Object.entries(files)) {
       lines.push(`    mkdir -p "$dest/$(dirname "${file}")"`);
       lines.push(`    cat > "$dest/${file}" <<'WORKFLOW_EOF'\n${content}\nWORKFLOW_EOF`);
@@ -178,6 +181,15 @@ describe('script/fleet-workflow-guards.sh', () => {
     } finally {
       fs.rmSync(summaryPath, { force: true });
     }
+  });
+
+  // clone が成功したように見えてチェックアウトが無い場合、黙って clean と報告しては
+  // いけない。走査できなかったことが分かる形で残す必要がある。
+  test('does not report clean when the checkout is missing', () => {
+    const result = runFleet(['--repos', 'ghost'], { workflows: {} });
+
+    expect(result.output).not.toContain('No workflow guard violations');
+    expect(result.output).toContain('ghost');
   });
 
   test('treats a repository without workflows as clean instead of erroring', () => {

--- a/test/fleet-workflow-guards.test.js
+++ b/test/fleet-workflow-guards.test.js
@@ -1,0 +1,208 @@
+const fs = require('fs');
+const path = require('path');
+const { execFileSync } = require('child_process');
+
+const repoPath = path.resolve(__dirname, '..');
+const inheritedGitEnvKeys = ['GIT_DIR', 'GIT_WORK_TREE', 'GIT_INDEX_FILE', 'GIT_PREFIX'];
+
+function cleanGitEnv(extra = {}) {
+  const env = { ...process.env, ...extra };
+  for (const key of inheritedGitEnvKeys) {
+    delete env[key];
+  }
+  return env;
+}
+
+/**
+ * gh のスタブを作る。repo list は discovered を返し、repo clone は fixtures を配置する。
+ * @param {object} options - スタブの内容。
+ * @param {string[]} options.discovered - `gh repo list` が返すリポジトリ名。
+ * @param {Record<string, Record<string, string>>} options.workflows - リポジトリ名ごとの配置内容。
+ * @returns {string} gh スタブのシェルスクリプト。
+ */
+function buildGhStub({ discovered = [], workflows = {} }) {
+  const lines = ['#!/usr/bin/env bash', 'if [ "$1" = "repo" ] && [ "$2" = "list" ]; then'];
+  for (const name of discovered) {
+    lines.push(`  echo '${name}'`);
+  }
+  lines.push('  exit 0', 'fi', 'if [ "$1" = "repo" ] && [ "$2" = "clone" ]; then');
+  // gh repo clone <owner/name> <dest> -- <flags...> なので $3=owner/name, $4=dest
+  lines.push('  name="${3##*/}"', '  dest="$4"', '  mkdir -p "$dest"');
+  for (const [name, files] of Object.entries(workflows)) {
+    lines.push(`  if [ "$name" = "${name}" ]; then`);
+    for (const [file, content] of Object.entries(files)) {
+      lines.push(`    mkdir -p "$dest/$(dirname "${file}")"`);
+      lines.push(`    cat > "$dest/${file}" <<'WORKFLOW_EOF'\n${content}\nWORKFLOW_EOF`);
+    }
+    lines.push('  fi');
+  }
+  lines.push('  exit 0', 'fi', 'exit 1', '');
+  return lines.join('\n');
+}
+
+function runFleet(args, { discovered = [], workflows = {}, env = {} } = {}) {
+  const contextDir = path.join(repoPath, '.context');
+  fs.mkdirSync(contextDir, { recursive: true });
+  const tempRoot = fs.mkdtempSync(path.join(contextDir, 'fleet-guards-test-'));
+
+  try {
+    const binDir = path.join(tempRoot, 'bin');
+    fs.mkdirSync(binDir, { recursive: true });
+    const ghPath = path.join(binDir, 'gh');
+    fs.writeFileSync(ghPath, buildGhStub({ discovered, workflows }));
+    fs.chmodSync(ghPath, 0o755);
+
+    const scriptPath = path.join(repoPath, 'script', 'fleet-workflow-guards.sh');
+    try {
+      const stdout = execFileSync('bash', [scriptPath, ...args], {
+        cwd: repoPath,
+        env: cleanGitEnv({
+          ...env,
+          PATH: `${binDir}:${process.env.PATH}`,
+          FLEET_WORK_DIR: path.join(tempRoot, 'work'),
+        }),
+        encoding: 'utf8',
+      });
+      return { status: 0, output: stdout };
+    } catch (error) {
+      return { status: error.status, output: `${error.stdout || ''}${error.stderr || ''}` };
+    }
+  } finally {
+    fs.rmSync(tempRoot, { recursive: true, force: true });
+  }
+}
+
+const CLEAN_WORKFLOW = [
+  'name: CI',
+  'jobs:',
+  '  build:',
+  '    steps:',
+  '      - uses: actions/checkout@abc123 # v7.0.1',
+  '',
+].join('\n');
+
+// keito4/config PR #1066 と同じ欠陥。checkout せずに gh label create を呼ぶ。
+const GH_CONTEXT_VIOLATION = [
+  'name: Dependabot Auto-merge',
+  'jobs:',
+  '  dependabot-auto:',
+  '    steps:',
+  '      - run: gh label create "dependabot-minor" --force',
+  '',
+].join('\n');
+
+describe('script/fleet-workflow-guards.sh', () => {
+  test('reports no violations when every repository is clean', () => {
+    const result = runFleet(['--repos', 'alpha bravo'], {
+      workflows: {
+        alpha: { '.github/workflows/ci.yml': CLEAN_WORKFLOW },
+        bravo: { '.github/workflows/ci.yml': CLEAN_WORKFLOW },
+      },
+    });
+
+    expect(result.status).toBe(0);
+    expect(result.output).toContain('alpha');
+    expect(result.output).toContain('bravo');
+    expect(result.output).toContain('No workflow guard violations');
+  });
+
+  test('fails and names the offending repository and workflow', () => {
+    const result = runFleet(['--repos', 'alpha bravo'], {
+      workflows: {
+        alpha: { '.github/workflows/ci.yml': CLEAN_WORKFLOW },
+        bravo: { '.github/workflows/dependabot-auto-merge.yml': GH_CONTEXT_VIOLATION },
+      },
+    });
+
+    expect(result.status).not.toBe(0);
+    expect(result.output).toContain('bravo');
+    expect(result.output).toContain('dependabot-auto-merge.yml');
+  });
+
+  // 1 リポジトリの違反で走査を打ち切ると、残りの実態が分からないまま直すことになる。
+  test('scans every repository even after one fails', () => {
+    const result = runFleet(['--repos', 'alpha bravo charlie'], {
+      workflows: {
+        alpha: { '.github/workflows/dependabot-auto-merge.yml': GH_CONTEXT_VIOLATION },
+        bravo: { '.github/workflows/ci.yml': CLEAN_WORKFLOW },
+        charlie: { '.github/workflows/dependabot-auto-merge.yml': GH_CONTEXT_VIOLATION },
+      },
+    });
+
+    expect(result.status).not.toBe(0);
+    expect(result.output).toContain('alpha');
+    expect(result.output).toContain('bravo');
+    expect(result.output).toContain('charlie');
+  });
+
+  test('discovers repositories from the owner when --repos is omitted', () => {
+    const result = runFleet([], {
+      discovered: ['alpha', 'bravo'],
+      workflows: {
+        alpha: { '.github/workflows/ci.yml': CLEAN_WORKFLOW },
+        bravo: { '.github/workflows/ci.yml': CLEAN_WORKFLOW },
+      },
+    });
+
+    expect(result.status).toBe(0);
+    expect(result.output).toContain('alpha');
+    expect(result.output).toContain('bravo');
+  });
+
+  // config が配る templates/workflows/ も検査対象。下流に配られた欠陥を取りこぼさない。
+  test('checks distributed templates in the scanned repository', () => {
+    const result = runFleet(['--repos', 'alpha'], {
+      workflows: {
+        alpha: { 'templates/workflows/claude-health-check.yml': GH_CONTEXT_VIOLATION },
+      },
+    });
+
+    expect(result.status).not.toBe(0);
+    expect(result.output).toContain('claude-health-check.yml');
+  });
+
+  test('writes a markdown summary when GITHUB_STEP_SUMMARY is set', () => {
+    const contextDir = path.join(repoPath, '.context');
+    fs.mkdirSync(contextDir, { recursive: true });
+    const summaryPath = path.join(contextDir, `fleet-summary-${process.pid}.md`);
+
+    try {
+      runFleet(['--repos', 'alpha'], {
+        workflows: { alpha: { '.github/workflows/ci.yml': CLEAN_WORKFLOW } },
+        env: { GITHUB_STEP_SUMMARY: summaryPath },
+      });
+
+      const summary = fs.readFileSync(summaryPath, 'utf8');
+      expect(summary).toContain('Workflow guard');
+      expect(summary).toContain('alpha');
+    } finally {
+      fs.rmSync(summaryPath, { force: true });
+    }
+  });
+
+  test('treats a repository without workflows as clean instead of erroring', () => {
+    const result = runFleet(['--repos', 'empty'], { workflows: { empty: {} } });
+
+    expect(result.status).toBe(0);
+    expect(result.output).toContain('empty');
+  });
+});
+
+describe('Fleet workflow guards CI contract', () => {
+  function readFile(relativePath) {
+    return fs.readFileSync(path.join(repoPath, relativePath), 'utf8');
+  }
+
+  test('the workflow delegates to the executable script', () => {
+    const workflow = readFile('.github/workflows/fleet-workflow-guards.yml');
+
+    expect(workflow).toContain('script/fleet-workflow-guards.sh');
+    expect(workflow).toContain('workflow_dispatch:');
+    expect(workflow).toContain('schedule:');
+    // 他リポジトリを読むため PAT が要る。GITHUB_TOKEN は自リポジトリしか見えない。
+    expect(workflow).toContain('secrets.CLAUDE_PAT');
+    // 走査は読み取りのみ。他リポジトリへは書き込まない。
+    expect(workflow).not.toContain('gh issue create');
+    expect(workflow).not.toContain('gh pr create');
+  });
+});

--- a/test/integration/workflows.bats
+++ b/test/integration/workflows.bats
@@ -18,13 +18,13 @@ load ../test_helper/test_helper
   done
 }
 
-@test "root workflow count is consolidated to 15 files" {
+@test "root workflow count is consolidated to 16 files" {
   local workflows_dir="${REPO_ROOT}/.github/workflows"
   local count
 
   count=$(find "$workflows_dir" -maxdepth 1 -type f \( -name '*.yml' -o -name '*.yaml' \) | wc -l | tr -d ' ')
 
-  [ "$count" -eq 15 ]
+  [ "$count" -eq 16 ]
   [ ! -e "$workflows_dir/rebuild-docker-cache.yml" ]
 }
 

--- a/test/repo-maintenance-gh-guards.test.js
+++ b/test/repo-maintenance-gh-guards.test.js
@@ -111,6 +111,47 @@ describe('check_gh_repo_context', () => {
     },
   );
 
+  // シェルの行継続の先にある --repo も同じコマンドの一部。
+  // keito4/calendar_alerm の release-please.yml が実際にこの書き方で、
+  // 誤検知すると正常動作しているワークフローを CI が拒否する。
+  test('accepts a repository flag on a shell line continuation', () => {
+    const workflow = [
+      'name: Release Please',
+      'jobs:',
+      '  trigger-cd:',
+      '    steps:',
+      '      - name: Trigger CD workflow',
+      '        run: |',
+      '          gh workflow run cd.yml \\',
+      '            --repo "$GITHUB_REPOSITORY" \\',
+      '            --field "tag=$TAG_NAME"',
+      '',
+    ].join('\n');
+
+    const result = runCheck(FLAG, { 'release-please.yml': workflow });
+
+    expect(result.status).toBe(0);
+  });
+
+  // 継続行があっても、リポジトリ指定が無ければ検出する。
+  test('still flags a continued command that never names a repository', () => {
+    const workflow = [
+      'name: Release Please',
+      'jobs:',
+      '  trigger-cd:',
+      '    steps:',
+      '      - name: Trigger CD workflow',
+      '        run: |',
+      '          gh workflow run cd.yml \\',
+      '            --field "tag=$TAG_NAME"',
+      '',
+    ].join('\n');
+
+    const result = runCheck(FLAG, { 'release-please.yml': workflow });
+
+    expect(result.status).not.toBe(0);
+  });
+
   test('ignores gh subcommands that take a pull request URL', () => {
     const result = runCheck(FLAG, {
       'dependabot-auto-merge.yml': ghWorkflow({ command: 'gh pr edit "$PR_URL" --add-label "x"' }),


### PR DESCRIPTION
Closes #1074

> [!NOTE]
> [PR #1073](https://github.com/keito4/config/pull/1073) の commit を含みます。行継続の誤検知を直さないまま横断実行すると正常な calendar_alerm が違反として出るため、この PR は #1073 の上に積んでいます。base はフル CI を通すため main にしています。#1073 を先にマージすれば、この PR の差分は fleet 分だけに縮みます。どちらの順でマージしても問題ありません。

## Why

ワークフロー検査は config 内でしか動かない。下流リポジトリには `script/repo-maintenance.sh` も `scheduled-maintenance.yml` も配布されておらず、他のリポジトリで同種の不具合が起きても検知できない。

実際、検査を実リポジトリへ向けたところ **config 内では見つからなかった誤検知**（[#1072](https://github.com/keito4/config/issues/1072)）が判明した。横断実行は再発防止だけでなく検査自体の品質にも効く。

## What

検査は bash と awk だけで動き、対象リポジトリのワークフロー YAML を読むだけなので、**各リポジトリへスクリプトを配布せず config から一括で走らせられる**。検査を直せば次回の実行から全リポジトリへ反映される。

| 追加 | 内容 |
| --- | --- |
| `script/fleet-workflow-guards.sh` | 直近 push されたリポジトリを自動検出し、4検査を実行して結果を集計する |
| `.github/workflows/fleet-workflow-guards.yml` | 週次（月曜 07:00 JST）+ 手動実行。`days` / `repos` を指定可能 |

### 方針

- **走査は読み取りのみ**。対象リポジトリへ Issue や PR は作らない（テストで固定）
- **1リポジトリで違反が出ても走査を打ち切らない**。全違反を集計してから落ちる。1件直すたびに次が出る往復を避けるため
- 他リポジトリを読むため `GITHUB_TOKEN` ではなく `CLAUDE_PAT` を使う（`GITHUB_TOKEN` は自リポジトリしか見えない）
- 配布方式（各リポジトリへ script を同期）ではなく中央集約にしたのは、同期対象ファイルが増えず、検査の修正が各リポジトリでの同期 PR マージを待たずに反映されるため。sync 対象外の private-config / agentdeck-streamdeck-plugin なども自動でカバーできる

## How to test

**実リポジトリ13件に対して本番同等で実行**:

```
✓ config              ✓ intent-gate-android   ✓ private-config
✓ Claude-Usage-Tracker ✓ calendar_alerm       ✓ agentdeck-streamdeck-plugin
✓ personal-dashboard  ✓ ohana                 ✓ extensions
✓ effectuation        ✓ arduino-playground    ✓ notion-mac-task-widget
✓ scale_out
✓ No workflow guard violations across 13 repositories
exit=0
```

`raycast-extensions` は最終 push が 90 日超のため対象外（仕様どおり）。

**検出側**: 行継続の修正前に同じ仕組みで走らせたところ、calendar_alerm の `release-please.yml` を名指しで報告した（それが #1072 の発見経緯）。

- Unit (Jest): 945 tests, 0 failures（新規 8 件の Red → Green 確認済み）
- Integration (BATS): 310 tests, 0 failures（ワークフロー数の固定値を 15→16 へ更新）
- actionlint / lint / format / shellcheck: すべて pass

## レビュー対応

CodeRabbit / Codex / CI の shellcheck から計 5 件の指摘。**いずれも横断走査が黙って「違反なし」を報告する、または想定外の範囲へ広がる**もので、すべて修正した。

| 指摘 | 内容 |
| --- | --- |
| **違反判定を ⚠ 行の grep で行っていた** | `check_artifact_retention` は `output::warning` ではなく素の `file: message` を出すため、**非ゼロ終了しているのに違反が消えて clean と報告**されていた（再現確認済み）。依存不足など違反以外の失敗も同様に握り潰していた → **終了ステータスを正とする** |
| SC2015 (`A && B \|\| C`) | `cd` の失敗を `\|\| true` が握り潰し「違反なし」と報告。実際この構造でテストが空振りした → チェックアウトが無い場合は violation として集計し `not scanned` と残す |
| `--days` 未検証 | `date` が失敗すると `cutoff` が空になり jq の比較が常に真 → **全リポジトリへ黙って広がる** → 正の整数のみ受け付ける |
| リポジトリ名未検証 | `../..` のような名前は `dest` が作業ディレクトリの外を指し、**`rm -rf` がそこへ及ぶ** → 英数字とドット・ハイフン・アンダースコアのみ受け付ける |

テストのスタブも「空リポジトリ」と「走査できなかった」を区別できるよう直した。

Unit 951 / Integration 310 / lint / format / shellcheck / actionlint すべて pass。実リポジトリ 5 件での再実行も clean。

## Risk

- **`CLAUDE_PAT` が必要**。未設定・失効時は clone が失敗し、該当リポジトリは `⚠️ clone failed` として記録され走査は継続する（全体は落ちない）。
- 週次実行で違反が見つかると **config のワークフローが赤くなる**。これは意図した挙動（「サマリを出して失敗させる」方針）。現時点で13リポジトリすべて clean のため、導入直後に赤くなることはない。
- 対象リポジトリを**自動検出**するため、新しいリポジトリは自動で走査対象に入る。手動実行時は `repos` 入力で明示指定もできる。
- リポジトリは `--depth 1 --no-tags` の浅いクローンで、ランナー上の一時領域にのみ展開する。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added scheduled and manually triggered scanning of workflow configurations across multiple repositories.
  * Added options to limit scans by repository and recency, with aggregated results and Markdown summaries.
* **Bug Fixes**
  * Improved detection of repository context in multi-line workflow commands.
* **Documentation**
  * Documented the new workflow guard scanner and updated workflow inventory details.
* **Tests**
  * Added comprehensive coverage for scanning, reporting, discovery, failures, and multi-line commands.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
