### PR TITLE
fix(gitignore): install_skills.sh が生成する .gemini/skills/ を無視する

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -83,6 +83,7 @@ report.log
 .codex/skills/
 .codex/prompts/
 .cursor/skills/
+.gemini/skills/
 .github/skills/
 
 # Codex profile snapshots (codex -p <name> reads $CODEX_HOME/<name>.config.toml)


### PR DESCRIPTION
## Why

`script/lib/install_skills.sh:236` は `.codex/skills` / `.cursor/skills` / `.gemini/skills` の 3 ディレクトリに `.agents/skills/` への symlink を張るが、`.gitignore` は前 2 つしか無視していない。このため `npx skills add` 系を実行した端末では `.gemini/skills/` が恒常的に untracked として残る。

実際に elu PC の checkout で発生しており、2026-08-05 に導入した repo-sync-check（各端末の checkout が origin/main に追随しているかを毎日確認する定期タスク）がこれを「未コミット変更」として毎回検知してしまう。

## What

`.gitignore` の Agent skills セクションに `.gemini/skills/` を 1 行追加する。

## How

既存の `.codex/skills/` / `.cursor/skills/` と同じ扱いに揃えただけ。追跡される正本は `skills.txt` と `skills-lock.json` のままで変わらない。

## Risk

低。無視対象は生成された symlink のみで、追跡中のファイルは無い（`git ls-files .gemini` は `.gemini/README.md` と `.gemini/settings.json` のみで、いずれも影響を受けない）。

Fixes #1076

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated project ignore settings to exclude Gemini skill files from version control.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->