### PR TITLE
fix(codex): config.toml を symlink 配備からマージ配備に変更

### DIFF
--- a/docs/adr/0022-codex-config-merge-deploy.md
+++ b/docs/adr/0022-codex-config-merge-deploy.md
@@ -1,0 +1,62 @@
+# ADR 0022: Codex config.toml のマージ配備（symlink 廃止）
+
+## Status
+
+Accepted
+
+## Context
+
+`import.sh` は `.codex/config.toml` を `~/.codex/config.toml` へシンボリックリンクで
+配備していた。しかし Codex / ChatGPT アプリは以下のような**端末固有の状態**を
+`$CODEX_HOME/config.toml` 自体に書き戻す:
+
+- `projects.*.trust_level`（ディレクトリ信頼の記録）
+- `marketplaces.*`（プラグインマーケットプレイスのローカルパス・更新時刻）
+- `plugins.*` の有効化状態
+- `node_repl` / `computer-use` など絶対パス入りの MCP サーバー定義
+- `notify` の通知クライアントパス
+
+この結果、git 追跡ファイルが**コミットもできず消すこともできない恒久的な dirty**
+になり、repo-sync-check（2026-08-05 導入）が「この端末にしか無い変更」として毎日
+通知し続けていた（狼少年化）。
+
+検討した選択肢:
+
+1. **Codex 側のローカル上書き機構を使う** — 調査の結果、自動読み込みされる
+   ローカル上書きファイルは存在しない。`-p` プロファイル
+   （`$CODEX_HOME/<name>.config.toml`）は明示指定が必要で、デスクトップアプリは
+   付与しない。`-c key=value` は CLI フラグのみ。さらにアプリが config.toml 自体へ
+   書き込む以上、追跡ファイルへの symlink はどのみち成立しない。
+2. **config.toml を生成物にし、ベース＋端末差分から組み立てる** — 採用。
+3. **repo-sync-check に既知の端末固有ファイルの除外リストを持たせる** — 対症療法。
+   dirty の根本原因が残り、本当に手当てが必要な変更の検知も鈍る。
+
+## Decision
+
+選択肢 2 を採用し、config.toml の配備を symlink から**深いマージによる実ファイル
+生成**に変える:
+
+- リポジトリの `.codex/config.toml` は**共有ベース**として追跡を維持する。
+- `~/.codex/config.toml` は **Codex が所有する実ファイル**とし、端末状態は
+  そこに蓄積させる（git からは不可視）。
+- `config::import_codex` は symlink せず `script/codex-config-merge.py`
+  （`uv run` / Python 3.11+ / tomli-w）で配備する。マージ規則は
+  「テーブルは再帰マージ、**ベースが定義するキーはベース優先**、ローカルにしか
+  無いキー（端末状態）は保持」。配備先が symlink の場合はリンク先の内容を
+  取り込んだうえで実ファイルへ自動移行する（既存端末の移行パス）。
+- `config::export_codex` は config.toml を対象外とする（端末状態のリポジトリへの
+  逆流防止）。共有設定の変更はリポジトリの `.codex/config.toml` を直接編集する。
+- `uv` が無い環境では、symlink の実ファイル化と新規シードのみ行い、マージは
+  警告してスキップする。
+
+## Consequences
+
+- 各端末の `git status` が clean を維持でき、repo-sync-check の通知は本当に
+  手当てが必要な変更だけになる。
+- 共有設定の更新は `import.sh` 実行時にベース優先で各端末へ伝播する。
+  ベースから**キーを削除**しても端末側には残る（マージは削除を伝播しない）点は
+  許容する。必要なら端末側で手動削除する。
+- 配備先ファイルは TOML 再シリアライズのためコメントを持たない。コメントの
+  正本はリポジトリ側ベースにある。
+- `codex features enable` などアプリ・CLI による設定変更は端末ローカルに
+  閉じる。全端末へ配りたい設定はベースへの手動反映が必要になる。

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -26,6 +26,7 @@
 | [0019](0019-downstream-template-auto-sync.md)                   | Downstream Template Auto-Sync                                     | Accepted           |
 | [0020](0020-claude-skill-distribution-and-settings-boundary.md) | Claude スキルの配布形式と settings.json のホスト／downstream 境界 | Accepted           |
 | [0021](0021-screenshot-based-mobile-data-ingest.md)             | スマホ専用データのスクショ経由週次取り込み                        | Accepted           |
+| [0022](0022-codex-config-merge-deploy.md)                       | Codex config.toml のマージ配備（symlink 廃止）                    | Accepted           |
 
 ## ADR テンプレート
 

--- a/script/codex-config-merge.py
+++ b/script/codex-config-merge.py
@@ -1,0 +1,88 @@
+#!/usr/bin/env -S uv run --script --quiet
+# /// script
+# requires-python = ">=3.11"
+# dependencies = ["tomli-w>=1.0,<2"]
+# ///
+"""リポジトリの .codex/config.toml（共有ベース）を端末の config.toml へマージ配備する。
+
+Codex / ChatGPT アプリは projects.*.trust_level・marketplaces.*・プラグイン有効化
+状態・絶対パス入りの MCP サーバー定義などの端末固有状態を $CODEX_HOME/config.toml
+自体に書き戻す。そのため実体を git 追跡ファイルへの symlink にはできない。
+
+  - リポジトリ .codex/config.toml : 共有ベース（追跡・clean を維持）
+  - ~/.codex/config.toml          : Codex が所有する実ファイル（端末状態はここに残る）
+
+マージ規則: テーブルは再帰的にマージし、ベースが定義するキーはベースが勝つ。
+ローカルにしか無いキー（端末状態）はそのまま保持する。
+配備先が symlink の場合はリンク先の内容をローカル状態として取り込んだうえで
+実ファイルに置き換える（symlink 環境からの自動移行）。
+
+注意: 書き込みは TOML を再シリアライズするため、配備先ファイル内のコメントは
+残らない（ベースのコメントはリポジトリ側に正本がある）。
+
+Usage: codex-config-merge.py <base_toml> <target_toml>
+"""
+
+import os
+import sys
+import tomllib
+from pathlib import Path
+
+import tomli_w
+
+
+def deep_merge(local, base):
+    """base を local に重ねる。dict は再帰マージ、それ以外は base 優先。"""
+    if isinstance(local, dict) and isinstance(base, dict):
+        merged = dict(local)
+        for key, value in base.items():
+            merged[key] = deep_merge(local[key], value) if key in local else value
+        return merged
+    return base
+
+
+def main() -> int:
+    if len(sys.argv) != 3:
+        print(f"Usage: {Path(sys.argv[0]).name} <base_toml> <target_toml>", file=sys.stderr)
+        return 2
+
+    base_path = Path(sys.argv[1])
+    target_path = Path(sys.argv[2])
+
+    try:
+        base = tomllib.loads(base_path.read_text())
+    except (OSError, tomllib.TOMLDecodeError) as err:
+        print(f"⚠️  ベースを読めません: {base_path}: {err}", file=sys.stderr)
+        return 1
+
+    local = {}
+    if target_path.exists():
+        try:
+            local = tomllib.loads(target_path.read_text())
+        except tomllib.TOMLDecodeError as err:
+            # 壊れたローカルを黙って捨てると端末状態が消えるため、手当てを促して止める
+            print(f"⚠️  配備先の TOML が不正です（修正するまでマージ中断）: {target_path}: {err}", file=sys.stderr)
+            return 1
+
+    output = tomli_w.dumps(deep_merge(local, base))
+
+    was_symlink = target_path.is_symlink()
+    if not was_symlink and target_path.exists() and target_path.read_text() == output:
+        return 0
+
+    if was_symlink:
+        target_path.unlink()
+
+    tmp_path = target_path.with_suffix(".toml.tmp")
+    tmp_path.write_text(output)
+    os.replace(tmp_path, target_path)
+
+    if was_symlink:
+        print(f"🔀 symlink を実ファイルへ移行してマージ配備しました: {target_path}")
+    else:
+        print(f"🔀 ベースをマージ配備しました: {target_path}")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/script/lib/config.sh
+++ b/script/lib/config.sh
@@ -10,8 +10,15 @@ typeset -ga CONFIG_CLAUDE_SHARED_DIRS=(commands agents hooks)
 typeset -ga CONFIG_CLAUDE_PLUGIN_FILES=(config.json known_marketplaces.json)
 
 # Constants for Codex configuration
-typeset -ga CONFIG_CODEX_SHARED_FILES=(config.toml)
+# config.toml は含めない: Codex 自身が端末固有の状態（projects.*.trust_level,
+# marketplaces.*, プラグイン有効化, 絶対パス入り MCP 定義）を config.toml に
+# 書き戻すため、symlink 配備すると追跡ファイルが恒久的に dirty になる。
+# 代わりに config::deploy_codex_config でベースをローカル実ファイルへマージ配備する。
+typeset -ga CONFIG_CODEX_SHARED_FILES=()
 typeset -ga CONFIG_CODEX_SHARED_DIRS=(prompts rules)
+
+# このライブラリを起点にした script/ ディレクトリの絶対パス（sourced でも解決できる %x を使う）
+typeset -g CONFIG_SCRIPT_DIR="${${(%):-%x}:A:h:h}"
 
 # Constants for Cursor configuration
 typeset -ga CONFIG_CURSOR_SHARED_FILES=(mcp.json)
@@ -200,14 +207,55 @@ config::export_claude() {
     CONFIG_CLAUDE_PLUGIN_FILES
 }
 
-config::import_codex() {
-  config::_import_tool "Codex" \
-    "${1:?Source directory required}" \
-    "${2:-$HOME/.codex}" \
-    CONFIG_CODEX_SHARED_FILES \
-    CONFIG_CODEX_SHARED_DIRS
+# Codex の config.toml をベース→ローカルの深いマージで配備する
+# （ベース定義キーはベース優先、ローカルのみのキー＝端末状態は保持。
+#   配備先が symlink なら実ファイルへ自動移行する。詳細は script/codex-config-merge.py）
+config::deploy_codex_config() {
+  local base="${1:?Base config.toml required}"
+  local target="${2:?Target config.toml required}"
+  local merge_script="$CONFIG_SCRIPT_DIR/codex-config-merge.py"
+
+  if command -v uv >/dev/null 2>&1 && [[ -f "$merge_script" ]]; then
+    if uv run --script --quiet "$merge_script" "$base" "$target"; then
+      echo "✅ Deployed codex/config.toml (merge)"
+      return 0
+    fi
+    echo "⚠️  codex/config.toml のマージ配備に失敗しました" >&2
+    return 1
+  fi
+
+  # uv が無い環境のフォールバック（マージはしないが dirty の原因は残さない）
+  if [[ -L "$target" ]]; then
+    local content
+    content="$(cat "$target")"
+    rm "$target"
+    printf '%s' "$content" >"$target"
+    echo "⚠️  uv が無いためマージをスキップ（symlink は実ファイル化しました）: $target"
+  elif [[ ! -e "$target" ]]; then
+    cp "$base" "$target"
+    echo "✅ Seeded codex/config.toml (uv 無しのため単純コピー)"
+  else
+    echo "⚠️  uv が無いため codex/config.toml のマージをスキップしました"
+  fi
 }
 
+config::import_codex() {
+  local source_dir="${1:?Source directory required}"
+  local target_dir="${2:-$HOME/.codex}"
+
+  config::_import_tool "Codex" \
+    "$source_dir" \
+    "$target_dir" \
+    CONFIG_CODEX_SHARED_FILES \
+    CONFIG_CODEX_SHARED_DIRS
+
+  if [[ -f "$source_dir/config.toml" ]]; then
+    config::deploy_codex_config "$source_dir/config.toml" "$target_dir/config.toml"
+  fi
+}
+
+# 注意: config.toml は export しない（端末固有状態がリポジトリへ逆流するため）。
+# 共有設定を変えたいときはリポジトリの .codex/config.toml を直接編集する。
 config::export_codex() {
   config::_export_tool "Codex" \
     "${1:-$HOME/.codex}" \

--- a/script/lib/config.sh
+++ b/script/lib/config.sh
@@ -17,8 +17,13 @@ typeset -ga CONFIG_CLAUDE_PLUGIN_FILES=(config.json known_marketplaces.json)
 typeset -ga CONFIG_CODEX_SHARED_FILES=()
 typeset -ga CONFIG_CODEX_SHARED_DIRS=(prompts rules)
 
-# このライブラリを起点にした script/ ディレクトリの絶対パス（sourced でも解決できる %x を使う）
-typeset -g CONFIG_SCRIPT_DIR="${${(%):-%x}:A:h:h}"
+# このライブラリを起点にした script/ ディレクトリの絶対パス
+# （zsh からも bash(bats) からも source されるため両対応で解決する）
+if [[ -n "${ZSH_VERSION:-}" ]]; then
+  typeset -g CONFIG_SCRIPT_DIR="${${(%):-%x}:A:h:h}"
+else
+  CONFIG_SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+fi
 
 # Constants for Cursor configuration
 typeset -ga CONFIG_CURSOR_SHARED_FILES=(mcp.json)


### PR DESCRIPTION
## Why
Codex / ChatGPT アプリは `projects.*.trust_level`・`marketplaces.*`・プラグイン有効化状態・絶対パス入り MCP 定義などの**端末固有状態を `$CODEX_HOME/config.toml` 自体に書き戻す**。そのため追跡ファイルへの symlink 配備では各端末の `git status` が恒久的に dirty になり、repo-sync-check が毎日通知し続けていた（air で顕在化）。Codex 側に自動読み込みされるローカル上書き機構は無い（`-p` は明示指定必須、`-c` は CLI フラグのみ）。

## What
- `script/codex-config-merge.py` を追加: `uv run`（Python 3.11+ tomllib / tomli-w）でリポジトリのベースを端末の実ファイルへ深いマージで配備。ベース定義キーはベース優先、ローカルのみのキー（端末状態）は保持。既存 symlink は内容を取り込んで実ファイルへ自動移行
- `config::import_codex`: config.toml の symlink 配備をやめ、マージ配備を呼ぶ（uv 不在時は実ファイル化／シードのみ行いマージは警告スキップ）
- `config::export_codex`: config.toml を除外（端末状態のリポジトリへの逆流防止）
- ADR 0022 追加・ADR index 更新

## How
マージ規則はテーブル再帰マージ・スカラー/配列はベース優先。検証済み:
- ベース優先／ローカル状態保持／symlink→実ファイル移行／冪等性／不正 TOML 時は中断（状態を破壊しない）
- air 端末で実移行し、移行前後で TOML が意味的に同一であること・`codex features list` が正常動作することを確認。air の working tree は clean 化済み

## Risk
- 配備先ファイルはコメントを持たなくなる（正本はリポジトリ側ベース）
- ベースからのキー削除は端末へ伝播しない（ADR に許容と明記）
- uv 前提。不在環境ではマージが行われない（警告表示・dirty は発生しない）

Closes #1080

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Codex configuration imports now merge shared settings with device-specific settings while preserving local-only values.
  * Existing symlinked configuration files are migrated to regular files.
  * Configuration updates avoid unnecessary rewrites and preserve comments where possible.

* **Bug Fixes**
  * Malformed configuration files are detected safely.
  * Environments without `uv` continue with migration and seeding, while clearly warning when merging is unavailable.

* **Documentation**
  * Added and indexed an ADR documenting the updated Codex configuration deployment behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->